### PR TITLE
capDL style update

### DIFF
--- a/proof/drefine/Arch_DR.thy
+++ b/proof/drefine/Arch_DR.thy
@@ -1426,7 +1426,6 @@ lemma invoke_page_directory_corres:
    apply (simp_all add:perform_page_invocation_def)
    apply (simp_all add: when_def  transform_page_dir_inv_def)
    apply safe
-   apply (clarsimp)
    apply (rule corres_dummy_return_r)
    apply (rule dcorres_symb_exec_r[OF corres_free_return[where P=\<top> and P'=\<top>]])
     apply wp

--- a/proof/drefine/Finalise_DR.thy
+++ b/proof/drefine/Finalise_DR.thy
@@ -3462,7 +3462,7 @@ next
        apply (rule monadic_rewrite_bindE_head)
        apply (rule monadic_trancl_preemptible_step)
       apply (simp add: finalise_slot_inner2_def
-                          [THEN fun_cong, unfolded split_def])
+                          [THEN meta_eq_to_obj_eq, THEN fun_cong, unfolded split_def])
       apply (simp add: alternative_bindE_distrib)
       apply (rule corres_alternate1)+
       apply (simp add: liftE_bindE bind_bindE_assoc bind_assoc)

--- a/spec/capDL/AARCH64/ArchVMAttributes_D.thy
+++ b/spec/capDL/AARCH64/ArchVMAttributes_D.thy
@@ -7,8 +7,8 @@
 (* Definition of architecture-dependent VM attribute validation. *)
 
 theory ArchVMAttributes_D
-imports
-  ASpec.ArchVMAttributes_A
+  imports
+    ASpec.ArchVMAttributes_A
 begin
 
 context Arch begin arch_global_naming (A)

--- a/spec/capDL/ARM/ArchVMAttributes_D.thy
+++ b/spec/capDL/ARM/ArchVMAttributes_D.thy
@@ -7,8 +7,8 @@
 (* Definition of architecture-dependent VM attribute validation. *)
 
 theory ArchVMAttributes_D
-imports
-  ASpec.ArchVMAttributes_A
+  imports
+    ASpec.ArchVMAttributes_A
 begin
 
 context Arch begin arch_global_naming (A)

--- a/spec/capDL/ARM_HYP/ArchVMAttributes_D.thy
+++ b/spec/capDL/ARM_HYP/ArchVMAttributes_D.thy
@@ -7,8 +7,8 @@
 (* Definition of architecture-dependent VM attribute validation. *)
 
 theory ArchVMAttributes_D
-imports
-  ASpec.ArchVMAttributes_A
+  imports
+    ASpec.ArchVMAttributes_A
 begin
 
 context Arch begin arch_global_naming (A)

--- a/spec/capDL/Asid_D.thy
+++ b/spec/capDL/Asid_D.thy
@@ -4,31 +4,29 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * Operations on page table objects and frames.
- *)
+(* Operations on ASID pools. *)
 
 theory Asid_D
-imports
-  Invocations_D
-  CSpace_D
-  Untyped_D
+  imports
+    Invocations_D
+    CSpace_D
+    Untyped_D
 begin
 
-definition
-  decode_asid_control_invocation :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow>
-      cdl_asid_control_intent \<Rightarrow> cdl_asid_control_invocation except_monad"
-where
-  "decode_asid_control_invocation target target_ref caps intent \<equiv> case intent of
-     AsidControlMakePoolIntent index depth \<Rightarrow>
-       doE
+definition decode_asid_control_invocation ::
+  "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_asid_control_intent \<Rightarrow>
+   cdl_asid_control_invocation except_monad"
+  where
+  "decode_asid_control_invocation target target_ref caps intent \<equiv>
+     case intent of
+       AsidControlMakePoolIntent index depth \<Rightarrow> doE
          base \<leftarrow> liftE $ select {x. x < 2 ^ asid_high_bits};
 
          \<comment> \<open>Fetch the untyped item, and ensure it is valid.\<close>
          (untyped_cap, untyped_cap_ref) \<leftarrow> throw_on_none $ get_index caps 0;
-         (case untyped_cap of
-             UntypedCap _ s _ \<Rightarrow> returnOk ()
-           | _ \<Rightarrow> throw);
+         case untyped_cap of
+           UntypedCap _ s _ \<Rightarrow> returnOk ()
+         | _ \<Rightarrow> throw;
          ensure_no_children untyped_cap_ref;
 
          \<comment> \<open>Fetch the slot we plan to put the generated cap into.\<close>
@@ -37,61 +35,55 @@ where
          ensure_empty target_slot;
 
          returnOk $ MakePool (set_available_range untyped_cap {}) untyped_cap_ref
-           (cap_objects untyped_cap) target_slot base
-       odE \<sqinter> throw"
+                             (cap_objects untyped_cap) target_slot base
+       odE
+       \<sqinter> throw"
 
 definition is_vspace_cap :: "cdl_cap \<Rightarrow> bool" where
   "is_vspace_cap cap \<equiv> is_table_cap cap \<and> cdl_cap_pt_type cap = vspace_type"
 
-definition
-  decode_asid_pool_invocation :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow>
-      cdl_asid_pool_intent \<Rightarrow> cdl_asid_pool_invocation except_monad"
-where
-  "decode_asid_pool_invocation target target_ref caps intent \<equiv> case intent of
-     AsidPoolAssignIntent \<Rightarrow>
-       doE
+definition decode_asid_pool_invocation ::
+  "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_asid_pool_intent \<Rightarrow>
+   cdl_asid_pool_invocation except_monad"
+  where
+  "decode_asid_pool_invocation target target_ref caps intent \<equiv>
+     case intent of
+       AsidPoolAssignIntent \<Rightarrow> doE
          (vs_cap, vs_cap_ref) \<leftarrow> throw_on_none $ get_index caps 0;
          unlessE (is_vspace_cap vs_cap) throw;
 
-         base \<leftarrow> (case target of
-             AsidPoolCap p base \<Rightarrow> returnOk $ base
-           | _ \<Rightarrow> throw);
+         base \<leftarrow> case target of AsidPoolCap p base \<Rightarrow> returnOk $ base | _ \<Rightarrow> throw;
          offset \<leftarrow> liftE $ select {x. x < 2 ^ asid_low_bits};
          returnOk $ Assign (base, offset) vs_cap_ref (cap_object target, offset)
-       odE \<sqinter> throw"
+       odE
+       \<sqinter> throw"
 
-definition
-  invoke_asid_control :: "cdl_asid_control_invocation \<Rightarrow> unit k_monad"
-where
+definition invoke_asid_control :: "cdl_asid_control_invocation \<Rightarrow> unit k_monad" where
   "invoke_asid_control params \<equiv>
-    case params of
-        MakePool untyped_cap untyped_cap_ref untyped_covers target_slot base \<Rightarrow>
-          do
-            \<comment> \<open>Untype the region. A choice may be made about whether to detype
-               objects with Untyped addresses.\<close>
-            modify (detype untyped_covers);
-            set_cap untyped_cap_ref untyped_cap;
-            targets \<leftarrow> return $ generate_range (Min (untyped_cap_range untyped_cap))
-                                    AsidPoolType (obj_bits_cdl AsidPoolType undefined) 1;
+     case params of
+       MakePool untyped_cap untyped_cap_ref untyped_covers target_slot base \<Rightarrow> do
+         \<comment> \<open>Detype the region. A choice may be made about whether to detype objects with
+             Untyped addresses.\<close>
+         modify (detype untyped_covers);
+         set_cap untyped_cap_ref untyped_cap;
+         targets \<leftarrow> return $ generate_range (Min (untyped_cap_range untyped_cap))
+                                            AsidPoolType (obj_bits_cdl AsidPoolType undefined) 1;
 
-            \<comment> \<open>Retype the region.\<close>
-            retype_region 0 AsidPoolType targets;
-            assert (targets \<noteq> []);
+         \<comment> \<open>Retype the region.\<close>
+         retype_region 0 AsidPoolType targets;
+         assert (targets \<noteq> []);
 
-            \<comment> \<open>Insert the cap.\<close>
-            frame \<leftarrow> return $ pick (hd targets);
-            insert_cap_child (AsidPoolCap frame base) untyped_cap_ref target_slot;
+         \<comment> \<open>Insert the cap.\<close>
+         frame \<leftarrow> return $ pick (hd targets);
+         insert_cap_child (AsidPoolCap frame base) untyped_cap_ref target_slot;
 
-            \<comment> \<open>Update the asid table.\<close>
-            asid_table \<leftarrow> gets cdl_asid_table;
-            asid_table' \<leftarrow> return $ asid_table (base \<mapsto> AsidPoolCap frame 0);
-            modify (\<lambda>s. s \<lparr>cdl_asid_table := asid_table'\<rparr>)
+         \<comment> \<open>Update the asid table.\<close>
+         asid_table \<leftarrow> gets cdl_asid_table;
+         asid_table' \<leftarrow> return $ asid_table (base \<mapsto> AsidPoolCap frame 0);
+         modify (\<lambda>s. s \<lparr>cdl_asid_table := asid_table'\<rparr>)
+       od"
 
-          od"
-
-definition
-  invoke_asid_pool :: "cdl_asid_pool_invocation \<Rightarrow> unit k_monad"
-where
+definition invoke_asid_pool :: "cdl_asid_pool_invocation \<Rightarrow> unit k_monad" where
   "invoke_asid_pool params \<equiv>
      case params of
        Assign asid vs_cap_ref ap_target_slot \<Rightarrow> do

--- a/spec/capDL/Asid_D.thy
+++ b/spec/capDL/Asid_D.thy
@@ -8,8 +8,6 @@
 
 theory Asid_D
   imports
-    Invocations_D
-    CSpace_D
     Untyped_D
 begin
 

--- a/spec/capDL/CNode_D.thy
+++ b/spec/capDL/CNode_D.thy
@@ -4,198 +4,182 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * Operations on CNodes.
- *)
+(* Operations on CNodes. *)
 
 theory CNode_D
-imports Invocations_D CSpace_D
+  imports Invocations_D CSpace_D
 begin
 
-definition
-  has_cancel_send_rights :: "cdl_cap \<Rightarrow> bool" where
-  "has_cancel_send_rights cap \<equiv> case cap of
-   EndpointCap _ _ R \<Rightarrow> R = UNIV
-   | _ \<Rightarrow> False"
+definition has_cancel_send_rights :: "cdl_cap \<Rightarrow> bool" where
+  "has_cancel_send_rights cap \<equiv> case cap of EndpointCap _ _ R \<Rightarrow> R = UNIV | _ \<Rightarrow> False"
 
-definition
-  decode_cnode_invocation :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow>
-      cdl_cnode_intent \<Rightarrow> cdl_cnode_invocation except_monad"
-where
-  "decode_cnode_invocation target target_ref caps intent \<equiv> case intent of
+definition decode_cnode_invocation ::
+  "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_cnode_intent \<Rightarrow>
+   cdl_cnode_invocation except_monad"
+  where
+  "decode_cnode_invocation target target_ref caps intent \<equiv>
+     case intent of
        \<comment> \<open>Copy a cap to anther capslot, without modifying the cap.\<close>
-       CNodeCopyIntent dest_index dest_depth src_index src_depth rights \<Rightarrow>
-         doE
-           (src_root, _) \<leftarrow> throw_on_none $ get_index caps 0;
-           dest_slot \<leftarrow> lookup_slot_for_cnode_op target dest_index (unat dest_depth);
-           ensure_empty dest_slot;
-           src_slot \<leftarrow> lookup_slot_for_cnode_op src_root src_index (unat src_depth);
-           src_cap \<leftarrow> liftE $ get_cap src_slot;
-           new_cap \<leftarrow> returnOk $ update_cap_rights (cap_rights src_cap \<inter> rights) src_cap;
-           cap \<leftarrow> derive_cap src_slot new_cap;
-           whenE (cap = cdl_cap.NullCap) throw;
+       CNodeCopyIntent dest_index dest_depth src_index src_depth rights \<Rightarrow> doE
+         (src_root, _) \<leftarrow> throw_on_none $ get_index caps 0;
+         dest_slot \<leftarrow> lookup_slot_for_cnode_op target dest_index (unat dest_depth);
+         ensure_empty dest_slot;
+         src_slot \<leftarrow> lookup_slot_for_cnode_op src_root src_index (unat src_depth);
+         src_cap \<leftarrow> liftE $ get_cap src_slot;
+         new_cap \<leftarrow> returnOk $ update_cap_rights (cap_rights src_cap \<inter> rights) src_cap;
+         cap \<leftarrow> derive_cap src_slot new_cap;
+         whenE (cap = cdl_cap.NullCap) throw;
 
-           returnOk $ InsertCall cap src_slot dest_slot
-         odE
+         returnOk $ InsertCall cap src_slot dest_slot
+       odE
 
      \<comment> \<open>Copy a cap to another capslot, possibly modifying the cap.\<close>
-     | CNodeMintIntent dest_index dest_depth src_index src_depth rights badge \<Rightarrow>
-         doE
-           (src_root, _) \<leftarrow> throw_on_none $ get_index caps 0;
-           dest_slot \<leftarrow> lookup_slot_for_cnode_op target dest_index (unat dest_depth);
-           ensure_empty dest_slot;
-           src_slot \<leftarrow> lookup_slot_for_cnode_op src_root src_index (unat src_depth);
-           src_cap \<leftarrow> liftE $ get_cap src_slot;
+     | CNodeMintIntent dest_index dest_depth src_index src_depth rights badge \<Rightarrow> doE
+         (src_root, _) \<leftarrow> throw_on_none $ get_index caps 0;
+         dest_slot \<leftarrow> lookup_slot_for_cnode_op target dest_index (unat dest_depth);
+         ensure_empty dest_slot;
+         src_slot \<leftarrow> lookup_slot_for_cnode_op src_root src_index (unat src_depth);
+         src_cap \<leftarrow> liftE $ get_cap src_slot;
 
-           \<comment> \<open>Munge the caps rights/data.\<close>
-           new_cap \<leftarrow> returnOk $ update_cap_rights (cap_rights src_cap \<inter> rights) src_cap;
-           new_cap' \<leftarrow> liftE $ update_cap_data False badge new_cap;
+         \<comment> \<open>Munge the caps rights/data.\<close>
+         new_cap \<leftarrow> returnOk $ update_cap_rights (cap_rights src_cap \<inter> rights) src_cap;
+         new_cap' \<leftarrow> liftE $ update_cap_data False badge new_cap;
 
-           cap \<leftarrow> derive_cap src_slot new_cap';
-           whenE (cap = cdl_cap.NullCap) throw;
+         cap \<leftarrow> derive_cap src_slot new_cap';
+         whenE (cap = cdl_cap.NullCap) throw;
 
-           returnOk $ InsertCall cap src_slot dest_slot
-         odE
+         returnOk $ InsertCall cap src_slot dest_slot
+       odE
 
      \<comment> \<open>Move a cap to another capslot, without modifying the cap.\<close>
-     | CNodeMoveIntent dest_index dest_depth src_index src_depth \<Rightarrow>
-         doE
-           (src_root, _) \<leftarrow> throw_on_none $ get_index caps 0;
-           dest_slot \<leftarrow> lookup_slot_for_cnode_op target dest_index (unat dest_depth);
-           ensure_empty dest_slot;
-           src_slot \<leftarrow> lookup_slot_for_cnode_op src_root src_index (unat src_depth);
-           src_cap \<leftarrow> liftE $ get_cap src_slot;
-           whenE (src_cap = NullCap) throw;
-           returnOk $ MoveCall src_cap src_slot dest_slot
-         odE
+     | CNodeMoveIntent dest_index dest_depth src_index src_depth \<Rightarrow> doE
+         (src_root, _) \<leftarrow> throw_on_none $ get_index caps 0;
+         dest_slot \<leftarrow> lookup_slot_for_cnode_op target dest_index (unat dest_depth);
+         ensure_empty dest_slot;
+         src_slot \<leftarrow> lookup_slot_for_cnode_op src_root src_index (unat src_depth);
+         src_cap \<leftarrow> liftE $ get_cap src_slot;
+         whenE (src_cap = NullCap) throw;
+         returnOk $ MoveCall src_cap src_slot dest_slot
+       odE
 
      \<comment> \<open>Move a cap to another capslot, possibly modifying the cap.\<close>
-     | CNodeMutateIntent dest_index dest_depth src_index src_depth badge \<Rightarrow>
-         doE
-           (src_root, _) \<leftarrow> throw_on_none $ get_index caps 0;
-           dest_slot \<leftarrow> lookup_slot_for_cnode_op target dest_index (unat dest_depth);
-           ensure_empty dest_slot;
-           src_slot \<leftarrow> lookup_slot_for_cnode_op src_root src_index (unat src_depth);
-           src_cap \<leftarrow> liftE $ get_cap src_slot;
+     | CNodeMutateIntent dest_index dest_depth src_index src_depth badge \<Rightarrow> doE
+         (src_root, _) \<leftarrow> throw_on_none $ get_index caps 0;
+         dest_slot \<leftarrow> lookup_slot_for_cnode_op target dest_index (unat dest_depth);
+         ensure_empty dest_slot;
+         src_slot \<leftarrow> lookup_slot_for_cnode_op src_root src_index (unat src_depth);
+         src_cap \<leftarrow> liftE $ get_cap src_slot;
 
-           \<comment> \<open>Munge the caps rights/data.\<close>
-           cap \<leftarrow> liftE $ update_cap_data True badge src_cap;
-           whenE (cap = NullCap) throw;
+         \<comment> \<open>Munge the caps rights/data.\<close>
+         cap \<leftarrow> liftE $ update_cap_data True badge src_cap;
+         whenE (cap = NullCap) throw;
 
-           returnOk $ MoveCall cap src_slot dest_slot
-         odE
+         returnOk $ MoveCall cap src_slot dest_slot
+       odE
 
      \<comment> \<open>Revoke all CDT children of the given cap.\<close>
-     | CNodeRevokeIntent index depth \<Rightarrow>
-         doE
-           target_slot \<leftarrow> lookup_slot_for_cnode_op target index (unat depth);
-           returnOk $ RevokeCall target_slot
-         odE
+     | CNodeRevokeIntent index depth \<Rightarrow> doE
+         target_slot \<leftarrow> lookup_slot_for_cnode_op target index (unat depth);
+         returnOk $ RevokeCall target_slot
+       odE
 
      \<comment> \<open>Delete the given cap, but not its children.\<close>
-     | CNodeDeleteIntent index depth \<Rightarrow>
-         doE
-           target_slot \<leftarrow> lookup_slot_for_cnode_op target index (unat depth);
-           returnOk $ DeleteCall target_slot
-         odE
+     | CNodeDeleteIntent index depth \<Rightarrow> doE
+         target_slot \<leftarrow> lookup_slot_for_cnode_op target index (unat depth);
+         returnOk $ DeleteCall target_slot
+       odE
 
      \<comment> \<open>Save the current thread's reply cap into the target slot.\<close>
-     | CNodeSaveCallerIntent index depth \<Rightarrow>
-         doE
-           target_slot \<leftarrow> lookup_slot_for_cnode_op target index (unat depth);
-           ensure_empty target_slot;
-           returnOk $ SaveCall target_slot
-         odE
+     | CNodeSaveCallerIntent index depth \<Rightarrow> doE
+         target_slot \<leftarrow> lookup_slot_for_cnode_op target index (unat depth);
+         ensure_empty target_slot;
+         returnOk $ SaveCall target_slot
+       odE
 
      \<comment> \<open>Recycle the target cap.\<close>
-     | CNodeCancelBadgedSendsIntent index depth \<Rightarrow>
-         doE
-           target_slot \<leftarrow> lookup_slot_for_cnode_op target index (unat depth);
-           cap \<leftarrow> liftE $ get_cap target_slot;
-           unlessE (has_cancel_send_rights cap) throw;
-           returnOk $ CancelBadgedSendsCall cap
-         odE
+     | CNodeCancelBadgedSendsIntent index depth \<Rightarrow> doE
+         target_slot \<leftarrow> lookup_slot_for_cnode_op target index (unat depth);
+         cap \<leftarrow> liftE $ get_cap target_slot;
+         unlessE (has_cancel_send_rights cap) throw;
+         returnOk $ CancelBadgedSendsCall cap
+       odE
 
      \<comment> \<open>Atomically move several caps.\<close>
-     | CNodeRotateIntent dest_index dest_depth pivot_index pivot_depth pivot_badge src_index src_depth src_badge \<Rightarrow>
-         doE
-           pivot_root \<leftarrow> throw_on_none $ get_index caps 0;
-           src_root \<leftarrow> throw_on_none $ get_index caps 1;
+     | CNodeRotateIntent dest_index dest_depth pivot_index pivot_depth pivot_badge src_index
+                         src_depth src_badge \<Rightarrow> doE
+         pivot_root \<leftarrow> throw_on_none $ get_index caps 0;
+         src_root \<leftarrow> throw_on_none $ get_index caps 1;
 
-           dest_root \<leftarrow> returnOk $ target;
-           pivot_root \<leftarrow> returnOk $ fst pivot_root;
-           src_root \<leftarrow> returnOk $ fst src_root;
+         dest_root \<leftarrow> returnOk target;
+         pivot_root \<leftarrow> returnOk $ fst pivot_root;
+         src_root \<leftarrow> returnOk $ fst src_root;
 
-           dest_slot \<leftarrow> lookup_slot_for_cnode_op dest_root dest_index (unat dest_depth);
-           src_slot \<leftarrow> lookup_slot_for_cnode_op src_root src_index (unat src_depth);
-           pivot_slot \<leftarrow> lookup_slot_for_cnode_op pivot_root pivot_index (unat pivot_depth);
+         dest_slot \<leftarrow> lookup_slot_for_cnode_op dest_root dest_index (unat dest_depth);
+         src_slot \<leftarrow> lookup_slot_for_cnode_op src_root src_index (unat src_depth);
+         pivot_slot \<leftarrow> lookup_slot_for_cnode_op pivot_root pivot_index (unat pivot_depth);
 
-           whenE (pivot_slot = src_slot \<or> pivot_slot = dest_slot) throw;
+         whenE (pivot_slot = src_slot \<or> pivot_slot = dest_slot) throw;
 
-           unlessE (src_slot = dest_slot) $ ensure_empty dest_slot;
+         unlessE (src_slot = dest_slot) $ ensure_empty dest_slot;
 
-           src_cap \<leftarrow> liftE $ get_cap src_slot;
-           whenE (src_cap = NullCap) throw;
+         src_cap \<leftarrow> liftE $ get_cap src_slot;
+         whenE (src_cap = NullCap) throw;
 
-           pivot_cap \<leftarrow> liftE $ get_cap pivot_slot;
-           whenE (pivot_cap = NullCap) throw;
+         pivot_cap \<leftarrow> liftE $ get_cap pivot_slot;
+         whenE (pivot_cap = NullCap) throw;
 
-           \<comment> \<open>Munge caps.\<close>
-           new_src \<leftarrow> liftE $ update_cap_data True src_badge src_cap;
-           new_pivot \<leftarrow> liftE $ update_cap_data True pivot_badge pivot_cap;
+         \<comment> \<open>Munge caps.\<close>
+         new_src \<leftarrow> liftE $ update_cap_data True src_badge src_cap;
+         new_pivot \<leftarrow> liftE $ update_cap_data True pivot_badge pivot_cap;
 
-           whenE (new_src = NullCap) throw;
-           whenE (new_pivot = NullCap) throw;
+         whenE (new_src = NullCap) throw;
+         whenE (new_pivot = NullCap) throw;
 
-           returnOk $ RotateCall new_src new_pivot src_slot pivot_slot dest_slot
-         odE
-   "
+         returnOk $ RotateCall new_src new_pivot src_slot pivot_slot dest_slot
+       odE"
 
-definition
-  invoke_cnode :: "cdl_cnode_invocation \<Rightarrow> unit preempt_monad"
-where
-  "invoke_cnode params \<equiv> case params of
-    \<comment> \<open>Insert a new cap.\<close>
-      InsertCall cap src_slot dest_slot \<Rightarrow>
-        liftE $
-          insert_cap_sibling cap src_slot dest_slot
-          \<sqinter>
-          insert_cap_child cap src_slot dest_slot
+definition invoke_cnode :: "cdl_cnode_invocation \<Rightarrow> unit preempt_monad" where
+  "invoke_cnode params \<equiv>
+     case params of
+        \<comment> \<open>Insert a new cap.\<close>
+        InsertCall cap src_slot dest_slot \<Rightarrow>
+          liftE $
+            insert_cap_sibling cap src_slot dest_slot \<sqinter>
+            insert_cap_child cap src_slot dest_slot
 
-    \<comment> \<open>Move a cap, possibly modifying it in the process.\<close>
-    | MoveCall cap src_slot dest_slot \<Rightarrow>
-        liftE $ move_cap cap src_slot dest_slot
+      \<comment> \<open>Move a cap, possibly modifying it in the process.\<close>
+      | MoveCall cap src_slot dest_slot \<Rightarrow>
+          liftE $ move_cap cap src_slot dest_slot
 
     \<comment> \<open>Revoke a cap.\<close>
-    | RevokeCall src_slot \<Rightarrow>
-        revoke_cap src_slot
+      | RevokeCall src_slot \<Rightarrow>
+          revoke_cap src_slot
 
-    \<comment> \<open>Delete a cap.\<close>
-    | DeleteCall src_slot \<Rightarrow>
-        delete_cap src_slot
+      \<comment> \<open>Delete a cap.\<close>
+      | DeleteCall src_slot \<Rightarrow>
+          delete_cap src_slot
 
-    \<comment> \<open>Atomically move two capabilities.\<close>
-    | RotateCall cap1 cap2 slot1 slot2 slot3 \<Rightarrow>
-        liftE $ if slot1 = slot3 then
-          swap_cap cap1 slot1 cap2 slot2
-        else
-          do
-            move_cap cap2 slot2 slot3;
-            move_cap cap1 slot1 slot2
+      \<comment> \<open>Atomically move two capabilities.\<close>
+      | RotateCall cap1 cap2 slot1 slot2 slot3 \<Rightarrow>
+          liftE $
+            if slot1 = slot3
+            then swap_cap cap1 slot1 cap2 slot2
+            else do
+              move_cap cap2 slot2 slot3;
+              move_cap cap1 slot1 slot2
+            od
+
+      \<comment> \<open>Save a reply cap from the caller's TCB into this CNode.\<close>
+      | SaveCall dest_slot \<Rightarrow>
+          liftE $ do
+            current \<leftarrow> gets_the cdl_current_thread;
+            replycap \<leftarrow> get_cap (current, tcb_caller_slot);
+            when (replycap \<noteq> NullCap) $ move_cap replycap (current, tcb_caller_slot) dest_slot
           od
 
-    \<comment> \<open>Save a reply cap from the caller's TCB into this CNode.\<close>
-    | SaveCall dest_slot \<Rightarrow>
-        liftE $ do
-          current \<leftarrow> gets_the cdl_current_thread;
-          replycap \<leftarrow> get_cap (current, tcb_caller_slot);
-          when (replycap \<noteq> NullCap)
-            $ move_cap replycap (current, tcb_caller_slot) dest_slot
-        od
-
-    \<comment> \<open>Reset an object into its original state.\<close>
-    | CancelBadgedSendsCall (EndpointCap ep b _) \<Rightarrow> liftE $ when (b \<noteq> 0) $ cancel_badged_sends ep b
-    | CancelBadgedSendsCall _ \<Rightarrow> fail
-  "
+      \<comment> \<open>Reset an object into its original state.\<close>
+      | CancelBadgedSendsCall (EndpointCap ep b _) \<Rightarrow>
+          liftE $ when (b \<noteq> 0) $ cancel_badged_sends ep b
+      | CancelBadgedSendsCall _ \<Rightarrow> fail"
 
 end

--- a/spec/capDL/CNode_D.thy
+++ b/spec/capDL/CNode_D.thy
@@ -7,7 +7,7 @@
 (* Operations on CNodes. *)
 
 theory CNode_D
-  imports Invocations_D CSpace_D
+  imports CSpace_D
 begin
 
 definition has_cancel_send_rights :: "cdl_cap \<Rightarrow> bool" where

--- a/spec/capDL/CSpace_D.thy
+++ b/spec/capDL/CSpace_D.thy
@@ -4,245 +4,203 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * Operations on CSpace
- *)
+(* Operations on CSpace *)
 
 theory CSpace_D
-imports
-  PageTableUnmap_D
+  imports
+    PageTableUnmap_D
 begin
 
 (* Does the given cap have any children? *)
-definition
-  has_children :: "cdl_cap_ref \<Rightarrow> cdl_state \<Rightarrow> bool"
-where
+definition has_children :: "cdl_cap_ref \<Rightarrow> cdl_state \<Rightarrow> bool" where
   "has_children parent s = (\<exists>child. is_cdt_parent s parent child)"
 
-(*
- * Ensure that the given cap does not contain any children
- * in the CDT.
- *)
-definition
-  ensure_no_children :: "cdl_cap_ref \<Rightarrow> unit except_monad"
-where
+definition ensure_no_children :: "cdl_cap_ref \<Rightarrow> unit except_monad" where
   "ensure_no_children x \<equiv> doE
      c \<leftarrow> liftE $ gets (has_children x);
      whenE c $ throw
    odE"
 
 (* Ensure that the given cap slot is empty. *)
-definition
-  ensure_empty :: "cdl_cap_ref \<Rightarrow> unit except_monad"
-where
+definition ensure_empty :: "cdl_cap_ref \<Rightarrow> unit except_monad" where
   "ensure_empty cap_ref \<equiv> doE
      cap \<leftarrow> liftE $ get_cap cap_ref;
      unlessE (cap = NullCap) $ throw
-  odE"
+   odE"
 
 (* Insert a new cap into an object. The cap will have no parent. *)
-definition
-  insert_cap_orphan :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad"
-where
+definition insert_cap_orphan :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad" where
   "insert_cap_orphan new_cap dest_slot \<equiv> do
      old_cap \<leftarrow> get_cap dest_slot;
      assert (old_cap = NullCap);
      set_cap dest_slot new_cap
    od"
 
-primrec (nonexhaustive)
-  untyped_cap_range :: "cdl_cap \<Rightarrow> cdl_object_id set"
-where
+primrec (nonexhaustive) untyped_cap_range :: "cdl_cap \<Rightarrow> cdl_object_id set" where
   "untyped_cap_range (UntypedCap _ r available) = r"
 
-primrec (nonexhaustive)
-  available_range :: "cdl_cap \<Rightarrow> cdl_object_id set"
-where
+primrec (nonexhaustive) available_range :: "cdl_cap \<Rightarrow> cdl_object_id set" where
   "available_range (UntypedCap _ r available) = available"
 
-definition
-  set_available_range :: "cdl_cap \<Rightarrow> cdl_object_id set \<Rightarrow> cdl_cap"
-where
+definition set_available_range :: "cdl_cap \<Rightarrow> cdl_object_id set \<Rightarrow> cdl_cap" where
   "set_available_range cap nrange \<equiv>
-    case cap of UntypedCap d r available \<Rightarrow> UntypedCap d r nrange | _ \<Rightarrow> cap"
+     case cap of UntypedCap d r available \<Rightarrow> UntypedCap d r nrange | _ \<Rightarrow> cap"
 
 lemmas set_avaiable_range_simps[simp] = set_available_range_def[split_simps cdl_cap.split]
 
-definition
-  set_untyped_cap_as_full :: "cdl_cap \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad"
-where
+definition set_untyped_cap_as_full :: "cdl_cap \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad" where
   "set_untyped_cap_as_full src_cap new_cap src_slot \<equiv>
-  if (is_untyped_cap src_cap \<and> is_untyped_cap new_cap
-     \<and> cap_objects src_cap = cap_objects new_cap) then
-     (set_cap src_slot (set_available_range src_cap {}))
+     if is_untyped_cap src_cap \<and> is_untyped_cap new_cap \<and> cap_objects src_cap = cap_objects new_cap
+     then set_cap src_slot (set_available_range src_cap {})
      else return ()"
 
 (* Insert a new cap into an object. The cap will be a sibling. *)
-definition
-  insert_cap_sibling :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad"
-where
+definition insert_cap_sibling :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad" where
   "insert_cap_sibling new_cap src_slot dest_slot \<equiv> do
-    src_cap \<leftarrow> get_cap src_slot;
-    old_cap \<leftarrow> get_cap dest_slot;
-    assert (old_cap = NullCap);
-    set_untyped_cap_as_full src_cap new_cap src_slot;
-    set_cap dest_slot new_cap;
-    p \<leftarrow> gets $ opt_parent src_slot;
-    case p of
-      None \<Rightarrow> return ()
-    | Some parent \<Rightarrow> set_parent dest_slot parent
-  od"
+     src_cap \<leftarrow> get_cap src_slot;
+     old_cap \<leftarrow> get_cap dest_slot;
+     assert (old_cap = NullCap);
+     set_untyped_cap_as_full src_cap new_cap src_slot;
+     set_cap dest_slot new_cap;
+     p \<leftarrow> gets $ opt_parent src_slot;
+     case p of
+       None \<Rightarrow> return ()
+     | Some parent \<Rightarrow> set_parent dest_slot parent
+   od"
 
 (* Insert a new cap into an object. The cap will be a child. *)
-definition
-  insert_cap_child :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad"
-where
+definition insert_cap_child :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad" where
   "insert_cap_child new_cap src_slot dest_slot \<equiv> do
-    src_cap \<leftarrow> get_cap src_slot;
-    old_cap \<leftarrow> get_cap dest_slot;
-    assert (old_cap = NullCap);
-    set_untyped_cap_as_full src_cap new_cap src_slot;
-    set_cap dest_slot new_cap;
-    set_parent dest_slot src_slot
-  od"
+     src_cap \<leftarrow> get_cap src_slot;
+     old_cap \<leftarrow> get_cap dest_slot;
+     assert (old_cap = NullCap);
+     set_untyped_cap_as_full src_cap new_cap src_slot;
+     set_cap dest_slot new_cap;
+     set_parent dest_slot src_slot
+   od"
 
-(*
- * Delete an ASID pool.
- *)
-definition
-  delete_asid_pool :: "cdl_cnode_index \<Rightarrow> cdl_object_id \<Rightarrow> unit k_monad"
-where
+(* Delete an ASID pool. *)
+definition delete_asid_pool :: "cdl_cnode_index \<Rightarrow> cdl_object_id \<Rightarrow> unit k_monad" where
   "delete_asid_pool base ptr \<equiv> do
-    asid_table \<leftarrow> gets cdl_asid_table;
-    asid_table' \<leftarrow> return $ asid_table (base \<mapsto> NullCap);
-    modify (\<lambda>s. s \<lparr>cdl_asid_table := asid_table'\<rparr>)
-  od \<sqinter> return ()"
+     asid_table \<leftarrow> gets cdl_asid_table;
+     asid_table' \<leftarrow> return $ asid_table (base \<mapsto> NullCap);
+     modify (\<lambda>s. s \<lparr>cdl_asid_table := asid_table'\<rparr>)
+   od \<sqinter> return ()"
 
-(*
- * Delete a particular ASID, decactivating the PD using it
- * in the process.
- *)
-definition
-  delete_asid :: "cdl_asid \<Rightarrow> cdl_object_id \<Rightarrow> unit k_monad"
-where
+(* Delete a particular ASID, decactivating the PD using it  in the process. *)
+definition delete_asid :: "cdl_asid \<Rightarrow> cdl_object_id \<Rightarrow> unit k_monad" where
   "delete_asid asid pd \<equiv> do
-    asid_table \<leftarrow> gets cdl_asid_table;
-    case asid_table (fst asid) of
+     asid_table \<leftarrow> gets cdl_asid_table;
+     case asid_table (fst asid) of
        Some NullCap \<Rightarrow> return ()
      | Some (AsidPoolCap p _) \<Rightarrow> set_cap (p, (snd asid)) NullCap
      | _ \<Rightarrow> fail
-  od \<sqinter> return ()"
+   od \<sqinter> return ()"
 
-definition
-  get_irq_slot :: "cdl_irq \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_ref"
-where
+definition get_irq_slot :: "cdl_irq \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_ref" where
   "get_irq_slot irq s \<equiv> (cdl_irq_node s irq, 0)"
 
 text \<open>Actions to be taken after deleting an IRQ Handler capability.\<close>
-definition
-  deleting_irq_handler :: "cdl_irq \<Rightarrow> unit k_monad"
-where
- "deleting_irq_handler irq \<equiv>
-    gets (get_irq_slot irq) >>= delete_cap_simple"
+definition deleting_irq_handler :: "cdl_irq \<Rightarrow> unit k_monad" where
+  "deleting_irq_handler irq \<equiv> gets (get_irq_slot irq) >>= delete_cap_simple"
 
-definition
-  cancel_ipc ::"cdl_object_id \<Rightarrow> unit k_monad"
-  where "cancel_ipc ptr \<equiv>
-  do cap \<leftarrow> KHeap_D.get_cap (ptr,tcb_pending_op_slot);
-   (case cap of
-    PendingSyncRecvCap _ is_reply _ \<Rightarrow> ( do
-     when is_reply $ update_thread_fault ptr (\<lambda>x. False);
-     revoke_cap_simple (ptr,tcb_replycap_slot);
-     when (\<not> is_reply) $ set_cap (ptr,tcb_pending_op_slot) NullCap
-     od )
-   | PendingSyncSendCap _ _ _ _ _ _ \<Rightarrow> (do
-     revoke_cap_simple (ptr,tcb_replycap_slot);
-     set_cap (ptr,tcb_pending_op_slot) NullCap
-     od)
-   | PendingNtfnRecvCap _ \<Rightarrow> (do
-     revoke_cap_simple (ptr,tcb_replycap_slot);
-     set_cap (ptr, tcb_pending_op_slot) NullCap
-     od)
-   | _ \<Rightarrow> return ())
-  od"
+definition cancel_ipc ::"cdl_object_id \<Rightarrow> unit k_monad" where
+  "cancel_ipc ptr \<equiv> do
+     cap \<leftarrow> get_cap (ptr, tcb_pending_op_slot);
+     case cap of
+       PendingSyncRecvCap _ is_reply _ \<Rightarrow> do
+         when is_reply $ update_thread_fault ptr (\<lambda>x. False);
+         revoke_cap_simple (ptr,tcb_replycap_slot);
+         when (\<not> is_reply) $ set_cap (ptr,tcb_pending_op_slot) NullCap
+       od
+     | PendingSyncSendCap _ _ _ _ _ _ \<Rightarrow> do
+         revoke_cap_simple (ptr,tcb_replycap_slot);
+         set_cap (ptr,tcb_pending_op_slot) NullCap
+       od
+     | PendingNtfnRecvCap _ \<Rightarrow> do
+         revoke_cap_simple (ptr,tcb_replycap_slot);
+         set_cap (ptr, tcb_pending_op_slot) NullCap
+       od
+     | _ \<Rightarrow> return ()
+   od"
 
-definition
-  prepare_thread_delete ::"cdl_object_id \<Rightarrow> unit k_monad"
-  where "prepare_thread_delete ptr \<equiv> return ()" (* for ARM it does nothing *)
+definition prepare_thread_delete ::"cdl_object_id \<Rightarrow> unit k_monad" where
+  "prepare_thread_delete ptr \<equiv> return ()" (* for ARM it does nothing *)
 
-text \<open>Actions that must be taken when a capability is deleted. Returns a
-Zombie capability if deletion requires a long-running operation and also a
-possible IRQ to be cleared.\<close>
-fun
-  finalise_cap :: "cdl_cap \<Rightarrow> bool \<Rightarrow> (cdl_cap \<times> cdl_cap) k_monad"
-where
-  "finalise_cap NullCap                  final = return (NullCap, NullCap)"
-| "finalise_cap RestartCap               final = return (NullCap, NullCap)"
-| "finalise_cap (UntypedCap dev r a)           final = return (NullCap, NullCap)"
-| "finalise_cap (EndpointCap r b R)      final =
-      (liftM (K (NullCap, NullCap)) $ when  final $ cancel_all_ipc r)"
-| "finalise_cap (NotificationCap r b R) final =
-      (liftM (K (NullCap, NullCap)) $ when  final $
-       do
-         unbind_maybe_notification r;
-         cancel_all_ipc r
-       od)"
-| "finalise_cap (ReplyCap r R)           final = return (NullCap, NullCap)"
-| "finalise_cap (MasterReplyCap r)       final = return (NullCap, NullCap)"
-| "finalise_cap (CNodeCap r bits g sz)   final =
-      (return (if final then ZombieCap r else NullCap, NullCap))"
-| "finalise_cap (TcbCap r)               final =
-      (do
-         when final $ (do unbind_notification r;
+text \<open>
+  Actions that must be taken when a capability is deleted. Returns a
+  Zombie capability if deletion requires a long-running operation and also a
+  possible IRQ to be cleared.\<close>
+fun finalise_cap :: "cdl_cap \<Rightarrow> bool \<Rightarrow> (cdl_cap \<times> cdl_cap) k_monad" where
+    "finalise_cap NullCap final = return (NullCap, NullCap)"
+  | "finalise_cap RestartCap final = return (NullCap, NullCap)"
+  | "finalise_cap (UntypedCap dev r a) final = return (NullCap, NullCap)"
+  | "finalise_cap (EndpointCap r b R) final =
+       liftM (K (NullCap, NullCap)) (when final $ cancel_all_ipc r)"
+  | "finalise_cap (NotificationCap r b R) final =
+       liftM (K (NullCap, NullCap))
+             (when final $ do
+                unbind_maybe_notification r;
+                cancel_all_ipc r
+              od)"
+  | "finalise_cap (ReplyCap r R) final = return (NullCap, NullCap)"
+  | "finalise_cap (MasterReplyCap r) final = return (NullCap, NullCap)"
+  | "finalise_cap (CNodeCap r bits g sz) final =
+       return (if final then ZombieCap r else NullCap, NullCap)"
+  | "finalise_cap (TcbCap r) final = do
+       when final $ do
+         unbind_notification r;
          cancel_ipc r;
-         KHeap_D.set_cap (r, tcb_pending_op_slot) cdl_cap.NullCap;
-         prepare_thread_delete r od);
-         return (if final then (ZombieCap r) else NullCap, NullCap)
-       od)"
-| "finalise_cap (PendingSyncSendCap r _ _ _ _ _) final = return (NullCap, NullCap)"
-| "finalise_cap (PendingSyncRecvCap r _ _) final = return (NullCap, NullCap)"
-| "finalise_cap (PendingNtfnRecvCap r)  final = return (NullCap, NullCap)"
-| "finalise_cap IrqControlCap            final = return (NullCap, NullCap)"
-| "finalise_cap (IrqHandlerCap irq)      final = (
+         set_cap (r, tcb_pending_op_slot) cdl_cap.NullCap;
+         prepare_thread_delete r
+       od;
+       return (if final then ZombieCap r else NullCap, NullCap)
+     od"
+  | "finalise_cap (PendingSyncSendCap r _ _ _ _ _) final = return (NullCap, NullCap)"
+  | "finalise_cap (PendingSyncRecvCap r _ _) final = return (NullCap, NullCap)"
+  | "finalise_cap (PendingNtfnRecvCap r) final = return (NullCap, NullCap)"
+  | "finalise_cap IrqControlCap final = return (NullCap, NullCap)"
+  | "finalise_cap (IrqHandlerCap irq) final = (
        if final then do
          deleting_irq_handler irq;
          return (NullCap, (IrqHandlerCap irq))
        od
        else return (NullCap, NullCap))"
-| "finalise_cap (ZombieCap r)            final =
-      (do assert final; return (ZombieCap r, NullCap) od)"
-| "finalise_cap (AsidPoolCap ptr asid)        final = (
+  | "finalise_cap (ZombieCap r) final = do
+       assert final; return (ZombieCap r, NullCap)
+     od"
+  | "finalise_cap (AsidPoolCap ptr asid)        final = (
        if final then do
          delete_asid_pool asid ptr;
          return (NullCap, NullCap)
        od
        else return (NullCap, NullCap))"
-| "finalise_cap AsidControlCap           final = return (NullCap,NullCap)"
-| "finalise_cap (PageTableCap PD ptr x (Some (asid, _))) final = (
+  | "finalise_cap AsidControlCap final = return (NullCap,NullCap)"
+  | "finalise_cap (PageTableCap PD ptr x (Some (asid, _))) final = (
        if final \<and> x = Real then do
          delete_asid asid ptr;
          return (NullCap, NullCap)
        od
        else return (NullCap, NullCap))"
-| "finalise_cap (PageTableCap PT ptr x (Some asid)) final = (
-       if (final \<and> x = Real) then do
+  | "finalise_cap (PageTableCap PT ptr x (Some asid)) final = (
+       if final \<and> x = Real then do
          unmap_page_table asid ptr;
          return (NullCap, NullCap)
        od
        else return (NullCap, NullCap))"
-| "finalise_cap (FrameCap dev ptr _ s x (Some asid)) final = (
+  | "finalise_cap (FrameCap dev ptr _ s x (Some asid)) final = (
        if x = Real then do
          unmap_page asid ptr s;
          return (NullCap, NullCap)
        od
        else return (NullCap, NullCap))"
-| "finalise_cap _ final = return (NullCap, NullCap)"
+  | "finalise_cap _ final = return (NullCap, NullCap)"
 
 
-text \<open>The fast_finalise operation is used to delete a capability when it is
-known that a long-running operation is impossible. It is equivalent to calling
-the regular finalise operation. It cannot be defined in that way as doing so
-would create a circular definition.\<close>
+text \<open>
+  The fast_finalise operation is used to delete a capability when it is known that a long-running
+  operation is impossible. It is equivalent to calling the regular finalise operation. It cannot be
+  defined in that way as doing so would create a circular definition.\<close>
 lemma fast_finalise_def2:
   "fast_finalise cap final = do
      assert (can_fast_finalise cap);
@@ -252,235 +210,175 @@ lemma fast_finalise_def2:
   unfolding can_fast_finalise_def
   by (rule finalise_cap.cases[of "(cap,final)"]; simp add: assert_def liftM_def)
 
-(*
- * Atomically swap the two given caps.
- *)
-
-definition
-  swap_cap :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad"
-where
+(* Atomically swap the two given caps. *)
+definition swap_cap :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad" where
   "swap_cap cap1 slot1 cap2 slot2 \<equiv> do
      set_cap slot1 cap2;
      set_cap slot2 cap1;
      swap_parents slot1 slot2
-  od"
+   od"
 
-(*
- * Move the given cap from one location to another,
- * possibly modifying it along the way.
- *)
-definition
-  move_cap :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad"
-where
+(* Move the given cap from one location to another, possibly modifying it along the way. *)
+definition move_cap :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad" where
   "move_cap cap src_slot dest_slot \<equiv> do
      insert_cap_orphan cap dest_slot;
      set_cap src_slot NullCap;
      swap_parents src_slot dest_slot
-  od"
+   od"
 
-definition
-  monadic_rel_optionation_form :: "('a \<Rightarrow> ('s, 'b) nondet_monad)
-      \<Rightarrow> (('a \<times> 's) option \<times> ('b \<times> 's) option) set"
-where
- "monadic_rel_optionation_form f =
-    {(x, y). (x \<noteq> None \<and> y \<noteq> None \<and> the y \<in> fst (case_prod f (the x)))
-           \<or> (x \<noteq> None \<and> y = None \<and> snd (case_prod f (the x)))
-           \<or> (x = None \<and> y = None)}"
+definition monadic_rel_optionation_form ::
+  "('a \<Rightarrow> ('s, 'b) nondet_monad) \<Rightarrow> (('a \<times> 's) option \<times> ('b \<times> 's) option) set"
+  where
+  "monadic_rel_optionation_form f =
+     {(x, y). (x \<noteq> None \<and> y \<noteq> None \<and> the y \<in> fst (case_prod f (the x))) \<or>
+              (x \<noteq> None \<and> y = None \<and> snd (case_prod f (the x))) \<or>
+              (x = None \<and> y = None)}"
 
-definition
-  monadic_option_dest :: "('a \<times> 's) option set \<Rightarrow> (('a \<times> 's) set \<times> bool)"
-where
- "monadic_option_dest S = (Some -` S, None \<in> S)"
+definition monadic_option_dest :: "('a \<times> 's) option set \<Rightarrow> (('a \<times> 's) set \<times> bool)" where
+  "monadic_option_dest S = (Some -` S, None \<in> S)"
 
 lemma use_option_form:
   "f x = (\<lambda>s. monadic_option_dest  (monadic_rel_optionation_form f `` {Some (x, s)}))"
   by (simp add: monadic_rel_optionation_form_def monadic_option_dest_def)
 
-lemma ex_option: " (\<exists>x. P x) = ((\<exists>y. P (Some y)) \<or> P None)"
-  apply safe
-  apply (case_tac x, auto)
-  done
+lemma ex_option:
+  "(\<exists>x. P x) = ((\<exists>y. P (Some y)) \<or> P None)"
+  by (metis not_None_eq)
 
 lemma use_option_form_bind:
-  "f x >>= g = (\<lambda>s. monadic_option_dest
-       ((monadic_rel_optionation_form f O monadic_rel_optionation_form g) `` {Some (x, s)}))"
-  apply (rule ext)
-  apply (simp add: monadic_rel_optionation_form_def monadic_option_dest_def
-                   bind_def split_def)
-  apply (simp add: relcomp_unfold ex_option image_def prod_eq_iff Bex_def)
-  apply fastforce
-  done
+  "f x >>= g =
+   (\<lambda>s. monadic_option_dest
+         ((monadic_rel_optionation_form f O monadic_rel_optionation_form g) `` {Some (x, s)}))"
+  by (fastforce simp: monadic_rel_optionation_form_def monadic_option_dest_def bind_def
+                      relcomp_unfold ex_option image_def prod_eq_iff Bex_def)
 
-definition
-  monadic_trancl :: "('a \<Rightarrow> ('s, 'a) nondet_monad)
-       \<Rightarrow> 'a \<Rightarrow> ('s, 'a) nondet_monad"
-where
- "monadic_trancl f x = (\<lambda>s. monadic_option_dest ((monadic_rel_optionation_form f)\<^sup>* `` {Some (x, s)}))"
+definition monadic_trancl :: "('a \<Rightarrow> ('s, 'a) nondet_monad) \<Rightarrow> 'a \<Rightarrow> ('s, 'a) nondet_monad" where
+  "monadic_trancl f x =
+     (\<lambda>s. monadic_option_dest ((monadic_rel_optionation_form f)\<^sup>* `` {Some (x, s)}))"
 
-definition
-  monadic_trancl_preemptible ::
-     "('a \<Rightarrow> ('s, 'e + 'a) nondet_monad)
-         \<Rightarrow> ('a \<Rightarrow> ('s, 'e + 'a) nondet_monad)"
-where
- "monadic_trancl_preemptible f x
-    = monadic_trancl (lift f) (Inr x)"
+definition monadic_trancl_preemptible ::
+  "('a \<Rightarrow> ('s, 'e + 'a) nondet_monad) \<Rightarrow> ('a \<Rightarrow> ('s, 'e + 'a) nondet_monad)"
+  where
+  "monadic_trancl_preemptible f x = monadic_trancl (lift f) (Inr x)"
 
-definition
-  cap_removeable :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_state \<Rightarrow> bool"
-where
- "cap_removeable cap slot s =
-   (cap = NullCap
-      \<or> (\<exists>p. cap = ZombieCap p \<and> swp opt_cap s ` (({p} \<times> UNIV) - {slot})
-              \<subseteq> {Some NullCap, None}))"
+definition cap_removeable :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_state \<Rightarrow> bool" where
+  "cap_removeable cap slot s \<equiv>
+     cap = NullCap \<or>
+     (\<exists>p. cap = ZombieCap p \<and> swp opt_cap s ` (({p} \<times> UNIV) - {slot}) \<subseteq> {Some NullCap, None})"
 
-definition
-  finalise_slot_inner1 :: "cdl_cap_ref \<Rightarrow> (cdl_cap \<times> bool) k_monad"
-where
- "finalise_slot_inner1 victim = do
-    cap \<leftarrow> get_cap victim;
-    final \<leftarrow> is_final_cap cap;
-    (cap', irqopt) \<leftarrow> finalise_cap cap final;
-    removeable \<leftarrow> gets $ cap_removeable cap' victim;
-    when (\<not> removeable) (set_cap victim cap')
-        \<sqinter> set_cap victim cap';
-    return (cap', removeable)
-  od"
+definition finalise_slot_inner1 :: "cdl_cap_ref \<Rightarrow> (cdl_cap \<times> bool) k_monad" where
+  "finalise_slot_inner1 victim = do
+     cap \<leftarrow> get_cap victim;
+     final \<leftarrow> is_final_cap cap;
+     (cap', irqopt) \<leftarrow> finalise_cap cap final;
+     removeable \<leftarrow> gets $ cap_removeable cap' victim;
+     when (\<not>removeable) (set_cap victim cap') \<sqinter> set_cap victim cap';
+     return (cap', removeable)
+   od"
 
-definition
-  get_zombie_range :: "cdl_cap \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_ref set"
-where
- "get_zombie_range cap =
-    (\<lambda>s. case cap of ZombieCap p \<Rightarrow> dom (swp opt_cap s) \<inter> ({p} \<times> UNIV)
-               | _ \<Rightarrow> {})"
+definition get_zombie_range :: "cdl_cap \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_ref set" where
+  "get_zombie_range cap \<equiv>
+    \<lambda>s. case cap of ZombieCap p \<Rightarrow> dom (swp opt_cap s) \<inter> ({p} \<times> UNIV) | _ \<Rightarrow> {}"
 
-definition
-  swap_for_delete :: "cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad"
-where
- "swap_for_delete ptr1 ptr2 = do
-    cap1 \<leftarrow> get_cap ptr1;
-    cap2 \<leftarrow> get_cap ptr2;
-    swap_cap cap1 ptr1 cap2 ptr2
-  od"
+definition swap_for_delete :: "cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad" where
+  "swap_for_delete ptr1 ptr2 = do
+     cap1 \<leftarrow> get_cap ptr1;
+     cap2 \<leftarrow> get_cap ptr2;
+     swap_cap cap1 ptr1 cap2 ptr2
+   od"
 
-definition
- "finalise_slot_inner2 =
-      (\<lambda>(region, finalised).
-        liftE (do (victim', remove) \<leftarrow> select region;
-          (cap', removeable) \<leftarrow> finalise_slot_inner1 victim';
-          region' \<leftarrow> gets $ get_zombie_range cap';
-          return (region \<union> (region' \<times> {True}), if removeable then {(victim', remove)} else {})
-        od) \<sqinter>
-        liftE (do (slot, slot') \<leftarrow> select {(x, y). (x, True) \<in> region \<and> (y, True) \<in> region \<and> x \<noteq> y};
-          swap_for_delete slot slot';
-          return (region, {})
-        od) \<sqinter>
-        liftE (do victim' \<leftarrow> select {x. (x, True) \<in> finalised};
-          empty_slot victim';
-          return (region, {})
-        od) \<sqinter>
-        throw
-      )"
+definition finalise_slot_inner2 where
+  "finalise_slot_inner2 \<equiv>
+     \<lambda>(region, finalised).
+       liftE (do
+         (victim', remove) \<leftarrow> select region;
+         (cap', removeable) \<leftarrow> finalise_slot_inner1 victim';
+         region' \<leftarrow> gets $ get_zombie_range cap';
+         return (region \<union> (region' \<times> {True}), if removeable then {(victim', remove)} else {})
+       od) \<sqinter>
+       liftE (do
+         (slot, slot') \<leftarrow> select {(x, y). (x, True) \<in> region \<and> (y, True) \<in> region \<and> x \<noteq> y};
+         swap_for_delete slot slot';
+         return (region, {})
+       od) \<sqinter>
+       liftE (do
+         victim' \<leftarrow> select {x. (x, True) \<in> finalised};
+         empty_slot victim';
+         return (region, {})
+       od) \<sqinter>
+       throw"
 
-definition
-  finalise_slot :: "cdl_cap_ref \<Rightarrow> unit preempt_monad"
-where
- "finalise_slot victim = doE
-    (region, finalised) \<leftarrow>
-      monadic_trancl_preemptible finalise_slot_inner2
-        ({(victim, False)}, {});
+definition finalise_slot :: "cdl_cap_ref \<Rightarrow> unit preempt_monad" where
+  "finalise_slot victim = doE
+    (region, finalised) \<leftarrow> monadic_trancl_preemptible finalise_slot_inner2 ({(victim, False)}, {});
     whenE (victim \<notin> fst ` finalised) throw
   odE"
 
-definition
-  delete_cap :: "cdl_cap_ref \<Rightarrow> unit preempt_monad"
-where
- "delete_cap victim = doE
-    finalise_slot victim;
-    liftE $ empty_slot victim
-  odE"
+definition delete_cap :: "cdl_cap_ref \<Rightarrow> unit preempt_monad" where
+  "delete_cap victim = doE
+     finalise_slot victim;
+     liftE $ empty_slot victim
+   odE"
 
 
-(*
- * Revoke all the descendants of the given cap.
- *
- * If the CDT is being modelled, this will delete all the
- * descendants of the given cap. Wonderful things happen
- * if we happen to, in this process, delete something
- * that contains the cap we are trying to revoke.
- *)
-definition
-  revoke_cap :: "cdl_cap_ref \<Rightarrow> unit preempt_monad"
-where
+(* Revoke all the descendants of the given cap.
+
+   If the CDT is being modelled, this will delete all the descendants of the given cap. Wonderful
+   things happen if we happen to, in this process, delete something that contains the cap we are
+   trying to revoke. *)
+definition revoke_cap :: "cdl_cap_ref \<Rightarrow> unit preempt_monad" where
   "revoke_cap victim = doE
      fin \<leftarrow> monadic_trancl_preemptible (K (doE
-          S \<leftarrow> liftE $ gets $ descendants_of victim;
-          if S = {} then returnOk True
-          else doE
-            child \<leftarrow> liftE $ select S;
-            cap \<leftarrow> liftE $ get_cap child;
-            assertE (cap \<noteq> NullCap);
-            delete_cap child;
-            Monads_D.throw \<sqinter> returnOk False
-          odE
-       odE)) False;
+       S \<leftarrow> liftE $ gets $ descendants_of victim;
+       if S = {} then returnOk True
+       else doE
+         child \<leftarrow> liftE $ select S;
+         cap \<leftarrow> liftE $ get_cap child;
+         assertE (cap \<noteq> NullCap);
+         delete_cap child;
+         throw \<sqinter> returnOk False
+       odE
+     odE)) False;
      unlessE fin throw
    odE"
 
-(*
- * Get the badge the given thread object is using to
- * perform its IPC send operation.
- *)
-definition
-  get_tcb_ep_badge :: "cdl_tcb \<Rightarrow> cdl_badge option"
-where
+(* Get the badge the given thread object is using to perform its IPC send operation *)
+definition get_tcb_ep_badge :: "cdl_tcb \<Rightarrow> cdl_badge option" where
   "get_tcb_ep_badge t \<equiv>
-    case (cdl_tcb_caps t tcb_pending_op_slot) of
-      Some (PendingSyncSendCap _ badge _ _ _ _) \<Rightarrow> Some badge
-    | _ \<Rightarrow> None"
+     case cdl_tcb_caps t tcb_pending_op_slot of
+       Some (PendingSyncSendCap _ badge _ _ _ _) \<Rightarrow> Some badge
+     | _ \<Rightarrow> None"
 
-(*
- * Cancel all pending send operations to the given endpoint
- * that are using the given badge.
- *)
-definition
-  cancel_badged_sends :: "cdl_object_id \<Rightarrow> cdl_badge \<Rightarrow> unit k_monad"
-where
+(* Cancel all pending send operations to the given endpoint that are using the given badge. *)
+definition cancel_badged_sends :: "cdl_object_id \<Rightarrow> cdl_badge \<Rightarrow> unit k_monad" where
   "cancel_badged_sends ep badge \<equiv>
-    modify (\<lambda>s. s\<lparr>cdl_objects := map_option
-        (\<lambda>obj. case obj of
-            Tcb t \<Rightarrow>
-              if (is_thread_blocked_on_endpoint t ep
-                  \<and> get_tcb_ep_badge t = Some badge) then
-                    Tcb (remove_pending_operation t cdl_cap.RestartCap)
-              else
-                Tcb t
-          | _ \<Rightarrow> obj) \<circ> (cdl_objects s)\<rparr>)"
+     modify (\<lambda>s. s\<lparr>cdl_objects :=
+                     map_option
+                       (\<lambda>obj. case obj of
+                                Tcb t \<Rightarrow> if is_thread_blocked_on_endpoint t ep \<and>
+                                            get_tcb_ep_badge t = Some badge
+                                         then Tcb (remove_pending_operation t cdl_cap.RestartCap)
+                                         else Tcb t
+                              | _ \<Rightarrow> obj)
+                     \<circ> (cdl_objects s)\<rparr>)"
 
 
-(*
- * Regenerate the target object.
- *
- * Any children of the cap are first revoked. The object
- * is then reset into its original (as-if just created)
- * state. But maybe not. It's complex.
- *
- * In the C implementation, attempting to recycle a
- * non-master cap may do something that is not
- * a recycle. (Should be perhaps return an error?)
- *)
-definition
-  clear_object_caps :: "cdl_object_id \<Rightarrow> unit k_monad"
-where
- "clear_object_caps ptr = do
-    ptrs \<leftarrow> gets (\<lambda>s. {cptr. fst cptr = ptr \<and> opt_cap cptr s \<noteq> None});
-    ptrlist \<leftarrow> select {xs. set xs = ptrs \<and> distinct xs};
-    mapM_x empty_slot ptrlist
-  od"
+(* Regenerate the target object.
+
+   Any children of the cap are first revoked. The object is then reset into its original (as if
+   just created) state. But maybe not. It's complex. In the C implementation, attempting to
+   recycle a non-master cap may do something that is not a recycle. *)
+definition clear_object_caps :: "cdl_object_id \<Rightarrow> unit k_monad" where
+  "clear_object_caps ptr = do
+     ptrs \<leftarrow> gets (\<lambda>s. {cptr. fst cptr = ptr \<and> opt_cap cptr s \<noteq> None});
+     ptrlist \<leftarrow> select {xs. set xs = ptrs \<and> distinct xs};
+     mapM_x empty_slot ptrlist
+   od"
 
 definition cdl_default_tcb :: "cdl_object" where
   "cdl_default_tcb \<equiv> Tcb \<lparr>
-    cdl_tcb_caps =
-      [tcb_cspace_slot \<mapsto> cdl_cap.NullCap,
+     cdl_tcb_caps = [
+       tcb_cspace_slot \<mapsto> cdl_cap.NullCap,
        tcb_vspace_slot \<mapsto> cdl_cap.NullCap,
        tcb_replycap_slot \<mapsto> cdl_cap.NullCap,
        tcb_caller_slot \<mapsto> cdl_cap.NullCap,
@@ -488,201 +386,172 @@ definition cdl_default_tcb :: "cdl_object" where
        tcb_pending_op_slot \<mapsto> cdl_cap.NullCap,
        tcb_boundntfn_slot \<mapsto> cdl_cap.NullCap,
        tcb_boundvcpu_slot \<mapsto> cdl_cap.NullCap],
-    cdl_tcb_fault_endpoint = 0,
-    cdl_tcb_intent = \<lparr>
-      cdl_intent_op = None,
-      cdl_intent_error = False,
-      cdl_intent_cap = 0,
-      cdl_intent_extras = [],
-      cdl_intent_recv_slot = None
-    \<rparr>,
-    cdl_tcb_has_fault = False,
-    cdl_tcb_domain = minBound,
-    cdl_tcb_extra = default_tcb_extra_data\<rparr>"
+     cdl_tcb_fault_endpoint = 0,
+     cdl_tcb_intent = \<lparr>
+       cdl_intent_op = None,
+       cdl_intent_error = False,
+       cdl_intent_cap = 0,
+       cdl_intent_extras = [],
+       cdl_intent_recv_slot = None\<rparr>,
+     cdl_tcb_has_fault = False,
+     cdl_tcb_domain = minBound,
+     cdl_tcb_extra = default_tcb_extra_data\<rparr>"
 
-definition obj_tcb :: "cdl_object \<Rightarrow> cdl_tcb"
-where "obj_tcb obj \<equiv> case obj of Tcb tcb \<Rightarrow> tcb"
+definition obj_tcb :: "cdl_object \<Rightarrow> cdl_tcb" where
+  "obj_tcb obj \<equiv> case obj of Tcb tcb \<Rightarrow> tcb"
 
-definition tcb_caps_merge :: "cdl_tcb \<Rightarrow> cdl_tcb \<Rightarrow> cdl_tcb"
-  where "tcb_caps_merge regtcb captcb \<equiv> regtcb\<lparr>cdl_tcb_caps
-  := (cdl_tcb_caps captcb)(tcb_pending_op_slot \<mapsto> the (cdl_tcb_caps regtcb tcb_pending_op_slot), tcb_boundntfn_slot \<mapsto> the (cdl_tcb_caps regtcb tcb_boundntfn_slot))\<rparr>"
+definition tcb_caps_merge :: "cdl_tcb \<Rightarrow> cdl_tcb \<Rightarrow> cdl_tcb" where
+  "tcb_caps_merge regtcb captcb \<equiv>
+     regtcb\<lparr>cdl_tcb_caps :=
+              (cdl_tcb_caps captcb)
+                (tcb_pending_op_slot \<mapsto> the (cdl_tcb_caps regtcb tcb_pending_op_slot),
+                 tcb_boundntfn_slot \<mapsto> the (cdl_tcb_caps regtcb tcb_boundntfn_slot))\<rparr>"
 
-definition merge_with_dft_tcb :: "cdl_object_id \<Rightarrow> unit k_monad"
-where "merge_with_dft_tcb o_id \<equiv>
- do
-  new_intent \<leftarrow> select UNIV;
-  KHeap_D.update_thread o_id (cdl_tcb_intent_update (\<lambda>x. new_intent) \<circ> (tcb_caps_merge (obj_tcb cdl_default_tcb)))
- od"
+definition merge_with_dft_tcb :: "cdl_object_id \<Rightarrow> unit k_monad" where
+  "merge_with_dft_tcb o_id \<equiv> do
+     new_intent \<leftarrow> select UNIV;
+     update_thread o_id
+       (cdl_tcb_intent_update (\<lambda>x. new_intent) \<circ> tcb_caps_merge (obj_tcb cdl_default_tcb))
+   od"
 
-fun
-  reset_mem_mapping :: "cdl_cap \<Rightarrow> cdl_cap"
-where
-  "reset_mem_mapping (FrameCap dev p rts sz b mp) = FrameCap dev p rts sz b None"
-| "reset_mem_mapping (PageTableCap l ptr b mp) = PageTableCap l ptr b None"
-| "reset_mem_mapping cap = cap"
+fun reset_mem_mapping :: "cdl_cap \<Rightarrow> cdl_cap" where
+    "reset_mem_mapping (FrameCap dev p rts sz b mp) = FrameCap dev p rts sz b None"
+  | "reset_mem_mapping (PageTableCap l ptr b mp) = PageTableCap l ptr b None"
+  | "reset_mem_mapping cap = cap"
 
 
-(*
- * Walk a user's CSpace to convert a user's CPTR into a cap slot.
- *)
-function
-  resolve_address_bits ::
+(* Walk a user's CSpace to convert a user's CPTR into a cap slot. *)
+function resolve_address_bits ::
   "cdl_cap \<Rightarrow> cdl_cptr \<Rightarrow> nat \<Rightarrow> (cdl_cap_ref \<times> nat) fault_monad"
-where
+  where
   "resolve_address_bits cnode_cap cap_ptr remaining_size = doE
-    unlessE (is_cnode_cap cnode_cap) $ throw;
+     unlessE (is_cnode_cap cnode_cap) $ throw;
 
-    \<comment> \<open>Fetch the next level CNode.\<close>
-    cnode \<leftarrow> liftE $ get_cnode $ cap_object cnode_cap;
-    radix_size \<leftarrow> returnOk $ cdl_cnode_size_bits cnode;
-    guard_size \<leftarrow> returnOk $ cap_guard_size cnode_cap;
-    cap_guard  \<leftarrow> returnOk $ cap_guard cnode_cap;
-    level_size \<leftarrow> returnOk (radix_size + guard_size);
-    assertE (level_size \<noteq> 0);
+     \<comment> \<open>Fetch the next level CNode.\<close>
+     cnode \<leftarrow> liftE $ get_cnode $ cap_object cnode_cap;
+     radix_size \<leftarrow> returnOk $ cdl_cnode_size_bits cnode;
+     guard_size \<leftarrow> returnOk $ cap_guard_size cnode_cap;
+     cap_guard  \<leftarrow> returnOk $ cap_guard cnode_cap;
+     level_size \<leftarrow> returnOk (radix_size + guard_size);
+     assertE (level_size \<noteq> 0);
 
-    \<comment> \<open>Ensure the guard matches up.\<close>
-    guard \<leftarrow> returnOk $ (cap_ptr >> (remaining_size-guard_size)) && (mask guard_size);
-    unlessE (guard_size \<le> remaining_size \<and> guard = cap_guard) $ throw;
+     \<comment> \<open>Ensure the guard matches up.\<close>
+     guard \<leftarrow> returnOk $ (cap_ptr >> (remaining_size-guard_size)) && (mask guard_size);
+     unlessE (guard_size \<le> remaining_size \<and> guard = cap_guard) $ throw;
 
-    \<comment> \<open>Ensure we still enough unresolved bits left in our CPTR.\<close>
-    whenE (level_size > remaining_size) $ throw;
+     \<comment> \<open>Ensure we still enough unresolved bits left in our CPTR.\<close>
+     whenE (level_size > remaining_size) $ throw;
 
-    \<comment> \<open>Find the next slot.\<close>
-    offset \<leftarrow> returnOk $ (cap_ptr >> (remaining_size-level_size)) && (mask radix_size);
-    slot \<leftarrow> returnOk (cap_object cnode_cap, unat offset);
-    size_left \<leftarrow> returnOk (remaining_size - level_size);
-    if (size_left = 0) then
-      returnOk (slot, 0)
-    else
-      doE
-        next_cap \<leftarrow> liftE $ get_cap (slot);
-        if is_cnode_cap next_cap then
-          resolve_address_bits next_cap cap_ptr size_left
-        else
-          returnOk (slot, size_left)
-      odE
-  odE"
+     \<comment> \<open>Find the next slot.\<close>
+     offset \<leftarrow> returnOk $ (cap_ptr >> (remaining_size-level_size)) && (mask radix_size);
+      slot \<leftarrow> returnOk (cap_object cnode_cap, unat offset);
+     size_left \<leftarrow> returnOk (remaining_size - level_size);
+     if size_left = 0 then
+       returnOk (slot, 0)
+     else doE
+       next_cap \<leftarrow> liftE $ get_cap (slot);
+       if is_cnode_cap next_cap
+       then resolve_address_bits next_cap cap_ptr size_left
+       else returnOk (slot, size_left)
+     odE
+   odE"
   by fastforce+
 
 termination resolve_address_bits
-  apply (relation "measure (\<lambda>(a,b,c). c)")
-  apply (auto simp: in_monad)
-  done
+  by (relation "measure (\<lambda>(a,b,c). c)") (auto simp: in_monad)
 
-definition
-  lookup_slot :: "cdl_object_id \<Rightarrow> cdl_cptr \<Rightarrow> cdl_cap_ref fault_monad"
-where
-  "lookup_slot thread cptr \<equiv>
-    doE
-      cspace_root \<leftarrow> liftE $ get_cap (thread, tcb_cspace_slot);
-      (slot, _) \<leftarrow> resolve_address_bits cspace_root cptr word_bits;
-      returnOk slot
-    odE"
+definition lookup_slot :: "cdl_object_id \<Rightarrow> cdl_cptr \<Rightarrow> cdl_cap_ref fault_monad" where
+  "lookup_slot thread cptr \<equiv> doE
+     cspace_root \<leftarrow> liftE $ get_cap (thread, tcb_cspace_slot);
+     (slot, _) \<leftarrow> resolve_address_bits cspace_root cptr word_bits;
+     returnOk slot
+   odE"
 
-definition
-  lookup_cap :: "cdl_object_id \<Rightarrow> cdl_cptr \<Rightarrow> cdl_cap fault_monad"
-where
-  "lookup_cap thread cptr \<equiv>
-    doE
-      slot \<leftarrow> lookup_slot thread cptr;
-      liftE $ get_cap slot
-    odE"
+definition lookup_cap :: "cdl_object_id \<Rightarrow> cdl_cptr \<Rightarrow> cdl_cap fault_monad" where
+  "lookup_cap thread cptr \<equiv> doE
+     slot \<leftarrow> lookup_slot thread cptr;
+     liftE $ get_cap slot
+   odE"
 
-definition
-  lookup_cap_and_slot :: "cdl_object_id \<Rightarrow> cdl_cptr \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) fault_monad"
-where
-  "lookup_cap_and_slot thread cptr \<equiv>
-    doE
-      slot \<leftarrow> lookup_slot thread cptr;
-      cap \<leftarrow> liftE $ get_cap slot;
-      returnOk (cap, slot)
-    odE"
+definition lookup_cap_and_slot ::
+  "cdl_object_id \<Rightarrow> cdl_cptr \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) fault_monad"
+  where
+  "lookup_cap_and_slot thread cptr \<equiv> doE
+     slot \<leftarrow> lookup_slot thread cptr;
+     cap \<leftarrow> liftE $ get_cap slot;
+     returnOk (cap, slot)
+   odE"
 
-definition
-  lookup_slot_for_cnode_op :: "cdl_cap \<Rightarrow> cdl_cptr \<Rightarrow> nat \<Rightarrow> cdl_cap_ref except_monad"
-where
-  "lookup_slot_for_cnode_op croot cptr depth \<equiv>
-    doE
-      whenE (depth < 1 \<or> depth > word_bits) throw;
-      (slot, rem) \<leftarrow> fault_to_except $ resolve_address_bits croot cptr depth;
-      if rem = 0 then returnOk slot else throw
-    odE"
+definition lookup_slot_for_cnode_op :: "cdl_cap \<Rightarrow> cdl_cptr \<Rightarrow> nat \<Rightarrow> cdl_cap_ref except_monad"
+  where
+  "lookup_slot_for_cnode_op croot cptr depth \<equiv> doE
+     whenE (depth < 1 \<or> depth > word_bits) throw;
+     (slot, rem) \<leftarrow> fault_to_except $ resolve_address_bits croot cptr depth;
+     if rem = 0 then returnOk slot else throw
+   odE"
 
 
-(*
- * Update the badge of a badged cap. For notification and endpoint caps, mask off bits the kernel
- * is unable to store for implementation reasons.
- *)
-definition
-  badge_update :: "machine_word \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap"
-where
+(* Update the badge of a badged cap. For notification and endpoint caps, mask off bits the kernel
+   is unable to store for implementation reasons. *)
+definition badge_update :: "machine_word \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap" where
   "badge_update data cap \<equiv>
      let
        data' = if is_ep_cap cap \<or> is_ntfn_cap cap then data && mask badge_bits else data
      in
        update_cap_badge data' cap"
 
-(*
- * Transform a capability based on a request from the user.
- *
- * The "data" word is interpreted differently for different cap types.
- *
- * We return a set of possible caps to allow for non-deterministic
- * implementations, to avoid messy implementation details of the CDT
- * in lower-level models.
- *)
+(* Transform a capability based on a request from the user.
+
+   The "data" word is interpreted differently for different cap types.
+
+   We return a set of possible caps to allow for non-deterministic
+   implementations, to avoid messy implementation details of the CDT
+   in lower-level models. *)
 definition update_cap_data :: "bool \<Rightarrow> machine_word \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap k_monad" where
   "update_cap_data preserve data cap \<equiv>
-    return $ case cap of
-        EndpointCap _ b _ \<Rightarrow> if b = 0 \<and> \<not> preserve then badge_update data cap else NullCap
-      | NotificationCap _ b _ \<Rightarrow> if b = 0 \<and> \<not> preserve then badge_update data cap else NullCap
-      | CNodeCap object guard guard_size sz \<Rightarrow>
-          let
-            reserved_bits = 3;
-            guard_bits = 18;
-            guard_size_bits = 5;
-            new_guard_size = unat ((data >> reserved_bits) && mask guard_size_bits);
-            new_guard = (data >> (reserved_bits + guard_size_bits)) &&
-                        mask (min (unat ((data >> reserved_bits) && mask guard_size_bits)) guard_bits)
-          in
-            if new_guard_size + sz > word_bits
-            then NullCap
-            else CNodeCap object new_guard new_guard_size sz
-      | SMCCap b \<Rightarrow> if b = 0 \<and> \<not> preserve then badge_update data cap else NullCap
-      | _ \<Rightarrow> cap"
+     return $ case cap of
+       EndpointCap _ b _ \<Rightarrow> if b = 0 \<and> \<not> preserve then badge_update data cap else NullCap
+     | NotificationCap _ b _ \<Rightarrow> if b = 0 \<and> \<not> preserve then badge_update data cap else NullCap
+     | CNodeCap object guard guard_size sz \<Rightarrow>
+         let
+           reserved_bits = 3;
+           guard_bits = 18;
+           guard_size_bits = 5;
+           new_guard_size = unat ((data >> reserved_bits) && mask guard_size_bits);
+           new_guard = (data >> (reserved_bits + guard_size_bits)) &&
+                       mask (min (unat ((data >> reserved_bits) && mask guard_size_bits)) guard_bits)
+         in
+           if new_guard_size + sz > word_bits
+           then NullCap
+           else CNodeCap object new_guard new_guard_size sz
+     | SMCCap b \<Rightarrow> if b = 0 \<and> \<not> preserve then badge_update data cap else NullCap
+     | _ \<Rightarrow> cap"
 
-(*
- * Some caps may not be copied/minted. In this case the following function
- * returns NullCap or throws.
- *
- * PageTable and PageDirectory caps may not be copied if already mapped. This is
- * left out here and modelled by nondeterminism.
- *)
-definition
-  derive_cap :: "cdl_cap_ref \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap except_monad"
-where
-  "derive_cap slot cap \<equiv> case cap of
-     UntypedCap _ _ _ \<Rightarrow> doE ensure_no_children slot; returnOk cap odE
-   | ReplyCap _ _ \<Rightarrow> returnOk NullCap
-   | MasterReplyCap oref \<Rightarrow> returnOk NullCap
-   | IrqControlCap \<Rightarrow> returnOk NullCap
-   | ZombieCap _ \<Rightarrow> returnOk NullCap
-   | FrameCap dev p r sz b x \<Rightarrow> returnOk (FrameCap dev p r sz b None)
-   | PageTableCap _ _ _ _ \<Rightarrow> throw \<sqinter> returnOk cap
-   | _ \<Rightarrow> returnOk cap"
+(* Some caps may not be copied/minted. In this case the following function
+   returns NullCap or throws.
+
+   PageTable and PageDirectory caps may not be copied if already mapped. This is
+   left out here and modelled by nondeterminism. *)
+definition derive_cap :: "cdl_cap_ref \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap except_monad" where
+  "derive_cap slot cap \<equiv>
+     case cap of
+       UntypedCap _ _ _        \<Rightarrow> doE ensure_no_children slot; returnOk cap odE
+     | ReplyCap _ _            \<Rightarrow> returnOk NullCap
+     | MasterReplyCap oref     \<Rightarrow> returnOk NullCap
+     | IrqControlCap           \<Rightarrow> returnOk NullCap
+     | ZombieCap _             \<Rightarrow> returnOk NullCap
+     | FrameCap dev p r sz b x \<Rightarrow> returnOk (FrameCap dev p r sz b None)
+     | PageTableCap _ _ _ _    \<Rightarrow> throw \<sqinter> returnOk cap
+     | _                       \<Rightarrow> returnOk cap"
 
 
-(* This function is here to make it available in both Tcb_D and
-   PageTable_D *)
+(* This function is here to make it available in both Tcb_D and PageTable_D *)
 
 (* Modify the TCB's IpcBuffer or Registers in an arbitrary fashion. *)
-definition
-  corrupt_tcb_intent :: "cdl_object_id \<Rightarrow> unit k_monad"
-where
-  "corrupt_tcb_intent target_tcb \<equiv>
-    do
-      new_intent \<leftarrow> select UNIV;
-      update_thread target_tcb (\<lambda>t. t\<lparr>cdl_tcb_intent := new_intent\<rparr>)
-    od"
+definition corrupt_tcb_intent :: "cdl_object_id \<Rightarrow> unit k_monad" where
+  "corrupt_tcb_intent target_tcb \<equiv> do
+     new_intent \<leftarrow> select UNIV;
+     update_thread target_tcb (\<lambda>t. t\<lparr>cdl_tcb_intent := new_intent\<rparr>)
+   od"
 
 end

--- a/spec/capDL/Decode_D.thy
+++ b/spec/capDL/Decode_D.thy
@@ -11,8 +11,6 @@ theory Decode_D
     Interrupt_D
     PageTable_D
     GenPageTable_D
-    Tcb_D
-    Untyped_D
 begin
 
 definition get_cnode_intent :: "cdl_intent \<Rightarrow> cdl_cnode_intent option" where

--- a/spec/capDL/Decode_D.thy
+++ b/spec/capDL/Decode_D.thy
@@ -5,219 +5,145 @@
  *)
 
 theory Decode_D
-imports
-  Asid_D
-  CNode_D
-  Interrupt_D
-  PageTable_D
-  GenPageTable_D
-  Tcb_D
-  Untyped_D
+  imports
+    Asid_D
+    CNode_D
+    Interrupt_D
+    PageTable_D
+    GenPageTable_D
+    Tcb_D
+    Untyped_D
 begin
 
-definition
-  get_cnode_intent :: "cdl_intent \<Rightarrow> cdl_cnode_intent option"
-where
-  "get_cnode_intent intent \<equiv>
-    case intent of
-        CNodeIntent x \<Rightarrow> Some x
-      | _ \<Rightarrow> None"
+definition get_cnode_intent :: "cdl_intent \<Rightarrow> cdl_cnode_intent option" where
+  "get_cnode_intent intent \<equiv> case intent of CNodeIntent x \<Rightarrow> Some x | _ \<Rightarrow> None"
 
-definition
-  get_tcb_intent :: "cdl_intent \<Rightarrow> cdl_tcb_intent option"
-where
-  "get_tcb_intent intent \<equiv>
-    case intent of
-        TcbIntent x \<Rightarrow> Some x
-      | _ \<Rightarrow> None"
+definition get_tcb_intent :: "cdl_intent \<Rightarrow> cdl_tcb_intent option" where
+  "get_tcb_intent intent \<equiv> case intent of TcbIntent x \<Rightarrow> Some x | _ \<Rightarrow> None"
 
-definition
-  get_irq_control_intent :: "cdl_intent \<Rightarrow> cdl_irq_control_intent option"
-where
-  "get_irq_control_intent intent \<equiv>
-    case intent of
-        IrqControlIntent x \<Rightarrow> Some x
-      | _ \<Rightarrow> None"
+definition get_irq_control_intent :: "cdl_intent \<Rightarrow> cdl_irq_control_intent option" where
+  "get_irq_control_intent intent \<equiv> case intent of IrqControlIntent x \<Rightarrow> Some x | _ \<Rightarrow> None"
 
-definition
-  get_irq_handler_intent :: "cdl_intent \<Rightarrow> cdl_irq_handler_intent option"
-where
-  "get_irq_handler_intent intent \<equiv>
-    case intent of
-        IrqHandlerIntent x \<Rightarrow> Some x
-      | _ \<Rightarrow> None"
+definition get_irq_handler_intent :: "cdl_intent \<Rightarrow> cdl_irq_handler_intent option" where
+  "get_irq_handler_intent intent \<equiv> case intent of IrqHandlerIntent x \<Rightarrow> Some x | _ \<Rightarrow> None"
 
-definition
-  get_asid_pool_intent :: "cdl_intent \<Rightarrow> cdl_asid_pool_intent option"
-where
-  "get_asid_pool_intent intent \<equiv>
-    case intent of
-        AsidPoolIntent x \<Rightarrow> Some x
-      | _ \<Rightarrow> None"
+definition get_asid_pool_intent :: "cdl_intent \<Rightarrow> cdl_asid_pool_intent option" where
+  "get_asid_pool_intent intent \<equiv> case intent of AsidPoolIntent x \<Rightarrow> Some x | _ \<Rightarrow> None"
 
+definition get_asid_control_intent :: "cdl_intent \<Rightarrow> cdl_asid_control_intent option" where
+  "get_asid_control_intent intent \<equiv> case intent of AsidControlIntent x \<Rightarrow> Some x | _ \<Rightarrow> None"
 
-definition
-  get_asid_control_intent :: "cdl_intent \<Rightarrow> cdl_asid_control_intent option"
-where
-  "get_asid_control_intent intent \<equiv>
-    case intent of
-        AsidControlIntent x \<Rightarrow> Some x
-      | _ \<Rightarrow> None"
+definition get_page_intent :: "cdl_intent \<Rightarrow> cdl_page_intent option" where
+  "get_page_intent intent \<equiv> case intent of PageIntent x \<Rightarrow> Some x | _ \<Rightarrow> None"
 
-definition
-  get_page_intent :: "cdl_intent \<Rightarrow> cdl_page_intent option"
-where
-  "get_page_intent intent \<equiv>
-    case intent of
-        PageIntent x \<Rightarrow> Some x
-      | _ \<Rightarrow> None"
+definition get_page_table_intent :: "cdl_intent \<Rightarrow> cdl_page_table_intent option" where
+  "get_page_table_intent intent \<equiv> case intent of PageTableIntent x \<Rightarrow> Some x | _ \<Rightarrow> None"
 
-definition
-  get_page_table_intent :: "cdl_intent \<Rightarrow> cdl_page_table_intent option"
-where
-  "get_page_table_intent intent \<equiv>
-    case intent of
-        PageTableIntent x \<Rightarrow> Some x
-      | _ \<Rightarrow> None"
+definition get_page_directory_intent :: "cdl_intent \<Rightarrow> cdl_page_directory_intent option" where
+  "get_page_directory_intent intent \<equiv> case intent of PageDirectoryIntent x \<Rightarrow> Some x | _ \<Rightarrow> None"
 
-definition
-  get_page_directory_intent :: "cdl_intent \<Rightarrow> cdl_page_directory_intent option"
-where
-  "get_page_directory_intent intent \<equiv>
-    case intent of
-        PageDirectoryIntent x \<Rightarrow> Some x
-      | _ \<Rightarrow> None"
+definition get_untyped_intent :: "cdl_intent \<Rightarrow> cdl_untyped_intent option" where
+  "get_untyped_intent intent \<equiv> case intent of UntypedIntent x \<Rightarrow> Some x | _ \<Rightarrow> None"
 
-definition
-  get_untyped_intent :: "cdl_intent \<Rightarrow> cdl_untyped_intent option"
-where
-  "get_untyped_intent intent \<equiv>
-    case intent of
-        UntypedIntent x \<Rightarrow> Some x
-      | _ \<Rightarrow> None"
+definition get_domain_intent :: "cdl_intent \<Rightarrow> cdl_domain_intent option" where
+  "get_domain_intent intent \<equiv> case intent of DomainIntent x \<Rightarrow> Some x | _ \<Rightarrow> None"
 
-definition
-  get_domain_intent :: "cdl_intent \<Rightarrow> cdl_domain_intent option"
-where
-  "get_domain_intent intent \<equiv>
-     case intent of
-         DomainIntent x \<Rightarrow> Some x
-       | _ \<Rightarrow> None"
-
-(*
- * Decode and validate the given intent, turning it into an
- * invocation.
- *)
-definition
-  decode_invocation :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_intent \<Rightarrow> cdl_invocation except_monad"
-where
+(* Decode and validate the given intent, turning it into a invocation. *)
+definition decode_invocation ::
+  "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_intent \<Rightarrow>
+   cdl_invocation except_monad"
+  where
   "decode_invocation invoked_cap invoked_cap_ref caps intent \<equiv>
-    case invoked_cap of
-       \<comment> \<open>For endpoint-like caps, we always perform an operation,
-          regardless of the user's actual intent.\<close>
-         EndpointCap o_id badge rights \<Rightarrow>
-           (if Write \<in> rights then
-             returnOk $ InvokeEndpoint (SyncMessage badge (Grant \<in> rights) (GrantReply \<in> rights) o_id)
-           else
-             throw)
-       | NotificationCap o_id badge rights \<Rightarrow>
-           (if Write \<in> rights then
-             returnOk $ InvokeNotification (Signal badge o_id)
-           else
-             throw)
-       | ReplyCap o_id rights \<Rightarrow>
-           returnOk $ InvokeReply (ReplyMessage o_id invoked_cap_ref (Grant \<in> rights))
+     case invoked_cap of
+       EndpointCap o_id badge rights \<Rightarrow>
+         if Write \<in> rights
+         then returnOk $ InvokeEndpoint (SyncMessage badge (Grant \<in> rights)
+                                                     (GrantReply \<in> rights) o_id)
+         else throw
+     | NotificationCap o_id badge rights \<Rightarrow>
+         if Write \<in> rights
+         then returnOk $ InvokeNotification (Signal badge o_id)
+         else throw
+     | ReplyCap o_id rights \<Rightarrow>
+         returnOk $ InvokeReply (ReplyMessage o_id invoked_cap_ref (Grant \<in> rights))
 
-       \<comment> \<open>
-         For other operations, we only perform the user's intent
-         if it matches up with the cap.
-
-         Note that this does not currently match the current
-         implementation: instead, the user's message will be
-         decoded into a new (undefined) intent for what the
-         cap happened to be. I propose modifying labels used to
-         avoid overlaps between different items so that we can
-         recognise when the user is invoking the wrong item.
-       \<close>
-       | CNodeCap _ _ _ _ \<Rightarrow>
-           doE
-             cnode_intent \<leftarrow> throw_opt undefined $ get_cnode_intent intent;
-             liftME InvokeCNode $ decode_cnode_invocation invoked_cap invoked_cap_ref caps cnode_intent
+     \<comment> \<open>For non-endpoint operations, we only perform the user's intent if it matches up with
+         the cap.
+         Note that this does not currently match the current implementation: instead, in the
+         implementation, the user's message will be decoded into a new (undefined) intent for
+         what the cap happened to be. Making invocation labels non-overlapping could change that.\<close>
+     | CNodeCap _ _ _ _ \<Rightarrow> doE
+         cnode_intent \<leftarrow> throw_opt undefined $ get_cnode_intent intent;
+         liftME InvokeCNode $ decode_cnode_invocation invoked_cap invoked_cap_ref caps cnode_intent
+       odE
+     | TcbCap _ \<Rightarrow> doE
+         tcb_intent \<leftarrow> throw_opt undefined $ get_tcb_intent intent;
+         liftME InvokeTcb $ decode_tcb_invocation invoked_cap invoked_cap_ref caps tcb_intent
+       odE
+     | IrqControlCap \<Rightarrow> doE
+         irq_control_intent \<leftarrow> throw_opt undefined $ get_irq_control_intent intent;
+         liftME InvokeIrqControl $ decode_irq_control_invocation invoked_cap invoked_cap_ref caps
+                                                                 irq_control_intent
+       odE
+     | IrqHandlerCap _ \<Rightarrow> doE
+         irq_handler_intent \<leftarrow> throw_opt undefined $ get_irq_handler_intent intent;
+         liftME InvokeIrqHandler $ decode_irq_handler_invocation invoked_cap invoked_cap_ref caps
+                                                                 irq_handler_intent
+       odE
+     | SGISignalCap _ _ \<Rightarrow>
+         returnOk $ InvokeSGISignal SGISignalGenerate
+     | AsidPoolCap _ _\<Rightarrow> doE
+         asid_pool_intent \<leftarrow> throw_opt undefined $ get_asid_pool_intent intent;
+         liftME InvokeAsidPool $ decode_asid_pool_invocation invoked_cap invoked_cap_ref caps
+                                                             asid_pool_intent
+       odE
+     | AsidControlCap \<Rightarrow> doE
+         asid_control_intent \<leftarrow> throw_opt undefined $ get_asid_control_intent intent;
+         liftME InvokeAsidControl $ decode_asid_control_invocation invoked_cap invoked_cap_ref
+                                                                   caps asid_control_intent
+       odE
+     | UntypedCap _ _ _ \<Rightarrow> doE
+         untyped_intent \<leftarrow> throw_opt undefined $ get_untyped_intent intent;
+         liftME InvokeUntyped $ decode_untyped_invocation invoked_cap invoked_cap_ref caps
+                                                          untyped_intent
+       odE
+     | FrameCap _ _ _ _ _ _ \<Rightarrow> doE
+         page_intent \<leftarrow> throw_opt undefined $ get_page_intent intent;
+         liftME InvokePage $ (if cdl_ARCH = AARCH32
+                              then decode_page_invocation
+                              else gen_decode_page_invocation)
+                             invoked_cap invoked_cap_ref caps page_intent
+       odE
+     | PageTableCap pt_t _ _ _ \<Rightarrow>
+         if cdl_ARCH = AARCH32
+         then
+           if pt_t = PT
+           then doE
+             page_table_intent \<leftarrow> throw_opt undefined $ get_page_table_intent intent;
+             liftME InvokePageTable $ decode_page_table_invocation invoked_cap invoked_cap_ref caps
+                                                                   page_table_intent
            odE
-       | TcbCap _ \<Rightarrow>
-           doE
-             tcb_intent \<leftarrow> throw_opt undefined $ get_tcb_intent intent;
-             liftME InvokeTcb $ decode_tcb_invocation invoked_cap invoked_cap_ref caps tcb_intent
+           else if pt_t = PD
+           then doE
+             page_directory_intent \<leftarrow> throw_opt undefined $ get_page_directory_intent intent;
+             liftME InvokePageDirectory $
+               decode_page_directory_invocation invoked_cap invoked_cap_ref caps
+                                                page_directory_intent
            odE
-       | IrqControlCap \<Rightarrow>
-           doE
-             irq_control_intent \<leftarrow> throw_opt undefined $ get_irq_control_intent intent;
-             liftME InvokeIrqControl $ decode_irq_control_invocation
-                 invoked_cap invoked_cap_ref caps irq_control_intent
-           odE
-       | IrqHandlerCap _ \<Rightarrow>
-           doE
-             irq_handler_intent \<leftarrow> throw_opt undefined $ get_irq_handler_intent intent;
-             liftME InvokeIrqHandler $ decode_irq_handler_invocation
-                 invoked_cap invoked_cap_ref caps irq_handler_intent
-           odE
-       | SGISignalCap _ _ \<Rightarrow>
-             returnOk $ InvokeSGISignal SGISignalGenerate
-       | AsidPoolCap _ _\<Rightarrow>
-           doE
-             asid_pool_intent \<leftarrow> throw_opt undefined $ get_asid_pool_intent intent;
-             liftME InvokeAsidPool $ decode_asid_pool_invocation
-                 invoked_cap invoked_cap_ref caps asid_pool_intent
-           odE
-       | AsidControlCap \<Rightarrow>
-           doE
-             asid_control_intent \<leftarrow> throw_opt undefined $ get_asid_control_intent intent;
-             liftME InvokeAsidControl $ decode_asid_control_invocation
-                 invoked_cap invoked_cap_ref caps asid_control_intent
-           odE
-       | UntypedCap _ _ _ \<Rightarrow>
-           doE
-             untyped_intent \<leftarrow> throw_opt undefined $ get_untyped_intent intent;
-             liftME InvokeUntyped $ decode_untyped_invocation
-                 invoked_cap invoked_cap_ref caps untyped_intent
-           odE
-       | FrameCap _ _ _ _ _ _ \<Rightarrow>
-           doE
-             page_intent \<leftarrow> throw_opt undefined $ get_page_intent intent;
-             liftME InvokePage $
-                      (if cdl_ARCH = AARCH32
-                       then decode_page_invocation
-                       else gen_decode_page_invocation)
-                      invoked_cap invoked_cap_ref caps page_intent
-           odE
-       | PageTableCap pt_t _ _ _ \<Rightarrow>
-           if cdl_ARCH = AARCH32 then
-             if pt_t = PT then doE
-               page_table_intent \<leftarrow> throw_opt undefined $ get_page_table_intent intent;
-               liftME InvokePageTable $ decode_page_table_invocation
-                                          invoked_cap invoked_cap_ref caps page_table_intent
-             odE
-             else if pt_t = PD then doE
-               page_directory_intent \<leftarrow> throw_opt undefined $ get_page_directory_intent intent;
-               liftME InvokePageDirectory $ decode_page_directory_invocation
-                                              invoked_cap invoked_cap_ref caps page_directory_intent
-             odE
-             else fail
-           else doE
-             page_table_intent \<leftarrow> throw_on_none $ get_page_table_intent intent;
-             liftME InvokePageTable $ gen_decode_page_table_invocation
-                                        invoked_cap invoked_cap_ref caps page_table_intent
-           odE
-       | DomainCap \<Rightarrow>
-          doE
-            domain_intent \<leftarrow> throw_opt undefined $ get_domain_intent intent;
-            liftME InvokeDomain $ decode_domain_invocation caps domain_intent
-          odE
-       | VCPUCap vcpu \<Rightarrow>
-          doE
-            _ \<leftarrow> unlessE (intent = VCPUIntent) throw;
-            liftME InvokeVCPU $ decode_vcpu_invocation vcpu caps
-          odE
+           else fail
+         else doE
+           page_table_intent \<leftarrow> throw_on_none $ get_page_table_intent intent;
+           liftME InvokePageTable $ gen_decode_page_table_invocation invoked_cap invoked_cap_ref
+                                                                     caps page_table_intent
+         odE
+       | DomainCap \<Rightarrow> doE
+           domain_intent \<leftarrow> throw_opt undefined $ get_domain_intent intent;
+           liftME InvokeDomain $ decode_domain_invocation caps domain_intent
+         odE
+       | VCPUCap vcpu \<Rightarrow> doE
+           _ \<leftarrow> unlessE (intent = VCPUIntent) throw;
+           liftME InvokeVCPU $ decode_vcpu_invocation vcpu caps
+         odE
 
        \<comment> \<open>Don't support operations on other types of caps.\<close>
        | _ \<Rightarrow> throw"

--- a/spec/capDL/Endpoint_D.thy
+++ b/spec/capDL/Endpoint_D.thy
@@ -8,8 +8,6 @@
 
 theory Endpoint_D
   imports
-    Invocations_D
-    CSpace_D
     Tcb_D
 begin
 

--- a/spec/capDL/Endpoint_D.thy
+++ b/spec/capDL/Endpoint_D.thy
@@ -4,475 +4,373 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * Operations on endpoints.
- *)
+(* Operations on endpoints.  *)
 
 theory Endpoint_D
-imports Invocations_D CSpace_D Tcb_D
+  imports
+    Invocations_D
+    CSpace_D
+    Tcb_D
 begin
 
 (* Inject the reply cap into the target TCB *)
-definition
-  inject_reply_cap :: "cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> bool \<Rightarrow> unit k_monad"
-where
+definition inject_reply_cap :: "cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> bool \<Rightarrow> unit k_monad" where
   "inject_reply_cap src_tcb_id dst_tcb_id can_grant \<equiv> do
-     set_cap (src_tcb_id, tcb_pending_op_slot) $
-         cdl_cap.PendingSyncRecvCap src_tcb_id True False;
+     set_cap (src_tcb_id, tcb_pending_op_slot) $ PendingSyncRecvCap src_tcb_id True False;
      insert_cap_child (ReplyCap src_tcb_id (if can_grant then {Grant, Write} else {Write}))
                       (src_tcb_id, tcb_replycap_slot)
                       (dst_tcb_id, tcb_caller_slot);
      return ()
-  od"
-
-(*
- * Get the slot where we should place an incoming cap for a
- * particular thread.
- *)
-
-definition
-  get_receive_slot :: "cdl_object_id \<Rightarrow> cdl_cap_ref option k_monad"
-where
-  "get_receive_slot thread \<equiv>
-    do
-      tcb \<leftarrow> get_thread thread;
-      recv_slot \<leftarrow> (case (cdl_tcb_caps tcb tcb_ipcbuffer_slot) of (Some (FrameCap _ _ rights _ _ _)) \<Rightarrow>
-        if (Read \<in> rights \<and> Write \<in> rights)
-          then return (cdl_intent_recv_slot (cdl_tcb_intent tcb))
-        else
-          return None
-      | _ \<Rightarrow> return None);
-      case ( recv_slot ) of
-          None \<Rightarrow>
-            return None
-        | Some (croot, index, depth) \<Rightarrow>
-            doE
-              \<comment> \<open>Lookup the slot.\<close>
-              cspace_root \<leftarrow> unify_failure $ lookup_cap thread croot;
-              result \<leftarrow> unify_failure $ lookup_slot_for_cnode_op cspace_root index depth;
-
-              \<comment> \<open>Ensure nothing is already in it.\<close>
-              cap \<leftarrow> liftE $ get_cap result;
-              whenE (cap \<noteq> NullCap) throw;
-
-              returnOk $ Some result
-            odE <catch> (\<lambda>_. return None)
-    od
-  "
-
-(* Get the cptr's that the given thread wishes to transfer. *)
-definition
-  get_send_slots :: "cdl_object_id \<Rightarrow> cdl_cptr list k_monad"
-where
-  "get_send_slots thread \<equiv>
-    do
-      tcb \<leftarrow> get_thread thread;
-      return $ cdl_intent_extras (cdl_tcb_intent tcb)
-    od
-  "
-
-definition
-  get_ipc_buffer :: "cdl_object_id \<Rightarrow> bool \<Rightarrow> cdl_object_id option k_monad"
-where
-  "get_ipc_buffer oid in_receive \<equiv> do
-    frame_cap \<leftarrow> get_cap (oid,tcb_ipcbuffer_slot);
-    (case frame_cap of
-        Types_D.FrameCap _ a rights _ _ _ \<Rightarrow> if (Write \<in> rights \<and> Read \<in> rights) \<or> (Read\<in> rights \<and> \<not> in_receive)
-          then return (Some a)
-          else return None
-        | _ \<Rightarrow> return None)
    od"
 
-definition
-  corrupt_ipc_buffer :: "cdl_object_id \<Rightarrow> bool \<Rightarrow> unit k_monad"
-  where
+(* Get the slot where we should place an incoming cap for a particular thread. *)
+definition get_receive_slot :: "cdl_object_id \<Rightarrow> cdl_cap_ref option k_monad" where
+  "get_receive_slot thread \<equiv> do
+     tcb \<leftarrow> get_thread thread;
+     recv_slot \<leftarrow> case cdl_tcb_caps tcb tcb_ipcbuffer_slot of
+                    Some (FrameCap _ _ rights _ _ _) \<Rightarrow>
+                      if Read \<in> rights \<and> Write \<in> rights
+                      then return (cdl_intent_recv_slot (cdl_tcb_intent tcb))
+                      else return None
+                  | _ \<Rightarrow> return None;
+     case recv_slot of
+       None \<Rightarrow> return None
+     | Some (croot, index, depth) \<Rightarrow> doE
+       \<comment> \<open>Lookup the slot.\<close>
+       cspace_root \<leftarrow> unify_failure $ lookup_cap thread croot;
+       result \<leftarrow> unify_failure $ lookup_slot_for_cnode_op cspace_root index depth;
+
+       \<comment> \<open>Ensure nothing is already in it.\<close>
+       cap \<leftarrow> liftE $ get_cap result;
+       whenE (cap \<noteq> NullCap) throw;
+
+       returnOk $ Some result
+     odE <catch> (\<lambda>_. return None)
+   od"
+
+(* Get the cptr's that the given thread wishes to transfer. *)
+definition get_send_slots :: "cdl_object_id \<Rightarrow> cdl_cptr list k_monad" where
+  "get_send_slots thread \<equiv> do
+     tcb \<leftarrow> get_thread thread;
+     return $ cdl_intent_extras (cdl_tcb_intent tcb)
+   od"
+
+definition get_ipc_buffer :: "cdl_object_id \<Rightarrow> bool \<Rightarrow> cdl_object_id option k_monad" where
+  "get_ipc_buffer oid in_receive \<equiv> do
+     frame_cap \<leftarrow> get_cap (oid, tcb_ipcbuffer_slot);
+     case frame_cap of
+        FrameCap _ a rights _ _ _ \<Rightarrow>
+          if (Write \<in> rights \<and> Read \<in> rights) \<or> (Read \<in> rights \<and> \<not>in_receive)
+          then return (Some a)
+          else return None
+        | _ \<Rightarrow> return None
+   od"
+
+definition corrupt_ipc_buffer :: "cdl_object_id \<Rightarrow> bool \<Rightarrow> unit k_monad" where
   "corrupt_ipc_buffer oid in_receive \<equiv> do
-    buffer \<leftarrow> get_ipc_buffer oid in_receive;
-    (case buffer of
-        Some a \<Rightarrow> corrupt_frame a
-      | None \<Rightarrow> corrupt_tcb_intent oid)
-  od"
+     buffer \<leftarrow> get_ipc_buffer oid in_receive;
+     case buffer of
+       Some a \<Rightarrow> corrupt_frame a
+     | None \<Rightarrow> corrupt_tcb_intent oid
+   od"
 
-(*
- * Transfers at most one cap in addition to a number of endpoint badges.
- *
- * Endpoint badges are transferred if the cap to be transferred is to
- * the endpoint used in the transfer.
- *)
-fun
-  transfer_caps_loop :: "cdl_object_id option \<Rightarrow> cdl_object_id \<Rightarrow>
-                         (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_cap_ref option
-                         \<Rightarrow> unit k_monad"
-where
-  "transfer_caps_loop ep receiver [] dest = return ()"
-| "transfer_caps_loop ep receiver ((cap,slot)#caps) dest =
-      \<comment> \<open>Transfer badge, transfer cap, or abort early if more than
-         one cap to transfer\<close>
-      (if is_ep_cap cap \<and> ep = Some (cap_object cap)
-      then do
-        \<comment> \<open>transfer badge\<close>
-        corrupt_ipc_buffer receiver True;
-        \<comment> \<open>transfer rest of badges or cap\<close>
-        transfer_caps_loop ep receiver caps dest
-      od
-      else if dest \<noteq> None then doE
-        new_cap \<leftarrow> returnOk (update_cap_rights (cap_rights cap - {Write}) cap) \<sqinter>
-                  returnOk cap;
+(* Transfers at most one cap in addition to a number of endpoint badges.
 
-        \<comment> \<open>Target cap is derived. This may abort transfer early.\<close>
-        target_cap \<leftarrow> derive_cap slot new_cap;
-        whenE (target_cap = NullCap) throw;
+   Endpoint badges are transferred if the cap to be transferred is to
+   the endpoint used in the transfer. *)
+fun transfer_caps_loop ::
+  "cdl_object_id option \<Rightarrow> cdl_object_id \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_cap_ref option \<Rightarrow>
+   unit k_monad"
+  where
+    "transfer_caps_loop ep receiver [] dest = return ()"
+  | "transfer_caps_loop ep receiver ((cap, slot) # caps) dest =
+       \<comment> \<open>Transfer badge, transfer cap, or abort early if more than one cap to transfer\<close>
+       (if is_ep_cap cap \<and> ep = Some (cap_object cap)
+        then do
+          \<comment> \<open>transfer badge\<close>
+          corrupt_ipc_buffer receiver True;
+          \<comment> \<open>transfer rest of badges or cap\<close>
+          transfer_caps_loop ep receiver caps dest
+        od
+        else if dest \<noteq> None then doE
+          new_cap \<leftarrow> returnOk (update_cap_rights (cap_rights cap - {Write}) cap) \<sqinter>
+                     returnOk cap;
 
-        \<comment> \<open>Copy the cap across as either a child or sibling.\<close>
-        liftE (insert_cap_child target_cap slot (the dest)
-               \<sqinter> insert_cap_sibling target_cap slot (the dest));
+          \<comment> \<open>Target cap is derived. This may abort transfer early.\<close>
+          target_cap \<leftarrow> derive_cap slot new_cap;
+          whenE (target_cap = NullCap) throw;
 
-        \<comment> \<open>Transfer rest of badges\<close>
-        liftE $ transfer_caps_loop ep receiver caps None
-      odE <catch> (\<lambda>_. return ())
-      else
-        return ())"
+          \<comment> \<open>Copy the cap across as either a child or sibling.\<close>
+          liftE (insert_cap_child target_cap slot (the dest)
+                 \<sqinter> insert_cap_sibling target_cap slot (the dest));
+
+          \<comment> \<open>Transfer rest of badges\<close>
+          liftE $ transfer_caps_loop ep receiver caps None
+        odE <catch> (\<lambda>_. return ())
+        else return ())"
 
 
-(*
- * Transfer caps from src to dest.
- *
- * In theory, the source thread specifies a list of caps to send, and
- * the destination thread specifies a list of cap slots to put them in.
- *
- * In the true spirit of L4 Pistachio, what _actually_ occurs during the
- * IPC transfer is hard to determine without knowing intricate details
- * of the kernel's implementation. In particular:
- *
- *   - Caps often just won't send, but still 'burn' the receive slot
- *     (ZombieCaps, ReplyCaps, IrqControlCap);
- *
- *   - Caps may not send, but still allow later caps to
- *     use the receive slot (Unwrapped endpoints);
- *
- *   - Cap sending may stop half way (cap lookup faults);
- *
- *   - The new cap may either be a sibling or child of source cap,
- *     depending on where in the CDT the source cap is.
- *
- *   - In reality, no more than one cap will ever be sent, because only
- *     one destination cap slot is supported elsewhere in the code.
- *
- * We remove some of the details, replacing them with nondeterminism.
- *)
-definition
-  transfer_caps :: "cdl_object_id option \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow>
-                    cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> unit k_monad"
-where
-  "transfer_caps ep caps sender receiver \<equiv>
-    do
-      dest_slot \<leftarrow> get_receive_slot receiver \<sqinter> return None;
-      transfer_caps_loop ep receiver caps dest_slot
-    od"
+(* Transfer caps from src to dest.
 
-(*
- * Get the set of threads waiting to receive on the given notification.
- *)
-definition
-  get_waiting_ntfn_recv_threads :: "cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_object_id set"
-where
+   In theory, the source thread specifies a list of caps to send, and
+   the destination thread specifies a list of cap slots to put them in.
+
+   In the true spirit of L4 Pistachio, what _actually_ occurs during the
+   IPC transfer is hard to determine without knowing intricate details
+   of the kernel's implementation. In particular:
+
+    - Caps often just won't send, but still 'burn' the receive slot
+      (ZombieCaps, ReplyCaps, IrqControlCap);
+
+    - Caps may not send, but still allow later caps to
+      use the receive slot (Unwrapped endpoints);
+
+    - Cap sending may stop half way (cap lookup faults);
+
+    - The new cap may either be a sibling or child of source cap,
+      depending on where in the CDT the source cap is.
+
+    - In reality, no more than one cap will ever be sent, because only
+      one destination cap slot is supported elsewhere in the code.
+
+  We remove some of the details, replacing them with nondeterminism. *)
+definition transfer_caps ::
+  "cdl_object_id option \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow>
+   unit k_monad"
+  where
+  "transfer_caps ep caps sender receiver \<equiv> do
+     dest_slot \<leftarrow> get_receive_slot receiver \<sqinter> return None;
+     transfer_caps_loop ep receiver caps dest_slot
+   od"
+
+(* Get the set of threads waiting to receive on the given notification. *)
+definition get_waiting_ntfn_recv_threads :: "cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_object_id set" where
   "get_waiting_ntfn_recv_threads target state \<equiv>
-     {x. \<exists>a. (cdl_objects state) x = Some (Tcb a) \<and>
-         (((cdl_tcb_caps a) tcb_pending_op_slot) = Some (PendingNtfnRecvCap target)) }"
+     {x. \<exists>a. cdl_objects state x = Some (Tcb a) \<and>
+             cdl_tcb_caps a tcb_pending_op_slot = Some (PendingNtfnRecvCap target)}"
 
 (* Get the set of threads waiting to receive on the given sync endpoint. *)
-definition
-  get_waiting_sync_recv_threads :: "cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_object_id set"
-where
+definition get_waiting_sync_recv_threads :: "cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_object_id set" where
   "get_waiting_sync_recv_threads target state \<equiv>
-     {x. \<exists>a. (cdl_objects state) x = Some (Tcb a) \<and>
-         (\<exists>can_grant. (cdl_tcb_caps a) tcb_pending_op_slot = Some (PendingSyncRecvCap target False can_grant)) }"
+     {x. \<exists>a. cdl_objects state x = Some (Tcb a) \<and>
+              (\<exists>can_grant. cdl_tcb_caps a tcb_pending_op_slot =
+                             Some (PendingSyncRecvCap target False can_grant))}"
 
-(*
- * Get the set of threads waiting to send to the given sync endpoint.
- *)
-definition
-  get_waiting_sync_send_threads :: "cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_object_id set"
-where
+(* Get the set of threads waiting to send to the given sync endpoint. *)
+definition get_waiting_sync_send_threads :: "cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_object_id set" where
   "get_waiting_sync_send_threads target state \<equiv>
-     {t. \<exists>fault a b. (cdl_objects state) t = Some (Tcb a) \<and>
-         (\<exists>call can_grant can_grant_reply. (cdl_tcb_caps a) tcb_pending_op_slot =
-                    Some (PendingSyncSendCap target b call can_grant can_grant_reply fault)) }"
+     {t. \<exists>fault a b. cdl_objects state t = Some (Tcb a) \<and>
+         (\<exists>call can_grant can_grant_reply.
+            cdl_tcb_caps a tcb_pending_op_slot =
+              Some (PendingSyncSendCap target b call can_grant can_grant_reply fault))}"
 
-(*
- * Get the set of threads which are bound to the given ntfn, but are
- * also waiting on sync IPC
- *)
-definition
-  get_waiting_sync_bound_ntfn_threads :: "cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_object_id set"
-where
+(* Get the set of threads which are bound to the given ntfn, but are  also waiting on sync IPC *)
+definition get_waiting_sync_bound_ntfn_threads :: "cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_object_id set"
+  where
   "get_waiting_sync_bound_ntfn_threads ntfn_id state \<equiv>
-     {x. \<exists>a ep_id. (cdl_objects state) x = Some (Tcb a) \<and>
-         (\<exists>can_grant. (cdl_tcb_caps a) tcb_pending_op_slot = Some (PendingSyncRecvCap ep_id False can_grant)) \<and>
-         ((cdl_tcb_caps a) tcb_boundntfn_slot = Some (BoundNotificationCap ntfn_id))}"
+     {x. \<exists>a ep_id. cdl_objects state x = Some (Tcb a) \<and>
+                   (\<exists>can_grant. cdl_tcb_caps a tcb_pending_op_slot =
+                                  Some (PendingSyncRecvCap ep_id False can_grant)) \<and>
+                   cdl_tcb_caps a tcb_boundntfn_slot = Some (BoundNotificationCap ntfn_id)}"
 
-(*
- * Mark a thread blocked on IPC.
- *
- * Theads get a new implicit "send once" or "receive once" capability
- * when they block on an IPC. This is because if the capability they
- * used to start the send/receive is revoked, the transfer will still be
- * allowed to proceed (even if it is at a much later point in time).
- *)
+(* Mark a thread blocked on IPC.
 
-definition
-  block_thread_on_ipc :: "cdl_object_id \<Rightarrow> cdl_cap \<Rightarrow> unit k_monad"
-where
-  "block_thread_on_ipc tcb cap \<equiv> set_cap (tcb, tcb_pending_op_slot) cap" (* Might need to do some check here *)
+   Theads get a new implicit "send once" or "receive once" capability
+   when they block on an IPC. This is because if the capability they
+   used to start the send/receive is revoked, the transfer will still be
+   allowed to proceed (even if it is at a much later point in time). *)
+definition block_thread_on_ipc :: "cdl_object_id \<Rightarrow> cdl_cap \<Rightarrow> unit k_monad" where
+  "block_thread_on_ipc tcb cap \<equiv> set_cap (tcb, tcb_pending_op_slot) cap"
 
-definition
-  lookup_extra_caps :: "cdl_object_id \<Rightarrow> cdl_cptr list \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list fault_monad"
-where
-  "lookup_extra_caps thread cptrs \<equiv>
-     mapME (\<lambda>cptr. lookup_cap_and_slot thread cptr) cptrs"
+definition lookup_extra_caps ::
+  "cdl_object_id \<Rightarrow> cdl_cptr list \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list fault_monad"
+  where
+  "lookup_extra_caps thread cptrs \<equiv> mapME (\<lambda>cptr. lookup_cap_and_slot thread cptr) cptrs"
 
-(*
- * Transfer a message from "sender" to "receiver", possibly copying caps
- * over in the process. If a fault is pending in receiver, send fault instead.
- *)
-definition
-  do_ipc_transfer :: "cdl_object_id option \<Rightarrow> cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> bool \<Rightarrow> unit k_monad"
-where
+(* Transfer a message from "sender" to "receiver", possibly copying caps
+   over in the process. If a fault is pending in receiver, send fault instead. *)
+definition do_ipc_transfer ::
+  "cdl_object_id option \<Rightarrow> cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> bool \<Rightarrow> unit k_monad"
+  where
   "do_ipc_transfer ep_id sender_id receiver_id can_grant \<equiv> do
-      \<comment> \<open>look up cap transfer\<close>
-      src_slots \<leftarrow> get_send_slots sender_id;
-      do \<comment> \<open>do normal transfer\<close>
-        caps \<leftarrow> if can_grant then
-                lookup_extra_caps sender_id src_slots <catch> (\<lambda>_. return [])
-              else
-                return [];
-        \<comment> \<open>copy registers, transfer message or fault\<close>
-        corrupt_ipc_buffer receiver_id True;
-        \<comment> \<open>transfer caps if no fault occured\<close>
-        transfer_caps ep_id caps sender_id receiver_id
-      od  \<sqinter>  \<comment> \<open>fault transfer\<close>
-      corrupt_ipc_buffer receiver_id True;
-      \<comment> \<open>set message info\<close>
-      corrupt_tcb_intent receiver_id
-  od"
+     \<comment> \<open>look up cap transfer\<close>
+     src_slots \<leftarrow> get_send_slots sender_id;
+     do \<comment> \<open>do normal transfer\<close>
+       caps \<leftarrow> if can_grant
+               then lookup_extra_caps sender_id src_slots <catch> (\<lambda>_. return [])
+               else return [];
+       \<comment> \<open>copy registers, transfer message or fault\<close>
+       corrupt_ipc_buffer receiver_id True;
+       \<comment> \<open>transfer caps if no fault occured\<close>
+       transfer_caps ep_id caps sender_id receiver_id
+     od \<sqinter>
+     \<comment> \<open>fault transfer\<close>
+     corrupt_ipc_buffer receiver_id True;
+     \<comment> \<open>set message info\<close>
+     corrupt_tcb_intent receiver_id
+   od"
 
+(* Transfer a message from "sender" to "receiver" using a reply capability.
 
-(*
- * Transfer a message from "sender" to "receiver" using a reply capability.
- *
- * The sender may have the right to grant caps over the channel.
- *
- * If a fault is pending in the receiver, the fault is transferred.
- *)
-
-definition
-  do_reply_transfer :: "cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> cdl_cap_ref \<Rightarrow> bool \<Rightarrow> unit k_monad"
-where
-  "do_reply_transfer sender_id receiver_id reply_cap_slot can_grant \<equiv>
-    do
-      has_fault \<leftarrow> get_thread_fault receiver_id;
-      when (\<not> has_fault) $ do_ipc_transfer None sender_id receiver_id can_grant;
-      \<comment> \<open>Clear out any pending operation caps.\<close>
-      delete_cap_simple reply_cap_slot;
-      when (has_fault) $ (do corrupt_tcb_intent receiver_id;
-        update_thread_fault receiver_id (\<lambda>_. False) od );
-      if ( \<not> has_fault) then set_cap (receiver_id, tcb_pending_op_slot) RunningCap
-      else
-         (set_cap (receiver_id,tcb_pending_op_slot) NullCap
-        \<sqinter> set_cap (receiver_id,tcb_pending_op_slot) RestartCap)
+   The sender may have the right to grant caps over the channel. If a fault is pending in the
+   receiver, the fault is transferred. *)
+definition do_reply_transfer ::
+  "cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> cdl_cap_ref \<Rightarrow> bool \<Rightarrow> unit k_monad"
+  where
+  "do_reply_transfer sender_id receiver_id reply_cap_slot can_grant \<equiv> do
+     has_fault \<leftarrow> get_thread_fault receiver_id;
+     when (\<not>has_fault) $ do_ipc_transfer None sender_id receiver_id can_grant;
+     \<comment> \<open>Clear out any pending operation caps.\<close>
+     delete_cap_simple reply_cap_slot;
+     when has_fault $ do
+       corrupt_tcb_intent receiver_id;
+       update_thread_fault receiver_id (\<lambda>_. False)
+     od;
+     if \<not>has_fault
+     then set_cap (receiver_id, tcb_pending_op_slot) RunningCap
+     else (set_cap (receiver_id,tcb_pending_op_slot) NullCap \<sqinter>
+           set_cap (receiver_id,tcb_pending_op_slot) RestartCap)
     od"
 
 (* Wake-up a thread waiting on an notification. *)
-definition
-  do_notification_transfer :: "cdl_object_id \<Rightarrow> unit k_monad"
-where
+definition do_notification_transfer :: "cdl_object_id \<Rightarrow> unit k_monad" where
   "do_notification_transfer receiver_id \<equiv> do
-      set_cap (receiver_id,tcb_pending_op_slot) RunningCap;
-      corrupt_tcb_intent receiver_id
+     set_cap (receiver_id,tcb_pending_op_slot) RunningCap;
+     corrupt_tcb_intent receiver_id
    od"
 
-(*
- * Signal on a notification.
- *
- * If someone is blocked on the notifications, we wake them up. Otherwise,
- * this is a no-(.)
- *)
-
-definition
-  send_signal_bound :: "cdl_object_id \<Rightarrow> unit k_monad"
-where
+(* Signal on a notification. If someone is blocked on the notifications, we wake them up.
+   Otherwise, this is a no-op.*)
+definition send_signal_bound :: "cdl_object_id \<Rightarrow> unit k_monad" where
   "send_signal_bound ntfn_id \<equiv> do
-      bound_tcbs \<leftarrow> gets $ get_waiting_sync_bound_ntfn_threads ntfn_id;
-      if (bound_tcbs \<noteq> {}) then do
-          t \<leftarrow> select bound_tcbs;
-          set_cap (t, tcb_pending_op_slot) NullCap;
-          do_notification_transfer t
-        od
-      else return ()
-    od"
-
-definition
-  send_signal :: "cdl_object_id \<Rightarrow> unit k_monad"
-where
-  "send_signal ep_id \<equiv>
-    (do waiters \<leftarrow> gets $ get_waiting_ntfn_recv_threads ep_id;
-          t \<leftarrow> option_select waiters;
-          case t of
-              None \<Rightarrow> return ()
-            | Some receiver \<Rightarrow> do_notification_transfer receiver
-     od)
-            \<sqinter> send_signal_bound ep_id"
-
-(*
- * Receive a signal (receive from a notification).
- *
- * We will either receive data or block waiting.
- *)
-definition
-  recv_signal :: "cdl_object_id \<Rightarrow> cdl_cap \<Rightarrow> unit k_monad"
-where
-  "recv_signal tcb_id_receiver ep_cap  \<equiv> do
-     ep_id \<leftarrow> return $ cap_object ep_cap;
-     block_thread_on_ipc tcb_id_receiver (PendingNtfnRecvCap ep_id) \<sqinter> corrupt_tcb_intent tcb_id_receiver
+     bound_tcbs \<leftarrow> gets $ get_waiting_sync_bound_ntfn_threads ntfn_id;
+     if bound_tcbs \<noteq> {} then do
+       t \<leftarrow> select bound_tcbs;
+       set_cap (t, tcb_pending_op_slot) NullCap;
+       do_notification_transfer t
+     od
+     else return ()
    od"
 
-(*
- * Send an IPC to the given endpoint. If someone is waiting, we wake
- * them up. Otherwise, we put the sender to sleep.
- *)
-definition
-  send_ipc :: "bool \<Rightarrow> bool \<Rightarrow> cdl_badge \<Rightarrow> bool \<Rightarrow> bool \<Rightarrow> cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> unit k_monad"
-where
-  "send_ipc block call badge can_grant can_grant_reply tcb_id_sender ep_id \<equiv>
-    do
-      waiters \<leftarrow> gets $ get_waiting_sync_recv_threads ep_id;
-      t \<leftarrow> option_select waiters;
-      case t of
-          None \<Rightarrow>
-            if block then
-              block_thread_on_ipc tcb_id_sender
-                  (PendingSyncSendCap ep_id badge call can_grant can_grant_reply False)
-            else
-              return ()
-        | Some tcb_id_receiver \<Rightarrow> do
-             \<comment> \<open>liftM instead of bind+return avoids early unfolding in send_ipc_corres\<close>
-             recv_state \<leftarrow> liftM (\<lambda>tcb. the (cdl_tcb_caps tcb tcb_pending_op_slot)) $
-                              get_thread tcb_id_receiver;
-             reply_can_grant \<leftarrow>
-               (case recv_state of
-                    PendingSyncRecvCap target False receiver_grant \<Rightarrow> do
-                      do_ipc_transfer (Some ep_id) tcb_id_sender tcb_id_receiver can_grant;
-                      return receiver_grant od
-                  | _ \<Rightarrow> fail);
-             set_cap (tcb_id_receiver,tcb_pending_op_slot) RunningCap;
-             (when (can_grant \<or> can_grant_reply) $
-                  (inject_reply_cap tcb_id_sender tcb_id_receiver reply_can_grant))
-               \<sqinter> set_cap (tcb_id_sender,tcb_pending_op_slot) NullCap \<sqinter> return ()
-          od
-    od"
+definition send_signal :: "cdl_object_id \<Rightarrow> unit k_monad" where
+  "send_signal ep_id \<equiv>
+     do waiters \<leftarrow> gets $ get_waiting_ntfn_recv_threads ep_id;
+       t \<leftarrow> option_select waiters;
+       case t of
+         None \<Rightarrow> return ()
+       | Some receiver \<Rightarrow> do_notification_transfer receiver
+     od
+     \<sqinter> send_signal_bound ep_id"
 
-(*
- * Receive an IPC from the given endpoint. If someone is waiting, we
- * wake them up. Otherwise, we put the receiver to sleep.
- *)
-definition
-  receive_sync :: "cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> bool \<Rightarrow> unit k_monad"
-where
-  "receive_sync thread ep_id receiver_can_grant \<equiv> do
-    waiters \<leftarrow> gets $ get_waiting_sync_send_threads ep_id;
-      waiter \<leftarrow> option_select waiters;
-      (case waiter of
-          None \<Rightarrow>
-            block_thread_on_ipc thread (PendingSyncRecvCap ep_id False receiver_can_grant)
-             \<sqinter> corrupt_tcb_intent thread
-        | Some tcb_id_sender \<Rightarrow> (do
-            tcb \<leftarrow> get_thread tcb_id_sender;
-            case ((cdl_tcb_caps tcb) tcb_pending_op_slot) of
-              Some (PendingSyncSendCap target _ call can_grant can_grant_reply fault) \<Rightarrow> (do
-                 do_ipc_transfer (Some ep_id) tcb_id_sender thread can_grant;
-                 (when (can_grant \<or> can_grant_reply) $
-                    (inject_reply_cap tcb_id_sender thread receiver_can_grant)) \<sqinter>
-                 set_cap (tcb_id_sender, tcb_pending_op_slot) RunningCap \<sqinter>
-                 set_cap (tcb_id_sender, tcb_pending_op_slot) NullCap
-              od)
-        od)
-      )
-    od"
+(* Receive a signal (receive from a notification).  We will either receive data or block waiting. *)
+definition recv_signal :: "cdl_object_id \<Rightarrow> cdl_cap \<Rightarrow> unit k_monad" where
+  "recv_signal tcb_id_receiver ep_cap \<equiv> do
+     ep_id \<leftarrow> return $ cap_object ep_cap;
+     block_thread_on_ipc tcb_id_receiver (PendingNtfnRecvCap ep_id)
+     \<sqinter> corrupt_tcb_intent tcb_id_receiver
+   od"
 
-(* This is more nonderministic than is really required, but
-   it makes the refinement proofs much easier *)
-definition
-  receive_ipc :: "cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> bool \<Rightarrow> unit k_monad"
-where
-  "receive_ipc thread ep_id can_grant \<equiv> corrupt_tcb_intent thread \<sqinter> receive_sync thread ep_id can_grant"
-
-definition
-  invoke_endpoint :: "bool \<Rightarrow> bool \<Rightarrow> cdl_endpoint_invocation \<Rightarrow> unit k_monad"
-where
-  "invoke_endpoint is_call can_block params \<equiv> case params of
-    SyncMessage badge can_grant can_grant_reply ep_id \<Rightarrow> do
-      thread \<leftarrow> gets_the cdl_current_thread;
-      send_ipc can_block is_call badge can_grant can_grant_reply thread ep_id
-    od"
-
-definition
-  invoke_notification :: "cdl_notification_invocation \<Rightarrow> unit k_monad"
-where
-  "invoke_notification params \<equiv> case params of
-    Signal badge ep_id \<Rightarrow>
-      send_signal ep_id"
-
-definition
-  invoke_reply :: "cdl_reply_invocation \<Rightarrow> unit k_monad"
-where
-  "invoke_reply params \<equiv> case params of
-    ReplyMessage recv reply_cap_ref rights \<Rightarrow> do
-      send \<leftarrow> gets_the cdl_current_thread;
-      do_reply_transfer send recv reply_cap_ref rights
-    od"
-
-
-(*
- * Send a fault IPC to the given thread's fault handler.
- *)
-definition
-  send_fault_ipc :: "cdl_object_id \<Rightarrow> unit fault_monad"
+(* Send an IPC to the given endpoint. If someone is waiting, we wake  them up.
+   Otherwise, we put the sender to sleep. *)
+definition send_ipc ::
+  "bool \<Rightarrow> bool \<Rightarrow> cdl_badge \<Rightarrow> bool \<Rightarrow> bool \<Rightarrow> cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> unit k_monad"
   where
-  "send_fault_ipc tcb_id \<equiv>
-    doE
-      \<comment> \<open>Lookup where we should send the fault IPC to.\<close>
-      tcb \<leftarrow> liftE $ get_thread tcb_id;
-      target_ep_cptr \<leftarrow> returnOk $ cdl_tcb_fault_endpoint tcb;
-      handler_cap \<leftarrow> lookup_cap tcb_id target_ep_cptr;
-      (case handler_cap of
-          EndpointCap ref badge rights \<Rightarrow>
-            if Write \<in> rights \<and> (Grant \<in> rights \<or> GrantReply \<in> rights) then
-              liftE $ do
-                update_thread_fault tcb_id (\<lambda>_. True);
-                send_ipc True True badge (Grant \<in> rights) True tcb_id ref
-              od
-            else
-               throw
-        | _ \<Rightarrow> throw)
-    odE"
+  "send_ipc block call badge can_grant can_grant_reply tcb_id_sender ep_id \<equiv> do
+     waiters \<leftarrow> gets $ get_waiting_sync_recv_threads ep_id;
+     t \<leftarrow> option_select waiters;
+     case t of
+       None \<Rightarrow> if block
+               then block_thread_on_ipc tcb_id_sender
+                                        (PendingSyncSendCap ep_id badge call can_grant
+                                                            can_grant_reply False)
+               else return ()
+     | Some tcb_id_receiver \<Rightarrow> do
+         \<comment> \<open>liftM instead of bind+return avoids early unfolding in send_ipc_corres\<close>
+         recv_state \<leftarrow> liftM (\<lambda>tcb. the (cdl_tcb_caps tcb tcb_pending_op_slot)) $
+                             get_thread tcb_id_receiver;
+         reply_can_grant \<leftarrow> case recv_state of
+                              PendingSyncRecvCap target False receiver_grant \<Rightarrow> do
+                                do_ipc_transfer (Some ep_id) tcb_id_sender tcb_id_receiver can_grant;
+                                return receiver_grant od
+                            | _ \<Rightarrow> fail;
+         set_cap (tcb_id_receiver,tcb_pending_op_slot) RunningCap;
+         when (can_grant \<or> can_grant_reply)
+              (inject_reply_cap tcb_id_sender tcb_id_receiver reply_can_grant)
+         \<sqinter> set_cap (tcb_id_sender,tcb_pending_op_slot) NullCap \<sqinter> return ()
+       od
+   od"
 
-(*
- * Handle a fault caused by the current thread.
- *
- * The abstract spec adds two additional parameters:
- *
- *    1. The fault type (which we abstract away);
- *
- *    2. The thread causing the fault (which always turns out
- *       to be the current thread).
- *)
-definition
-  handle_fault :: "unit k_monad"
-where
+(* Receive an IPC from the given endpoint. If someone is waiting, we wake them up. Otherwise, we
+   put the receiver to sleep. *)
+definition receive_sync :: "cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> bool \<Rightarrow> unit k_monad" where
+  "receive_sync thread ep_id receiver_can_grant \<equiv> do
+     waiters \<leftarrow> gets $ get_waiting_sync_send_threads ep_id;
+     waiter \<leftarrow> option_select waiters;
+     case waiter of
+       None \<Rightarrow> block_thread_on_ipc thread (PendingSyncRecvCap ep_id False receiver_can_grant)
+               \<sqinter> corrupt_tcb_intent thread
+     | Some tcb_id_sender \<Rightarrow> do
+         tcb \<leftarrow> get_thread tcb_id_sender;
+         case cdl_tcb_caps tcb tcb_pending_op_slot of
+           Some (PendingSyncSendCap target _ call can_grant can_grant_reply fault) \<Rightarrow> do
+             do_ipc_transfer (Some ep_id) tcb_id_sender thread can_grant;
+             when (can_grant \<or> can_grant_reply)
+                  (inject_reply_cap tcb_id_sender thread receiver_can_grant)
+             \<sqinter> set_cap (tcb_id_sender, tcb_pending_op_slot) RunningCap
+             \<sqinter> set_cap (tcb_id_sender, tcb_pending_op_slot) NullCap
+           od
+       od
+   od"
+
+(* This is more nonderministic than is really required, but it makes the refinement proofs much easier *)
+definition receive_ipc :: "cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> bool \<Rightarrow> unit k_monad" where
+  "receive_ipc thread ep_id can_grant \<equiv>
+     corrupt_tcb_intent thread \<sqinter> receive_sync thread ep_id can_grant"
+
+definition invoke_endpoint :: "bool \<Rightarrow> bool \<Rightarrow> cdl_endpoint_invocation \<Rightarrow> unit k_monad" where
+  "invoke_endpoint is_call can_block params \<equiv>
+     case params of
+       SyncMessage badge can_grant can_grant_reply ep_id \<Rightarrow> do
+         thread \<leftarrow> gets_the cdl_current_thread;
+         send_ipc can_block is_call badge can_grant can_grant_reply thread ep_id
+       od"
+
+definition invoke_notification :: "cdl_notification_invocation \<Rightarrow> unit k_monad" where
+  "invoke_notification params \<equiv> case params of Signal badge ep_id \<Rightarrow> send_signal ep_id"
+
+definition invoke_reply :: "cdl_reply_invocation \<Rightarrow> unit k_monad" where
+  "invoke_reply params \<equiv>
+     case params of
+       ReplyMessage recv reply_cap_ref rights \<Rightarrow> do
+         send \<leftarrow> gets_the cdl_current_thread;
+         do_reply_transfer send recv reply_cap_ref rights
+       od"
+
+(* Send a fault IPC to the given thread's fault handler. *)
+definition send_fault_ipc :: "cdl_object_id \<Rightarrow> unit fault_monad" where
+  "send_fault_ipc tcb_id \<equiv> doE
+     \<comment> \<open>Look up where we should send the fault IPC to.\<close>
+     tcb \<leftarrow> liftE $ get_thread tcb_id;
+     target_ep_cptr \<leftarrow> returnOk $ cdl_tcb_fault_endpoint tcb;
+     handler_cap \<leftarrow> lookup_cap tcb_id target_ep_cptr;
+     case handler_cap of
+       EndpointCap ref badge rights \<Rightarrow> if Write \<in> rights \<and> (Grant \<in> rights \<or> GrantReply \<in> rights)
+                                       then liftE $ do
+                                         update_thread_fault tcb_id (\<lambda>_. True);
+                                         send_ipc True True badge (Grant \<in> rights) True tcb_id ref
+                                       od
+                                       else throw
+     | _ \<Rightarrow> throw
+   odE"
+
+(* Handle a fault caused by the current thread.
+   The abstract spec adds two additional parameters:
+      1. The fault type (which we abstract away);
+      2. The thread causing the fault (which always turns out to be the current thread). *)
+definition handle_fault :: "unit k_monad" where
   "handle_fault \<equiv> do
-    tcb_id \<leftarrow> gets_the cdl_current_thread;
-    (send_fault_ipc tcb_id
-      <catch> (\<lambda>_. KHeap_D.set_cap (tcb_id,tcb_pending_op_slot) cdl_cap.NullCap))
-  od"
+     tcb_id \<leftarrow> gets_the cdl_current_thread;
+     send_fault_ipc tcb_id <catch> (\<lambda>_. set_cap (tcb_id, tcb_pending_op_slot) NullCap)
+   od"
 
 end

--- a/spec/capDL/GenPageTable_D.thy
+++ b/spec/capDL/GenPageTable_D.thy
@@ -4,16 +4,14 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * Operations on generic page table objects and frames. The intention is that these operations
- * can be instantiated, or in some cases used directly, to model the behaviour of multiple different
- * seL4 architectures.
- *)
+(* Operations on generic page table objects and frames. The intention is that these operations
+   can be instantiated, or in some cases used directly, to model the behaviour of multiple different
+   seL4 architectures. *)
 
 theory GenPageTable_D
-imports
-  Invocations_D
-  CSpace_D
+  imports
+    Invocations_D
+    CSpace_D
 begin
 
 (* FIXME AARCH64: move to nondet_monad *)

--- a/spec/capDL/GenPageTable_D.thy
+++ b/spec/capDL/GenPageTable_D.thy
@@ -10,7 +10,6 @@
 
 theory GenPageTable_D
   imports
-    Invocations_D
     CSpace_D
 begin
 

--- a/spec/capDL/Intents_D.thy
+++ b/spec/capDL/Intents_D.thy
@@ -23,10 +23,10 @@
  *)
 
 theory Intents_D
-imports
-  ASpec.CapRights_A
-  VMAttributes_D
-  Structures_D
+  imports
+    ASpec.CapRights_A
+    VMAttributes_D
+    Structures_D
 begin
 
 type_synonym domain_duration_len = 56
@@ -41,17 +41,17 @@ type_synonym cdl_right = rights
 (* A user cap pointer. *)
 type_synonym cdl_cptr = machine_word
 
-abbreviation (input) Read ::rights
-  where "Read \<equiv> AllowRead"
+abbreviation (input) Read :: rights where
+  "Read \<equiv> AllowRead"
 
-abbreviation (input) Write::rights
-  where "Write \<equiv> AllowWrite"
+abbreviation (input) Write :: rights where
+  "Write \<equiv> AllowWrite"
 
-abbreviation (input) Grant::rights
-  where "Grant \<equiv> AllowGrant"
+abbreviation (input) Grant :: rights where
+  "Grant \<equiv> AllowGrant"
 
-abbreviation (input) GrantReply::rights
-  where "GrantReply \<equiv> AllowGrantReply"
+abbreviation (input) GrantReply :: rights where
+  "GrantReply \<equiv> AllowGrantReply"
 
 (* Capability data, such as guard information. *)
 type_synonym cdl_raw_capdata = machine_word
@@ -76,7 +76,7 @@ type_synonym domain = word8
 datatype cdl_pt_type =
   PT | PD | VSROOT | PDPT | PML4
 
-definition
+definition vspace_type :: "cdl_pt_type" where
   "vspace_type \<equiv> case cdl_ARCH of
      AARCH32 \<Rightarrow> PD
    | AARCH64 \<Rightarrow> VSROOT
@@ -102,22 +102,22 @@ datatype cdl_cnode_intent =
     (* Copy: (target), dest_index, dest_depth, (src_root), src_index, src_depth, rights *)
     CNodeCopyIntent machine_word machine_word machine_word machine_word "cdl_right set"
     (* Mint: (target), dest_index, dest_depth, (src_root), src_index, src_depth, rights, badge *)
- |  CNodeMintIntent machine_word machine_word machine_word machine_word "cdl_right set" cdl_raw_capdata
+  | CNodeMintIntent machine_word machine_word machine_word machine_word "cdl_right set" cdl_raw_capdata
     (* Move: (target), dest_index, dest_depth, (src_root), src_index, src_depth *)
- |  CNodeMoveIntent machine_word machine_word machine_word machine_word
+  | CNodeMoveIntent machine_word machine_word machine_word machine_word
     (* Mutate: (target), dest_index, dest_depth, (src_root), src_index, src_depth, badge *)
- |  CNodeMutateIntent machine_word machine_word machine_word machine_word cdl_raw_capdata
+  | CNodeMutateIntent machine_word machine_word machine_word machine_word cdl_raw_capdata
     (* Revoke: (target), index, depth *)
- |  CNodeRevokeIntent machine_word machine_word
+  | CNodeRevokeIntent machine_word machine_word
     (* Delete: (target), index, depth *)
- |  CNodeDeleteIntent machine_word machine_word
+  | CNodeDeleteIntent machine_word machine_word
     (* SaveCaller: (target), index, depth *)
- |  CNodeSaveCallerIntent machine_word machine_word
+  | CNodeSaveCallerIntent machine_word machine_word
     (* CancelBadgedSends: (target), index, depth *)
- |  CNodeCancelBadgedSendsIntent machine_word machine_word
+  | CNodeCancelBadgedSendsIntent machine_word machine_word
     (* Rotate: (target), dest_index, dest_depth, (pivot_root), pivot_index, pivot_depth, pivot_badge,
                (src_root), src_index, src_depth, src_badge *)
- |  CNodeRotateIntent machine_word machine_word machine_word machine_word cdl_raw_capdata
+  | CNodeRotateIntent machine_word machine_word machine_word machine_word cdl_raw_capdata
                       machine_word machine_word cdl_raw_capdata
 
 type_synonym arch_flags = word8 (* FIXME arch-split: check if used *)
@@ -126,35 +126,35 @@ datatype cdl_tcb_intent =
     (* ReadRegisters: (target), suspend_source, arch_flags, count *)
     TcbReadRegistersIntent bool arch_flags machine_word
     (* WriteRegisters: (target), resume_target, arch_flags, count, regs *)
- |  TcbWriteRegistersIntent bool arch_flags machine_word cdl_raw_usercontext
+  | TcbWriteRegistersIntent bool arch_flags machine_word cdl_raw_usercontext
     (* CopyRegisters: (target), (source), suspend_source, resume_target, transfer_frame,
                       transfer_integer, arch_flags *)
- |  TcbCopyRegistersIntent bool bool bool bool arch_flags
+  | TcbCopyRegistersIntent bool bool bool bool arch_flags
     (* Suspend: (target) *)
- |  TcbSuspendIntent
+  | TcbSuspendIntent
     (* Resume: (target) *)
- |  TcbResumeIntent
+  | TcbResumeIntent
     (* Configure: (target), fault_ep, (cspace_root), cspace_root_data, (vspace_root),
                   vspace_root_data, buffer, (bufferFrame) *)
- |  TcbConfigureIntent cdl_cptr cdl_raw_capdata cdl_raw_capdata machine_word
+  | TcbConfigureIntent cdl_cptr cdl_raw_capdata cdl_raw_capdata machine_word
     (* SetMCPriority: (target), mcp *)
- |  TcbSetMCPriorityIntent prio
+  | TcbSetMCPriorityIntent prio
     (* SetPriority: (target), priority *)
- |  TcbSetPriorityIntent prio
+  | TcbSetPriorityIntent prio
     (* SetSchedParams: (target), mcp, priority *)
- |  TcbSetSchedParamsIntent prio prio
+  | TcbSetSchedParamsIntent prio prio
     (* SetIPCBuffer: (target), buffer, (bufferFrame) *)
- |  TcbSetIPCBufferIntent machine_word
+  | TcbSetIPCBufferIntent machine_word
     (* SetSpace: (target), fault_ep, (cspace_root), cspace_root_data, (vspace_root), vspace_root_data *)
- |  TcbSetSpaceIntent machine_word cdl_raw_capdata cdl_raw_capdata
+  | TcbSetSpaceIntent machine_word cdl_raw_capdata cdl_raw_capdata
     (* BindNTFN: (target), (ntfn) *)
- |  TcbBindNTFNIntent
+  | TcbBindNTFNIntent
     (* UnbindNTFN: (target) *)
- |  TcbUnbindNTFNIntent
+  | TcbUnbindNTFNIntent
     (* SetTLSBase: (target) *)
- |  TcbSetTLSBaseIntent
+  | TcbSetTLSBaseIntent
     (* SetFlags: (target) set_flags clear_flags *)
- |  TcbSetFlagsIntent machine_word machine_word
+  | TcbSetFlagsIntent machine_word machine_word
 
 datatype cdl_untyped_intent =
     (* Retype: (target), (do_reset), type, size_bits, (root), node_index, node_depth, node_offset,
@@ -166,9 +166,9 @@ datatype cdl_irq_handler_intent =
     (* Ack: (target) *)
     IrqHandlerAckIntent
     (* SetEndpoint: (target), (endpoint) *)
- |  IrqHandlerSetEndpointIntent
+  | IrqHandlerSetEndpointIntent
     (* Clear: (target) *)
- |  IrqHandlerClearIntent
+  | IrqHandlerClearIntent
 
 datatype cdl_arch_irq_control_intent =
     (* ArchIssueIrqHandler: (target), irq, (root), index, depth *)
@@ -185,22 +185,22 @@ datatype cdl_irq_control_intent =
 datatype cdl_page_table_intent =
     (* Map: (target), (pd), vaddr, attr *)
     PageTableMapIntent machine_word cdl_raw_vmattrs
- |  PageTableUnmapIntent
+  | PageTableUnmapIntent
 
 datatype cdl_page_intent =
     (* Map: (target), (pd), vaddr, rights, attr *)
     PageMapIntent machine_word "cdl_right set" cdl_raw_vmattrs
     (* Unmap: (target) *)
- |  PageUnmapIntent
+  | PageUnmapIntent
     (* FlushCaches: (target) *)
- |  PageFlushCachesIntent
+  | PageFlushCachesIntent
     (* GetAddress *)
- | PageGetAddressIntent
+  | PageGetAddressIntent
 
 
 datatype cdl_page_directory_intent =
-   PageDirectoryFlushIntent
- | PageDirectoryNothingIntent
+    PageDirectoryFlushIntent
+  | PageDirectoryNothingIntent
 
 datatype cdl_asid_control_intent =
     (* MakePool: (target), (untyped), (root), index, depth *)

--- a/spec/capDL/Interrupt_D.thy
+++ b/spec/capDL/Interrupt_D.thy
@@ -4,169 +4,152 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * Operations on interrupt objects.
- *)
+(* Operations on interrupt objects. *)
 
 theory Interrupt_D
-imports Endpoint_D "ExecSpec.Platform"
+  imports
+    Endpoint_D
+    ExecSpec.Platform
 begin
 
 (* Return the currently pending IRQ. *)
-definition
-  get_active_irq :: "(cdl_irq option) k_monad"
-where
-  "get_active_irq \<equiv>
-    do
-      irq \<leftarrow> select UNIV;
-      return $ Some irq
-    od \<sqinter> (return None)
-  "
+definition get_active_irq :: "(cdl_irq option) k_monad" where
+  "get_active_irq \<equiv> do
+     irq \<leftarrow> select UNIV;
+     return $ Some irq
+   od
+   \<sqinter> return None"
 
-definition
-  arch_decode_irq_control_invocation :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow>
-      cdl_arch_irq_control_intent \<Rightarrow> cdl_irq_control_invocation except_monad"
-where
-  "arch_decode_irq_control_invocation target target_ref caps intent \<equiv> case intent of
-     ARMIrqControlIssueIrqHandlerIntent irq index depth \<Rightarrow>
-        doE
-          root \<leftarrow> throw_on_none $ get_index caps 0;
-          cnode_cap \<leftarrow> returnOk $ fst root;
-          dest_slot_cap_ref \<leftarrow> lookup_slot_for_cnode_op cnode_cap index (unat depth);
-          returnOk $ IssueIrqHandler irq target_ref dest_slot_cap_ref
-        odE \<sqinter> throw
-   | ARMIssueSGISignalIntent irq target index depth \<Rightarrow>
-        doE
-          root \<leftarrow> throw_on_none $ get_index caps 0;
-          cnode_cap \<leftarrow> returnOk $ fst root;
-          dest_slot_cap_ref \<leftarrow> lookup_slot_for_cnode_op cnode_cap index (unat depth);
-          ensure_empty dest_slot_cap_ref;
-          returnOk $ ArchIssueIrqHandler (ARMIssueSGISignal (ucast irq) (ucast target)
-                                                            target_ref dest_slot_cap_ref)
-        odE \<sqinter> throw"
+definition arch_decode_irq_control_invocation ::
+  "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_arch_irq_control_intent \<Rightarrow>
+   cdl_irq_control_invocation except_monad"
+  where
+  "arch_decode_irq_control_invocation target target_ref caps intent \<equiv>
+     case intent of
+       ARMIrqControlIssueIrqHandlerIntent irq index depth \<Rightarrow> doE
+         root \<leftarrow> throw_on_none $ get_index caps 0;
+         cnode_cap \<leftarrow> returnOk $ fst root;
+         dest_slot_cap_ref \<leftarrow> lookup_slot_for_cnode_op cnode_cap index (unat depth);
+         returnOk $ IssueIrqHandler irq target_ref dest_slot_cap_ref
+       odE
+       \<sqinter> throw
+     | ARMIssueSGISignalIntent irq target index depth \<Rightarrow> doE
+         root \<leftarrow> throw_on_none $ get_index caps 0;
+         cnode_cap \<leftarrow> returnOk $ fst root;
+         dest_slot_cap_ref \<leftarrow> lookup_slot_for_cnode_op cnode_cap index (unat depth);
+         ensure_empty dest_slot_cap_ref;
+         returnOk $ ArchIssueIrqHandler (ARMIssueSGISignal (ucast irq) (ucast target)
+                                                           target_ref dest_slot_cap_ref)
+       odE
+       \<sqinter> throw"
 
-definition
-  decode_irq_control_invocation :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow>
-      cdl_irq_control_intent \<Rightarrow> cdl_irq_control_invocation except_monad"
-where
-  "decode_irq_control_invocation target target_ref caps intent \<equiv> case intent of
-      \<comment> \<open>Create an IRQ handler cap for the given IRQ, placing it
-         in the specified CNode slot.\<close>
-      IrqControlIssueIrqHandlerIntent irq index depth \<Rightarrow>
-        doE
-          root \<leftarrow> throw_on_none $ get_index caps 0;
-          cnode_cap \<leftarrow> returnOk $ fst root;
-          dest_slot_cap_ref \<leftarrow> lookup_slot_for_cnode_op cnode_cap index (unat depth);
-          returnOk $ IssueIrqHandler irq target_ref dest_slot_cap_ref
-        odE \<sqinter> throw
-    | ArchIrqControlIssueIrqHandlerIntent arch_intent \<Rightarrow>
-        arch_decode_irq_control_invocation target target_ref caps arch_intent"
+definition decode_irq_control_invocation ::
+  "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_irq_control_intent \<Rightarrow>
+   cdl_irq_control_invocation except_monad"
+  where
+  "decode_irq_control_invocation target target_ref caps intent \<equiv>
+     case intent of
+       IrqControlIssueIrqHandlerIntent irq index depth \<Rightarrow> doE
+         \<comment> \<open>Create an IRQ handler cap for the given IRQ, placing it in the specified CNode slot.\<close>
+         root \<leftarrow> throw_on_none $ get_index caps 0;
+         cnode_cap \<leftarrow> returnOk $ fst root;
+         dest_slot_cap_ref \<leftarrow> lookup_slot_for_cnode_op cnode_cap index (unat depth);
+         returnOk $ IssueIrqHandler irq target_ref dest_slot_cap_ref
+       odE
+       \<sqinter> throw
+     | ArchIrqControlIssueIrqHandlerIntent arch_intent \<Rightarrow>
+         arch_decode_irq_control_invocation target target_ref caps arch_intent"
 
-definition
-  decode_irq_handler_invocation :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow>
-      cdl_irq_handler_intent \<Rightarrow> cdl_irq_handler_invocation except_monad"
-where
-  "decode_irq_handler_invocation target target_ref caps intent \<equiv> case intent of
-    \<comment> \<open>Acknowledge an IRQ.\<close>
-    IrqHandlerAckIntent \<Rightarrow>
-      doE
-        irq \<leftarrow> liftE $ assert_opt $ cdl_cap_irq target;
-        returnOk $ AckIrq irq
-      odE \<sqinter> throw
+definition decode_irq_handler_invocation ::
+  "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_irq_handler_intent \<Rightarrow>
+   cdl_irq_handler_invocation except_monad"
+  where
+  "decode_irq_handler_invocation target target_ref caps intent \<equiv>
+     case intent of
+       IrqHandlerAckIntent \<Rightarrow> doE
+         \<comment> \<open>Acknowledge an IRQ.\<close>
+         irq \<leftarrow> liftE $ assert_opt $ cdl_cap_irq target;
+         returnOk $ AckIrq irq
+       odE
+       \<sqinter> throw
 
-    \<comment> \<open>Modify the IRQ so that it no longer sends to an endpoint.\<close>
-    | IrqHandlerClearIntent \<Rightarrow>
-      doE
-        irq \<leftarrow> liftE $ assert_opt $ cdl_cap_irq target;
-        returnOk $ ClearIrqHandler irq
-      odE \<sqinter> throw
+     | IrqHandlerClearIntent \<Rightarrow> doE
+         \<comment> \<open>Modify the IRQ so that it no longer sends to an endpoint.\<close>
+         irq \<leftarrow> liftE $ assert_opt $ cdl_cap_irq target;
+         returnOk $ ClearIrqHandler irq
+       odE
+       \<sqinter> throw
 
-    \<comment> \<open>Setup an IRQ to cause an endpoint to be sent to.\<close>
-    | IrqHandlerSetEndpointIntent \<Rightarrow>
-      doE
-        endpoint \<leftarrow> throw_on_none $ get_index caps 0;
-        endpoint_cap \<leftarrow> returnOk $ fst endpoint;
-        endpoint_cap_ref \<leftarrow> returnOk $ snd endpoint;
-        irq \<leftarrow> liftE $ assert_opt $ cdl_cap_irq target;
-        case endpoint_cap of
-              NotificationCap x _ _ \<Rightarrow> returnOk ()
-              | _                    \<Rightarrow> throw;
-        returnOk $ SetIrqHandler irq endpoint_cap endpoint_cap_ref
-      odE \<sqinter> throw
-  "
+     | IrqHandlerSetEndpointIntent \<Rightarrow> doE
+         \<comment> \<open>Setup an IRQ to cause an endpoint to be sent to.\<close>
+         endpoint \<leftarrow> throw_on_none $ get_index caps 0;
+         endpoint_cap \<leftarrow> returnOk $ fst endpoint;
+         endpoint_cap_ref \<leftarrow> returnOk $ snd endpoint;
+         irq \<leftarrow> liftE $ assert_opt $ cdl_cap_irq target;
+         case endpoint_cap of
+           NotificationCap x _ _ \<Rightarrow> returnOk ()
+         | _                     \<Rightarrow> throw;
+         returnOk $ SetIrqHandler irq endpoint_cap endpoint_cap_ref
+       odE
+       \<sqinter> throw"
 
-definition
-  arch_invoke_irq_control :: "arch_cdl_irq_control_invocation \<Rightarrow> unit k_monad"
-where
-  "arch_invoke_irq_control params \<equiv> case params of
-      ARMIssueSGISignal irq target control_slot dest_slot \<Rightarrow>
-        insert_cap_child (SGISignalCap irq target) control_slot dest_slot"
+definition arch_invoke_irq_control :: "arch_cdl_irq_control_invocation \<Rightarrow> unit k_monad" where
+  "arch_invoke_irq_control params \<equiv>
+     case params of
+       ARMIssueSGISignal irq target control_slot dest_slot \<Rightarrow>
+         insert_cap_child (SGISignalCap irq target) control_slot dest_slot"
 
-definition
-  invoke_irq_control :: "cdl_irq_control_invocation \<Rightarrow> unit k_monad"
-where
-  "invoke_irq_control params \<equiv> case params of
-      \<comment> \<open>Create a new IRQ handler cap.\<close>
-      IssueIrqHandler irq control_slot dest_slot \<Rightarrow>
-        insert_cap_child (IrqHandlerCap irq) control_slot dest_slot
-    | ArchIssueIrqHandler arch_inv \<Rightarrow>
-        arch_invoke_irq_control arch_inv"
+definition invoke_irq_control :: "cdl_irq_control_invocation \<Rightarrow> unit k_monad" where
+  "invoke_irq_control params \<equiv>
+     case params of
+       IssueIrqHandler irq control_slot dest_slot \<Rightarrow>
+         \<comment> \<open>Create a new IRQ handler cap.\<close>
+         insert_cap_child (IrqHandlerCap irq) control_slot dest_slot
+     | ArchIssueIrqHandler arch_inv \<Rightarrow>
+         arch_invoke_irq_control arch_inv"
 
-definition
-  invoke_irq_handler :: "cdl_irq_handler_invocation \<Rightarrow> unit k_monad"
-where
-  "invoke_irq_handler params \<equiv> case params of
-      \<comment> \<open>Acknowledge and unmask an IRQ.\<close>
-      AckIrq irq \<Rightarrow> return ()
+definition invoke_irq_handler :: "cdl_irq_handler_invocation \<Rightarrow> unit k_monad" where
+  "invoke_irq_handler params \<equiv>
+     case params of
+       AckIrq irq \<Rightarrow> return () \<comment> \<open>Acknowledge and unmask an IRQ.\<close>
 
-      \<comment> \<open>Attach an IRQ handler to write to an endpoint.\<close>
-    | SetIrqHandler irq cap slot \<Rightarrow>
-        do
-          irqslot \<leftarrow> gets (get_irq_slot irq);
-          delete_cap_simple irqslot;
-          insert_cap_child cap slot irqslot \<sqinter> insert_cap_sibling cap slot irqslot
-        od
+     | SetIrqHandler irq cap slot \<Rightarrow> do
+         \<comment> \<open>Attach an IRQ handler to write to an endpoint.\<close>
+         irqslot \<leftarrow> gets (get_irq_slot irq);
+         delete_cap_simple irqslot;
+         insert_cap_child cap slot irqslot \<sqinter> insert_cap_sibling cap slot irqslot
+       od
 
-      \<comment> \<open>Deassociate this handler with all endpoints.\<close>
-    | ClearIrqHandler irq \<Rightarrow>
-        do
-          irqslot \<leftarrow> gets (get_irq_slot irq);
-          delete_cap_simple irqslot
-        od
-  "
+     | ClearIrqHandler irq \<Rightarrow> do
+         \<comment> \<open>Dissociate this handler from all endpoints.\<close>
+         irqslot \<leftarrow> gets (get_irq_slot irq);
+         delete_cap_simple irqslot
+       od"
 
 (* performs machine op only *)
 definition invoke_sgi_signal_generate :: "cdl_sgi_signal_invocation \<Rightarrow> unit k_monad" where
   "invoke_sgi_signal_generate params \<equiv> return ()"
 
 (* Handle an interrupt. *)
-definition
-  handle_interrupt :: "cdl_irq \<Rightarrow> unit k_monad"
-where
-  "handle_interrupt irq \<equiv> if irq > maxIRQ then return () else
-    do
-      irq_slot \<leftarrow> gets $ get_irq_slot irq;
-      c \<leftarrow> gets $ opt_cap irq_slot;
-      case c of
-          None \<Rightarrow> return ()
-        | Some cap \<Rightarrow> (
-            case cap of
-              (NotificationCap obj _ rights) \<Rightarrow>
-                  if (Write \<in> rights) then send_signal obj else return ()
-              | _ \<Rightarrow> return ()
-          )
-    od
-  "
+definition handle_interrupt :: "cdl_irq \<Rightarrow> unit k_monad" where
+  "handle_interrupt irq \<equiv>
+     if irq > maxIRQ
+     then return ()
+     else do
+       irq_slot \<leftarrow> gets $ get_irq_slot irq;
+       c \<leftarrow> gets $ opt_cap irq_slot;
+       case c of
+         Some (NotificationCap obj _ rights) \<Rightarrow>
+           if Write \<in> rights then send_signal obj else return ()
+       | _ \<Rightarrow> return ()
+   od"
 
-definition
-  handle_pending_interrupts :: "unit k_monad"
-where
-  "handle_pending_interrupts \<equiv>
-    do
-      active \<leftarrow> get_active_irq;
-      case active of
-          Some irq \<Rightarrow> handle_interrupt irq
-        | None \<Rightarrow> return ()
-    od"
+definition handle_pending_interrupts :: "unit k_monad" where
+  "handle_pending_interrupts \<equiv> do
+     active \<leftarrow> get_active_irq;
+     case active of
+       Some irq \<Rightarrow> handle_interrupt irq
+     | None \<Rightarrow> return ()
+   od"
 
 end

--- a/spec/capDL/Invocations_D.thy
+++ b/spec/capDL/Invocations_D.thy
@@ -18,18 +18,19 @@ datatype cdl_cnode_invocation =
   | CancelBadgedSendsCall cdl_cap
 
 datatype cdl_untyped_invocation =
-    Retype cdl_cap_ref
-        cdl_object_type cdl_size_bits "cdl_cap_ref list" bool nat
+    Retype cdl_cap_ref cdl_object_type cdl_size_bits "cdl_cap_ref list" bool nat
 
 datatype cdl_tcb_invocation =
     WriteRegisters cdl_object_id bool "machine_word list" nat
   | ReadRegisters cdl_object_id bool machine_word nat
   | CopyRegisters cdl_object_id cdl_object_id bool bool bool bool nat
-  | ThreadControl cdl_object_id cdl_cap_ref
-        "cdl_cptr option"
-        "(cdl_cap \<times> cdl_cap_ref) option"
-        "(cdl_cap \<times> cdl_cap_ref) option"
-        "(cdl_cap \<times> cdl_cap_ref) option"
+  | ThreadControl
+      cdl_object_id
+      cdl_cap_ref
+      "cdl_cptr option"
+      "(cdl_cap \<times> cdl_cap_ref) option"
+      "(cdl_cap \<times> cdl_cap_ref) option"
+      "(cdl_cap \<times> cdl_cap_ref) option"
   | Suspend cdl_object_id
   | Resume cdl_object_id
   | NotificationControl cdl_object_id "cdl_object_id option"
@@ -74,7 +75,7 @@ datatype cdl_asid_pool_invocation =
     Assign cdl_asid cdl_cap_ref cdl_cap_ref
 
 datatype flush =
-   Clean | Invalidate | CleanInvalidate | Unify
+    Clean | Invalidate | CleanInvalidate | Unify
 
 datatype cdl_page_invocation =
     PageMap cdl_cap cdl_cap cdl_cap_ref cdl_cap_ref
@@ -84,8 +85,8 @@ datatype cdl_page_invocation =
 
 
 datatype cdl_page_directory_invocation =
-   PageDirectoryFlush  flush
- | PageDirectoryNothing
+    PageDirectoryFlush  flush
+  | PageDirectoryNothing
 
 
 datatype cdl_domain_invocation =
@@ -97,10 +98,10 @@ datatype cdl_domain_invocation =
                                   (dominv_duration : domain_duration)
 
 datatype cdl_sgi_signal_invocation =
-  SGISignalGenerate (* no params, machine op only *)
+    SGISignalGenerate (* no params, machine op only *)
 
 datatype cdl_vcpu_invocation =
-  VCPUSetTCB (vcpu_inv_vcpu : cdl_object_id) (vcpu_inv_tcb : cdl_object_id)
+    VCPUSetTCB (vcpu_inv_vcpu : cdl_object_id) (vcpu_inv_tcb : cdl_object_id)
 
 datatype cdl_invocation =
     InvokeUntyped cdl_untyped_invocation

--- a/spec/capDL/KHeap_D.thy
+++ b/spec/capDL/KHeap_D.thy
@@ -4,246 +4,182 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * Accessor functions for objects and caps.
- *)
+(* Accessor functions for objects and caps. *)
 
 theory KHeap_D
-imports Monads_D
+  imports Monads_D
 begin
 
 (* Return an item from the heap. Fail if no such object exists. *)
-abbreviation
-  get_object :: "cdl_object_id \<Rightarrow> cdl_object k_monad"
-where
+abbreviation get_object :: "cdl_object_id \<Rightarrow> cdl_object k_monad" where
   "get_object p \<equiv> gets_the (\<lambda>s. cdl_objects s p)"
 
 (* Set an item on the heap to the given object. *)
-definition
-  set_object :: "cdl_object_id \<Rightarrow> cdl_object \<Rightarrow> unit k_monad"
-where
-  "set_object p obj \<equiv>
-    modify (\<lambda>s. s \<lparr> cdl_objects := (cdl_objects s) (p \<mapsto> obj) \<rparr> )"
+definition set_object :: "cdl_object_id \<Rightarrow> cdl_object \<Rightarrow> unit k_monad" where
+  "set_object p obj \<equiv> modify (\<lambda>s. s \<lparr>cdl_objects := (cdl_objects s) (p \<mapsto> obj)\<rparr>)"
 
 (* Get a thread from the given pointer. *)
-definition
-  get_thread :: "cdl_object_id \<Rightarrow> cdl_tcb k_monad"
-where
-  "get_thread p \<equiv>
-    do
-      t \<leftarrow> get_object p;
-      case t of
-          Tcb tcb \<Rightarrow> return tcb
-        | _ \<Rightarrow> fail
-    od"
+definition get_thread :: "cdl_object_id \<Rightarrow> cdl_tcb k_monad" where
+  "get_thread p \<equiv> do
+     t \<leftarrow> get_object p;
+     case t of Tcb tcb \<Rightarrow> return tcb | _ \<Rightarrow> fail
+   od"
 
 (* Get a thread from the given pointer. *)
-definition
-  get_thread_fault :: "cdl_object_id \<Rightarrow> bool k_monad"
-where
-  "get_thread_fault p \<equiv>
-    do
-      t \<leftarrow> get_object p;
-      case t of
-          Tcb tcb \<Rightarrow> return (cdl_tcb_has_fault tcb)
-        | _ \<Rightarrow> fail
-    od"
+definition get_thread_fault :: "cdl_object_id \<Rightarrow> bool k_monad" where
+  "get_thread_fault p \<equiv> do
+     t \<leftarrow> get_object p;
+     case t of Tcb tcb \<Rightarrow> return (cdl_tcb_has_fault tcb) | _ \<Rightarrow> fail
+   od"
 
 (* Update a thread on the heap. *)
-definition
-  update_thread :: "cdl_object_id \<Rightarrow> (cdl_tcb \<Rightarrow> cdl_tcb) \<Rightarrow> unit k_monad"
-where
-  "update_thread p f \<equiv>
-     do
-       t \<leftarrow> get_object p;
-       case t of
-          Tcb tcb \<Rightarrow> set_object p (Tcb (f tcb))
-       | _ \<Rightarrow> fail
-     od"
+definition update_thread :: "cdl_object_id \<Rightarrow> (cdl_tcb \<Rightarrow> cdl_tcb) \<Rightarrow> unit k_monad" where
+  "update_thread p f \<equiv> do
+     t \<leftarrow> get_object p;
+     case t of Tcb tcb \<Rightarrow> set_object p (Tcb (f tcb)) | _ \<Rightarrow> fail
+   od"
 
-(* Update a thread on the heap. *)
-definition
-  update_thread_fault :: "cdl_object_id \<Rightarrow> (bool\<Rightarrow>bool) \<Rightarrow> unit k_monad"
-where
-  "update_thread_fault p f \<equiv>
-     do
-       t \<leftarrow> get_object p;
-       case t of
-          Tcb tcb \<Rightarrow> set_object p (Tcb (tcb\<lparr>cdl_tcb_has_fault := f (cdl_tcb_has_fault tcb)\<rparr>))
-       | _ \<Rightarrow> fail
-     od"
+(* Update the fault field in a thread on the heap. *)
+definition update_thread_fault :: "cdl_object_id \<Rightarrow> (bool\<Rightarrow>bool) \<Rightarrow> unit k_monad" where
+  "update_thread_fault p f \<equiv> do
+     t \<leftarrow> get_object p;
+     case t of
+       Tcb tcb \<Rightarrow> set_object p (Tcb (tcb\<lparr>cdl_tcb_has_fault := f (cdl_tcb_has_fault tcb)\<rparr>))
+     | _ \<Rightarrow> fail
+   od"
 
 (* Get a CNode from the given pointer. *)
-definition
-  get_cnode :: "cdl_object_id \<Rightarrow> cdl_cnode k_monad"
-where
-  "get_cnode p \<equiv>
-    do
-      t \<leftarrow> get_object p;
-      case t of
-          CNode cnode \<Rightarrow> return cnode
-        | _ \<Rightarrow> fail
-    od"
+definition get_cnode :: "cdl_object_id \<Rightarrow> cdl_cnode k_monad" where
+  "get_cnode p \<equiv> do
+     t \<leftarrow> get_object p;
+     case t of CNode cnode \<Rightarrow> return cnode | _ \<Rightarrow> fail
+   od"
 
-(*
- * Get the index out of the given list, returning None if it
- * doesn't exist.
- *)
-definition
-  get_index :: "'a list \<Rightarrow> nat \<Rightarrow> 'a option"
-where
-  "get_index a b \<equiv>
-     if b < length a then
-       Some (a ! b)
-     else
-       None"
+(* Get the element at given index out of the given list. Return None if no element exists. *)
+definition get_index :: "'a list \<Rightarrow> nat \<Rightarrow> 'a option" where
+  "get_index xs i \<equiv> if i < length xs then Some (xs ! i) else None"
 
-(* --- caps --- *)
 
-(* The slots of an object, returns an empty map for non-existing objects
-   or objects that do not have caps *)
-definition
-  slots_of :: "cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_map"
-where
+(* --- Caps --- *)
+
+(* The slots of an object. Empty map for non-existing objects or objects that do not have caps *)
+definition slots_of :: "cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_map" where
   "slots_of obj_id \<equiv> \<lambda>s.
-  case cdl_objects s obj_id of
-    None \<Rightarrow> Map.empty
-  | Some obj \<Rightarrow> object_slots obj"
+     case cdl_objects s obj_id of
+       None \<Rightarrow> Map.empty
+     | Some obj \<Rightarrow> object_slots obj"
 
 (* The cap at the given cap_ref. None if object or cap does not exist *)
-definition
-  opt_cap :: "cdl_cap_ref \<Rightarrow> cdl_state \<Rightarrow> cdl_cap option"
-where
+definition opt_cap :: "cdl_cap_ref \<Rightarrow> cdl_state \<Rightarrow> cdl_cap option" where
   "opt_cap \<equiv> \<lambda>(obj_id, slot) s. slots_of obj_id s slot"
 
-(* monad version of opt_cap *)
-abbreviation
-  get_cap :: "cdl_cap_ref \<Rightarrow> cdl_cap k_monad" where
+(* Monad version of opt_cap *)
+abbreviation get_cap :: "cdl_cap_ref \<Rightarrow> cdl_cap k_monad" where
   "get_cap p \<equiv> gets_the (opt_cap p)"
 
-
 (* Setting a cap at specific cap_ref. Object must exist and have cap slots. *)
-definition
-  set_cap :: "cdl_cap_ref \<Rightarrow> cdl_cap \<Rightarrow> unit k_monad"
-where
+definition set_cap :: "cdl_cap_ref \<Rightarrow> cdl_cap \<Rightarrow> unit k_monad" where
   "set_cap \<equiv> \<lambda>(obj_id, slot) cap. do
-    obj \<leftarrow> get_object obj_id;
-    assert (has_slots obj);
-    slots \<leftarrow> return $ object_slots obj;
-    obj' \<leftarrow> return $ update_slots (slots (slot \<mapsto> cap)) obj;
-    obj'' \<leftarrow> case obj' of
-              Tcb t \<Rightarrow> if slot = tcb_ipcbuffer_slot \<and> slots slot \<noteq> Some cap then do
-                   intent' \<leftarrow> select UNIV;
-                   return $ Tcb (t \<lparr> cdl_tcb_intent := intent' \<rparr>)
-                 od
-                 else return obj'
-             | _ \<Rightarrow> return obj';
-    set_object obj_id obj''
-  od"
-
+     obj \<leftarrow> get_object obj_id;
+     assert (has_slots obj);
+     slots \<leftarrow> return $ object_slots obj;
+     obj' \<leftarrow> return $ update_slots (slots (slot \<mapsto> cap)) obj;
+     obj'' \<leftarrow> case obj' of
+                Tcb t \<Rightarrow> if slot = tcb_ipcbuffer_slot \<and> slots slot \<noteq> Some cap
+                         then do
+                           intent' \<leftarrow> select UNIV;
+                           return $ Tcb (t \<lparr> cdl_tcb_intent := intent' \<rparr>)
+                         od
+                         else return obj'
+              | _ \<Rightarrow> return obj';
+     set_object obj_id obj''
+   od"
 
 
 (* looking up the parent of a cap in the cdt *)
-definition
-  opt_parent :: "cdl_cap_ref \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_ref option" where
+definition opt_parent :: "cdl_cap_ref \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_ref option" where
   "opt_parent p \<equiv> \<lambda>s. cdl_cdt s p"
 
-abbreviation
-  get_parent :: "cdl_cap_ref \<Rightarrow> cdl_cap_ref k_monad" where
+abbreviation get_parent :: "cdl_cap_ref \<Rightarrow> cdl_cap_ref k_monad" where
   "get_parent p \<equiv> gets_the (opt_parent p)"
 
 (* setting a cap derivation of a specific cap_ref  *)
-definition
-  set_parent :: "cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad" where
+definition set_parent :: "cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad" where
   "set_parent child parent \<equiv> do
-    cdt \<leftarrow> gets cdl_cdt;
-    assert (cdt child = None);
-    modify (\<lambda>s. s \<lparr> cdl_cdt := (cdl_cdt s) (child \<mapsto> parent) \<rparr> )
+     cdt \<leftarrow> gets cdl_cdt;
+     assert (cdt child = None);
+     modify (\<lambda>s. s\<lparr>cdl_cdt := (cdl_cdt s) (child \<mapsto> parent)\<rparr>)
    od"
 
 (* Removes a cap slot from the cdt, and points all its children to their grandparent *)
-definition
-  remove_parent :: "cdl_cap_ref \<Rightarrow> unit k_monad" where
+definition remove_parent :: "cdl_cap_ref \<Rightarrow> unit k_monad" where
   "remove_parent parent \<equiv>
-   modify (\<lambda>s. s \<lparr>cdl_cdt := (\<lambda> x. if x = parent
-                                 then None
-                                 else (if cdl_cdt s x = Some parent
-                                     then cdl_cdt s parent
-                                     else cdl_cdt s x )) \<rparr>)"
+     modify (\<lambda>s. s \<lparr>cdl_cdt := (\<lambda>x. if x = parent
+                                    then None
+                                    else if cdl_cdt s x = Some parent
+                                         then cdl_cdt s parent
+                                         else cdl_cdt s x)\<rparr>)"
 
 (* Swaps the parents of two cap_refs *)
-definition
-  swap_parents :: "cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad" where
-  "swap_parents p p' = modify (cdl_cdt_update
-     (\<lambda>cd. Fun.swap p p'
-          (\<lambda>x. if cd x = Some p then Some p' else
-              if cd x = Some p' then Some p else cd x)))"
+definition swap_parents :: "cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> unit k_monad" where
+  "swap_parents p p' =
+     modify (cdl_cdt_update
+               (\<lambda>cd. Fun.swap p p'
+                       (\<lambda>x. if cd x = Some p
+                            then Some p'
+                            else if cd x = Some p' then Some p else cd x)))"
 
-definition
-  is_cdt_parent :: "cdl_state \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> bool" where
+definition is_cdt_parent :: "cdl_state \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> bool" where
   "is_cdt_parent s p c \<equiv> cdl_cdt s c = Some p"
 
-definition
-  cdt_parent_rel :: "cdl_state \<Rightarrow> (cdl_cap_ref \<times> cdl_cap_ref) set" where
+definition cdt_parent_rel :: "cdl_state \<Rightarrow> (cdl_cap_ref \<times> cdl_cap_ref) set" where
   "cdt_parent_rel \<equiv> \<lambda>s. {(p,c). is_cdt_parent s p c}"
 
-abbreviation
-  parent_of :: "cdl_state \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> bool"
-  ("_ \<turnstile> _ cdt'_parent'_of _" [60,0,60] 61)
-where
+abbreviation parent_of ::
+  "cdl_state \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> bool" ("_ \<turnstile> _ cdt'_parent'_of _" [60,0,60] 61)
+  where
   "s \<turnstile> p cdt_parent_of c \<equiv> (p,c) \<in> cdt_parent_rel s"
 
-abbreviation
-  parent_of_trancl :: "cdl_state \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> bool"
-  ("_ \<turnstile> _ cdt'_parent'_of\<^sup>+ _" [60,0,60] 61)
-where
+abbreviation parent_of_trancl ::
+  "cdl_state \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> bool" ("_ \<turnstile> _ cdt'_parent'_of\<^sup>+ _" [60,0,60] 61)
+  where
   "s \<turnstile> x cdt_parent_of\<^sup>+ y \<equiv> (x, y) \<in> (cdt_parent_rel s)\<^sup>+"
 
-abbreviation
-  parent_of_rtrancl :: "cdl_state \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> bool"
-  ("_ \<turnstile> _ cdt'_parent'_of\<^sup>* _" [60,0,60] 61)
-where
+abbreviation parent_of_rtrancl ::
+  "cdl_state \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap_ref \<Rightarrow> bool" ("_ \<turnstile> _ cdt'_parent'_of\<^sup>* _" [60,0,60] 61)
+  where
   "s \<turnstile> x cdt_parent_of\<^sup>* y \<equiv> (x, y) \<in> (cdt_parent_rel s)\<^sup>*"
 
-\<comment> \<open>descendants of a slot\<close>
-definition
-  descendants_of :: "cdl_cap_ref \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_ref set" where
+definition descendants_of :: "cdl_cap_ref \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_ref set" where
   "descendants_of p s \<equiv> {q. (p,q) \<in> (cdt_parent_rel s)\<^sup>+}"
 
 
+definition tcb_ipcframe_id :: "cdl_tcb \<Rightarrow> cdl_object_id option" where
+  "tcb_ipcframe_id tcb \<equiv>
+     case cdl_tcb_caps tcb tcb_ipcbuffer_slot of
+       Some (FrameCap _ oid _ _ _ _) \<Rightarrow> Some oid
+     | _ \<Rightarrow> None"
 
-definition
-  tcb_ipcframe_id :: "cdl_tcb \<Rightarrow> cdl_object_id option"
-where
-  "tcb_ipcframe_id tcb \<equiv> case (cdl_tcb_caps tcb tcb_ipcbuffer_slot) of
-                              Some (FrameCap _ oid _ _ _ _) \<Rightarrow> Some oid
-                              | _                       \<Rightarrow> None"
-
-(*
- * Dealing with writes to message registers or other locations that
- * may have an effect on how intents are interpreted.
- *)
-definition
-  corrupt_intents ::"(machine_word \<Rightarrow> cdl_full_intent) \<Rightarrow> cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_state"
-where
-  "corrupt_intents f bufp s \<equiv>
-  let changed = (\<lambda>ptr. case cdl_objects s ptr of
-    Some (Tcb tcb)
-      \<Rightarrow> if tcb_ipcframe_id tcb = Some bufp then Some (Tcb (tcb\<lparr> cdl_tcb_intent := f ptr \<rparr> ) ) else None
-  | _ \<Rightarrow> None)
-  in
-  s\<lparr>cdl_objects := cdl_objects s ++ changed\<rparr>"
-
-(* When a memory frame has been corrupted,
- * we need to change all the intents of tcbs
- * whose ipc_buffer is located within that frame
- *)
-definition
-  corrupt_frame :: "cdl_object_id \<Rightarrow> unit k_monad"
+(* Dealing with writes to message registers or other locations that
+   may have an effect on how intents are interpreted. *)
+definition corrupt_intents ::
+  "(machine_word \<Rightarrow> cdl_full_intent) \<Rightarrow> cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_state"
   where
+  "corrupt_intents f bufp s \<equiv>
+     let changed = \<lambda>ptr. case cdl_objects s ptr of
+                           Some (Tcb tcb) \<Rightarrow> if tcb_ipcframe_id tcb = Some bufp
+                                             then Some (Tcb (tcb\<lparr>cdl_tcb_intent := f ptr\<rparr>))
+                                             else None
+                         | _ \<Rightarrow> None
+     in
+       s\<lparr>cdl_objects := cdl_objects s ++ changed\<rparr>"
+
+(* When a memory frame has been corrupted, we need to change all the intents of tcbs
+   whose ipc_buffer is located within that frame *)
+definition corrupt_frame :: "cdl_object_id \<Rightarrow> unit k_monad" where
   "corrupt_frame bufp \<equiv> do
-      f \<leftarrow> select UNIV;
-      modify (corrupt_intents f bufp)
-    od"
+     f \<leftarrow> select UNIV;
+     modify (corrupt_intents f bufp)
+  od"
 
 end

--- a/spec/capDL/Monads_D.thy
+++ b/spec/capDL/Monads_D.thy
@@ -4,15 +4,13 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * The basic monads used in capDL
- *)
+(* The basic monads used in capDL *)
 
 theory Monads_D
-imports
-  Types_D
-  Monads.Nondet_In_Monad
-  Monads.Nondet_VCG
+  imports
+    Types_D
+    Monads.Nondet_In_Monad
+    Monads.Nondet_VCG
 begin
 
 (* Kernel state monad *)
@@ -25,58 +23,33 @@ datatype cdl_fault_error = FaultError
 (* Exception monad, no further exception information *)
 type_synonym 'a except_monad = "(cdl_state, cdl_except_error + 'a) nondet_monad"
 
-(* Exception monad, no further exception information *)
+(* Preemption monad *)
 type_synonym 'a preempt_monad = "(cdl_state, cdl_preempt_error + 'a) nondet_monad"
 
-(* Exception monad, no further exception information *)
+(* Fault monad, no further fault information *)
 type_synonym 'a fault_monad =  "(cdl_state, cdl_fault_error + 'a) nondet_monad"
 
-abbreviation
-  throw :: "(cdl_state, 'a + 'b) nondet_monad" where
+abbreviation throw :: "(cdl_state, 'a + 'b) nondet_monad" where
   "throw == throwError undefined"
 
-text \<open>Allow preemption at this point.\<close>
-definition
-  preemption_point :: "unit preempt_monad" where
- "preemption_point \<equiv> throw \<sqinter> returnOk ()"
+(* Allow preemption at this point. *)
+definition preemption_point :: "unit preempt_monad" where
+  "preemption_point \<equiv> throw \<sqinter> returnOk ()"
 
-(*
- * Convert an exception monad with aribtrary type into a
- * new exception monad with unit type.
- *)
-definition
-  unify_failure :: "('f + 'a) k_monad \<Rightarrow> (unit + 'a) k_monad" where
- "unify_failure m \<equiv> handleE' m (\<lambda>x. throwError ())"
+(* Convert an exception monad with aribtrary type into a new exception monad with unit type. *)
+definition unify_failure :: "('f + 'a) k_monad \<Rightarrow> (unit + 'a) k_monad" where
+  "unify_failure m \<equiv> handleE' m (\<lambda>x. throwError ())"
 
-text \<open>
-  Convert a fault monad into an exception monad.
-\<close>
-definition
-  fault_to_except :: "'a fault_monad \<Rightarrow> 'a except_monad"
-where
+(* Convert a fault monad into an exception monad. *)
+definition fault_to_except :: "'a fault_monad \<Rightarrow> 'a except_monad" where
   "fault_to_except m \<equiv> handleE' m (\<lambda>x. throw)"
 
-(*
- * Non-deterministically select an item from the given set.
- * If the set if empty, return 'None'.
- *)
-definition
-  option_select :: "'a set \<Rightarrow> ('s, 'a option) nondet_monad"
-where
-  "option_select S \<equiv>
-    if S = {} then
-      return None
-    else
-      select S >>= (\<lambda>a. return (Some a))"
+(* Non-deterministically select an item from the given set. If the set is empty, return 'None'. *)
+definition option_select :: "'a set \<Rightarrow> ('s, 'a option) nondet_monad" where
+  "option_select S \<equiv> if S = {} then return None else select S >>= (\<lambda>a. return (Some a))"
 
 (* Return the given object, throwing an error if it is 'None'. *)
-definition
-  throw_on_none :: "'a option \<Rightarrow> ('e + 'a) k_monad"
-where
-  "throw_on_none x \<equiv>
-    case x of
-        None \<Rightarrow> throw
-      | Some y \<Rightarrow> returnOk y"
-
+definition throw_on_none :: "'a option \<Rightarrow> ('e + 'a) k_monad" where
+  "throw_on_none x \<equiv> case x of None \<Rightarrow> throw | Some y \<Rightarrow> returnOk y"
 
 end

--- a/spec/capDL/PageTableUnmap_D.thy
+++ b/spec/capDL/PageTableUnmap_D.thy
@@ -9,233 +9,189 @@
    architectures do not model unmapping. *)
 
 theory PageTableUnmap_D
-imports
-  Invocations_D
-  KHeap_D
+  imports
+    Invocations_D
+    KHeap_D
 begin
 
 \<comment> \<open>Return all slots in the system containing a cap with the given property.\<close>
-definition
-  slots_with :: "(cdl_cap \<Rightarrow> bool) \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_ref set"
-where
+definition slots_with :: "(cdl_cap \<Rightarrow> bool) \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_ref set" where
   "slots_with P s \<equiv> {(obj, slot). \<exists>x c. cdl_objects s obj = Some x \<and>
                                         has_slots x \<and>
                                         object_slots x slot = Some c \<and> P c}"
 
-
 \<comment> \<open>Remove a pending operation from the given TCB.\<close>
-definition
-  remove_pending_operation :: "cdl_tcb \<Rightarrow> cdl_cap \<Rightarrow> cdl_tcb"
-where
+definition remove_pending_operation :: "cdl_tcb \<Rightarrow> cdl_cap \<Rightarrow> cdl_tcb" where
   "remove_pending_operation t cap \<equiv> t\<lparr>cdl_tcb_caps := (cdl_tcb_caps t)(tcb_pending_op_slot \<mapsto> cap)\<rparr>"
 
-
 \<comment> \<open>Is the given thread pending on the given endpoint?\<close>
-definition
-  is_thread_blocked_on_endpoint :: "cdl_tcb \<Rightarrow> cdl_object_id \<Rightarrow> bool"
-where
+definition is_thread_blocked_on_endpoint :: "cdl_tcb \<Rightarrow> cdl_object_id \<Rightarrow> bool" where
   "is_thread_blocked_on_endpoint t ep \<equiv>
-    case (cdl_tcb_caps t tcb_pending_op_slot) of
-        Some (PendingSyncSendCap p _ _ _ _ _) \<Rightarrow> p = ep
-      | Some (PendingSyncRecvCap p is_reply _) \<Rightarrow> p = ep \<and> \<not> is_reply
-      | Some (PendingNtfnRecvCap p) \<Rightarrow> p = ep
-      | _ \<Rightarrow> False"
-
+     case cdl_tcb_caps t tcb_pending_op_slot of
+       Some (PendingSyncSendCap p _ _ _ _ _) \<Rightarrow> p = ep
+     | Some (PendingSyncRecvCap p is_reply _) \<Rightarrow> p = ep \<and> \<not> is_reply
+     | Some (PendingNtfnRecvCap p) \<Rightarrow> p = ep
+     | _ \<Rightarrow> False"
 
 \<comment> \<open>Cancel all pending IPCs currently blocked on this endpoint.\<close>
-definition
-  cancel_all_ipc :: "cdl_object_id \<Rightarrow> unit k_monad"
-where
+definition cancel_all_ipc :: "cdl_object_id \<Rightarrow> unit k_monad" where
   "cancel_all_ipc ep \<equiv>
-    modify (\<lambda>s. s\<lparr>cdl_objects :=  map_option
-        (\<lambda>obj. case obj of
-            Tcb t \<Rightarrow>
-              if (is_thread_blocked_on_endpoint t ep) then
-                Tcb (remove_pending_operation t RestartCap)
-              else
-                Tcb t
-           | _ \<Rightarrow> obj)
-          \<circ> (cdl_objects s)\<rparr>)"
+     modify (\<lambda>s. s\<lparr>cdl_objects :=
+                     map_option (\<lambda>obj. case obj of
+                                         Tcb t \<Rightarrow> if is_thread_blocked_on_endpoint t ep
+                                                  then Tcb (remove_pending_operation t RestartCap)
+                                                  else Tcb t
+                                       | _ \<Rightarrow> obj)
+                     \<circ> cdl_objects s\<rparr>)"
 
 \<comment> \<open>Is the given thread bound to the given ntfn?\<close>
-definition
-  is_thread_bound_to_ntfn :: "cdl_tcb \<Rightarrow> cdl_object_id \<Rightarrow> bool"
-where
+definition is_thread_bound_to_ntfn :: "cdl_tcb \<Rightarrow> cdl_object_id \<Rightarrow> bool" where
   "is_thread_bound_to_ntfn t ntfn \<equiv>
-    case (cdl_tcb_caps t tcb_boundntfn_slot) of
-        Some (BoundNotificationCap a) \<Rightarrow> a = ntfn
-      | _ \<Rightarrow> False"
+     case cdl_tcb_caps t tcb_boundntfn_slot of
+       Some (BoundNotificationCap a) \<Rightarrow> a = ntfn
+     | _ \<Rightarrow> False"
 
 \<comment> \<open>find all tcbs that are bound to a given ntfn\<close>
-definition
-  get_bound_notification_threads :: "cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_object_id set"
-where
+definition get_bound_notification_threads :: "cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_object_id set" where
   "get_bound_notification_threads ntfn_id state \<equiv>
-     {x. \<exists>a. (cdl_objects state) x = Some (Tcb a) \<and>
-         (((cdl_tcb_caps a) tcb_boundntfn_slot) = Some (BoundNotificationCap ntfn_id))}"
+     {t. \<exists>tcb. cdl_objects state t = Some (Tcb tcb) \<and>
+               cdl_tcb_caps tcb tcb_boundntfn_slot = Some (BoundNotificationCap ntfn_id)}"
 
-definition
-  modify_bound_ntfn :: "cdl_tcb \<Rightarrow> cdl_cap \<Rightarrow> cdl_tcb"
-where
-  "modify_bound_ntfn t cap \<equiv> t \<lparr> cdl_tcb_caps := (cdl_tcb_caps t)(tcb_boundntfn_slot \<mapsto> cap)\<rparr>"
+definition modify_bound_ntfn :: "cdl_tcb \<Rightarrow> cdl_cap \<Rightarrow> cdl_tcb" where
+  "modify_bound_ntfn t cap \<equiv> t \<lparr>cdl_tcb_caps := (cdl_tcb_caps t)(tcb_boundntfn_slot \<mapsto> cap)\<rparr>"
 
-
-abbreviation
-  do_unbind_notification :: "cdl_object_id \<Rightarrow> unit k_monad"
-where
+abbreviation do_unbind_notification :: "cdl_object_id \<Rightarrow> unit k_monad" where
   "do_unbind_notification tcb \<equiv> set_cap (tcb, tcb_boundntfn_slot) NullCap"
 
-definition
-  unbind_notification :: "cdl_object_id \<Rightarrow> unit k_monad"
-where
+definition unbind_notification :: "cdl_object_id \<Rightarrow> unit k_monad" where
   "unbind_notification tcb \<equiv> do
-     cap \<leftarrow> KHeap_D.get_cap (tcb, tcb_boundntfn_slot);
-     (case cap of
-      BoundNotificationCap _ \<Rightarrow> do_unbind_notification tcb
-    | _ \<Rightarrow> return ())
+     cap \<leftarrow> get_cap (tcb, tcb_boundntfn_slot);
+     case cap of
+       BoundNotificationCap _ \<Rightarrow> do_unbind_notification tcb
+     | _ \<Rightarrow> return ()
    od"
 
-definition
-  unbind_maybe_notification :: "cdl_object_id \<Rightarrow> unit k_monad"
-where
+definition unbind_maybe_notification :: "cdl_object_id \<Rightarrow> unit k_monad" where
   "unbind_maybe_notification ntfn_id \<equiv> do
      bound_tcbs \<leftarrow> gets $ get_bound_notification_threads ntfn_id;
      t \<leftarrow> option_select bound_tcbs;
-     (case t of
+     case t of
        None \<Rightarrow> return ()
-     | Some tcb \<Rightarrow> do_unbind_notification tcb)
-  od"
+     | Some tcb \<Rightarrow> do_unbind_notification tcb
+   od"
 
-definition
-  can_fast_finalise :: "cdl_cap \<Rightarrow> bool" where
- "can_fast_finalise cap \<equiv> case cap of ReplyCap r R \<Rightarrow> True
-                       | MasterReplyCap r \<Rightarrow> True
-                       | EndpointCap r b R \<Rightarrow> True
-                       | NotificationCap r b R \<Rightarrow> True
-                       | NullCap \<Rightarrow> True
-                       | RestartCap \<Rightarrow> True
-                       | RunningCap \<Rightarrow> True
-                       | PendingSyncSendCap r _ _ _ _ _ \<Rightarrow> True
-                       | PendingSyncRecvCap r _ _ \<Rightarrow> True
-                       | PendingNtfnRecvCap r \<Rightarrow> True
-                       | DomainCap \<Rightarrow> True
-                       | PageTableCap _ _ x _ \<Rightarrow> \<not>(x = Real)
-                       | FrameCap _ _ _ _ x _ \<Rightarrow> \<not>(x = Real)
-                       | _ \<Rightarrow> False"
+definition can_fast_finalise :: "cdl_cap \<Rightarrow> bool" where
+ "can_fast_finalise cap \<equiv>
+    case cap of
+      ReplyCap r R \<Rightarrow> True
+    | MasterReplyCap r \<Rightarrow> True
+    | EndpointCap r b R \<Rightarrow> True
+    | NotificationCap r b R \<Rightarrow> True
+    | NullCap \<Rightarrow> True
+    | RestartCap \<Rightarrow> True
+    | RunningCap \<Rightarrow> True
+    | PendingSyncSendCap r _ _ _ _ _ \<Rightarrow> True
+    | PendingSyncRecvCap r _ _ \<Rightarrow> True
+    | PendingNtfnRecvCap r \<Rightarrow> True
+    | DomainCap \<Rightarrow> True
+    | PageTableCap _ _ x _ \<Rightarrow> x \<noteq> Real
+    | FrameCap _ _ _ _ x _ \<Rightarrow> x \<noteq> Real
+    | _ \<Rightarrow> False"
 
 context
-notes [[function_internals =true]]
+  notes [[function_internals =true]]
 begin
 
-fun
-  fast_finalise :: "cdl_cap \<Rightarrow> bool \<Rightarrow> unit k_monad"
-where
-  "fast_finalise NullCap                  final = return ()"
-| "fast_finalise (RestartCap)             final = return ()"
-| "fast_finalise (RunningCap)             final = return ()"
-| "fast_finalise (ReplyCap r R)           final = return ()"
-| "fast_finalise (MasterReplyCap r)       final = return ()"
-| "fast_finalise (EndpointCap r b R)      final =
-      (when final $ cancel_all_ipc r)"
-| "fast_finalise (NotificationCap r b R) final =
-      (when final $ do
-            unbind_maybe_notification r;
-            cancel_all_ipc r
-          od)"
-| "fast_finalise (PendingSyncSendCap r _ _ _ _ _) final = return()"
-| "fast_finalise (PendingSyncRecvCap r _ _) final = return()"
-| "fast_finalise  (PendingNtfnRecvCap r) final = return()"
-| "fast_finalise DomainCap final = return ()"
-| "fast_finalise (PageTableCap _ _ x _) _ = (if x = Real then fail else return())"
-| "fast_finalise (FrameCap _ _ _ _ x _) _ = (if x = Real then fail else return())"
-| "fast_finalise _ _ = fail"
+fun fast_finalise :: "cdl_cap \<Rightarrow> bool \<Rightarrow> unit k_monad" where
+    "fast_finalise NullCap final = return ()"
+  | "fast_finalise RestartCap final = return ()"
+  | "fast_finalise RunningCap final = return ()"
+  | "fast_finalise (ReplyCap r R) final = return ()"
+  | "fast_finalise (MasterReplyCap r) final = return ()"
+  | "fast_finalise (EndpointCap r b R) final = when final (cancel_all_ipc r)"
+  | "fast_finalise (NotificationCap r b R) final =
+       (when final $ do
+          unbind_maybe_notification r;
+          cancel_all_ipc r
+        od)"
+  | "fast_finalise (PendingSyncSendCap r _ _ _ _ _) final = return()"
+  | "fast_finalise (PendingSyncRecvCap r _ _) final = return()"
+  | "fast_finalise  (PendingNtfnRecvCap r) final = return()"
+  | "fast_finalise DomainCap final = return ()"
+  | "fast_finalise (PageTableCap _ _ x _) _ = (if x = Real then fail else return())"
+  | "fast_finalise (FrameCap _ _ _ _ x _) _ = (if x = Real then fail else return())"
+  | "fast_finalise _ _ = fail"
 
 end
 
 \<comment> \<open>These caps don't count when determining if an entity should be deleted or not\<close>
-definition
-  cap_counts :: "cdl_cap \<Rightarrow> bool" where
- "cap_counts cap \<equiv> (case cap of
-    cdl_cap.NullCap \<Rightarrow> False
-  | UntypedCap _ _ _ \<Rightarrow> False
-  | ReplyCap _ _ \<Rightarrow> False
-  | MasterReplyCap _ \<Rightarrow> False
-  | RestartCap \<Rightarrow> False
-  | RunningCap \<Rightarrow> False
-  | PendingSyncSendCap _ _ _ _ _ _ \<Rightarrow> False
-  | PendingSyncRecvCap _ _ _ \<Rightarrow> False
-  | PendingNtfnRecvCap _ \<Rightarrow> False
-  | DomainCap \<Rightarrow> False
-  | BoundNotificationCap _ \<Rightarrow> False
-  | IrqControlCap  \<Rightarrow> False
-  | SGISignalCap _ _ \<Rightarrow> False
-  | AsidControlCap \<Rightarrow> False
-  | IOSpaceMasterCap \<Rightarrow> False
-  | FrameCap _ _ _ _ c _ \<Rightarrow> c = Real
-  | PageTableCap _ _ c _ \<Rightarrow> c = Real
-  | _ \<Rightarrow> True)"
+definition cap_counts :: "cdl_cap \<Rightarrow> bool" where
+  "cap_counts cap \<equiv> case cap of
+     cdl_cap.NullCap \<Rightarrow> False
+   | UntypedCap _ _ _ \<Rightarrow> False
+   | ReplyCap _ _ \<Rightarrow> False
+   | MasterReplyCap _ \<Rightarrow> False
+   | RestartCap \<Rightarrow> False
+   | RunningCap \<Rightarrow> False
+   | PendingSyncSendCap _ _ _ _ _ _ \<Rightarrow> False
+   | PendingSyncRecvCap _ _ _ \<Rightarrow> False
+   | PendingNtfnRecvCap _ \<Rightarrow> False
+   | DomainCap \<Rightarrow> False
+   | BoundNotificationCap _ \<Rightarrow> False
+   | IrqControlCap  \<Rightarrow> False
+   | SGISignalCap _ _ \<Rightarrow> False
+   | AsidControlCap \<Rightarrow> False
+   | IOSpaceMasterCap \<Rightarrow> False
+   | FrameCap _ _ _ _ c _ \<Rightarrow> c = Real
+   | PageTableCap _ _ c _ \<Rightarrow> c = Real
+   | _ \<Rightarrow> True"
 
-definition
-  cdl_cap_irq :: "cdl_cap \<Rightarrow> cdl_irq option" where
- "cdl_cap_irq cap \<equiv> (case cap of IrqHandlerCap irq \<Rightarrow> Some irq | _ \<Rightarrow> None)"
+definition cdl_cap_irq :: "cdl_cap \<Rightarrow> cdl_irq option" where
+  "cdl_cap_irq cap \<equiv> case cap of IrqHandlerCap irq \<Rightarrow> Some irq | _ \<Rightarrow> None"
 
 \<comment> \<open>Some caps don't count when determining if an entity should be deleted or not\<close>
-definition
-  is_final_cap' :: "cdl_cap \<Rightarrow> cdl_state \<Rightarrow> bool" where
- "is_final_cap' cap s \<equiv> ((cap_counts cap) \<and>
-  (\<exists>cref. {cref. \<exists>cap'. opt_cap cref s = Some cap'
-                       \<and> (cap_object cap = cap_object cap'
-                             \<and> cdl_cap_irq cap = cdl_cap_irq cap')
-                       \<and> cap_counts cap'}
-         = {cref}))"
+definition is_final_cap' :: "cdl_cap \<Rightarrow> cdl_state \<Rightarrow> bool" where
+  "is_final_cap' cap s \<equiv>
+     cap_counts cap \<and>
+     (\<exists>cref. {cref. \<exists>cap'. opt_cap cref s = Some cap' \<and>
+                           (cap_object cap = cap_object cap' \<and> cdl_cap_irq cap = cdl_cap_irq cap') \<and>
+                           cap_counts cap'} = {cref})"
 
-
-definition
-  is_final_cap :: "cdl_cap \<Rightarrow> bool k_monad" where
+definition is_final_cap :: "cdl_cap \<Rightarrow> bool k_monad" where
   "is_final_cap cap \<equiv> gets (is_final_cap' cap)"
 
+definition always_empty_slot :: "cdl_cap_ref \<Rightarrow> unit k_monad" where
+  "always_empty_slot slot = do
+     remove_parent slot;
+     set_cap slot NullCap
+   od"
 
-definition
-  always_empty_slot :: "cdl_cap_ref \<Rightarrow> unit k_monad"
-where
- "always_empty_slot slot = do
-    remove_parent slot;
-    set_cap slot NullCap
-  od"
-
-definition
-  empty_slot :: "cdl_cap_ref \<Rightarrow> unit k_monad"
-where
- "empty_slot slot = do
-  cap \<leftarrow> get_cap slot;
-  if cap = NullCap then
-    return ()
-  else do
-    remove_parent slot;
-    set_cap slot NullCap
-    od
-  od"
-
+definition empty_slot :: "cdl_cap_ref \<Rightarrow> unit k_monad"  where
+  "empty_slot slot = do
+     cap \<leftarrow> get_cap slot;
+     if cap = NullCap
+     then return ()
+     else do
+       remove_parent slot;
+       set_cap slot NullCap
+     od
+   od"
 
 text \<open>
- Non-premptable delete.
+  Non-premptable delete.
 
- Should only be used on deletes guaranteed not to preempt
- (and you are happy to prove this). In particular, it is
- useful for deleting caps that exist at the CapDL level
- but not at lower levels.
-\<close>
-definition
-  delete_cap_simple :: "cdl_cap_ref \<Rightarrow> unit k_monad"
-where
+  Should only be used on deletes guaranteed not to preempt (and you are happy to prove this).
+  In particular, it is useful for deleting caps that exist at the CapDL level  but not at lower
+  levels.\<close>
+definition delete_cap_simple :: "cdl_cap_ref \<Rightarrow> unit k_monad" where
   "delete_cap_simple cap_ref \<equiv> do
-    cap \<leftarrow> get_cap cap_ref;
-    unless (cap = NullCap) $ do
-      final \<leftarrow> is_final_cap cap;
-      fast_finalise cap final;
-      always_empty_slot cap_ref
-    od
-  od"
+     cap \<leftarrow> get_cap cap_ref;
+     unless (cap = NullCap) $ do
+       final \<leftarrow> is_final_cap cap;
+       fast_finalise cap final;
+       always_empty_slot cap_ref
+     od
+   od"
 
 
 text \<open>
@@ -244,127 +200,110 @@ text \<open>
   Should only be used on bounded revokes.
    * PageTableUnmap pt_cap_ref
    * PageUnmap frame_cap_ref \<Rightarrow>
-   * revoke_cap_simple (target_tcb, tcb_replycap_slot)
-\<close>
-function
-  revoke_cap_simple :: "cdl_cap_ref \<Rightarrow> unit k_monad"
-where
+   * revoke_cap_simple (target_tcb, tcb_replycap_slot)\<close>
+function revoke_cap_simple :: "cdl_cap_ref \<Rightarrow> unit k_monad" where
   "revoke_cap_simple victim s = (do
-    descendants \<leftarrow> gets $ KHeap_D.descendants_of victim;
-    assert (finite descendants);
-    non_null \<leftarrow> gets (\<lambda>s. {slot. opt_cap slot s \<noteq> Some NullCap \<and> opt_cap slot s \<noteq> None});
-    non_null_descendants \<leftarrow> return (descendants \<inter> non_null);
-    if (non_null_descendants \<noteq> {}) then do
-      a \<leftarrow> select non_null_descendants;
-      delete_cap_simple a;
-      revoke_cap_simple victim
-    od else return ()
-  od) s"
+     descendants \<leftarrow> gets $ descendants_of victim;
+     assert (finite descendants);
+     non_null \<leftarrow> gets (\<lambda>s. {slot. opt_cap slot s \<noteq> Some NullCap \<and> opt_cap slot s \<noteq> None});
+     non_null_descendants \<leftarrow> return (descendants \<inter> non_null);
+     if non_null_descendants \<noteq> {} then do
+       a \<leftarrow> select non_null_descendants;
+       delete_cap_simple a;
+       revoke_cap_simple victim
+     od else return ()
+   od) s"
   by auto
 
-definition cdl_get_pde :: "cdl_cap_ref \<Rightarrow> cdl_cap k_monad"
-where "cdl_get_pde ptr \<equiv>
-  KHeap_D.get_cap ptr"
+definition cdl_get_pde :: "cdl_cap_ref \<Rightarrow> cdl_cap k_monad" where
+  "cdl_get_pde ptr \<equiv> get_cap ptr"
 
-definition cdl_lookup_pd_slot :: "cdl_object_id \<Rightarrow> vptr \<Rightarrow> cdl_cap_ref"
-  where "cdl_lookup_pd_slot pd vptr \<equiv> (pd, unat (vptr >> sectionBits))"
+definition cdl_lookup_pd_slot :: "cdl_object_id \<Rightarrow> vptr \<Rightarrow> cdl_cap_ref" where
+  "cdl_lookup_pd_slot pd vptr \<equiv> (pd, unat (vptr >> sectionBits))"
 
-definition cdl_lookup_pt_slot :: "cdl_object_id \<Rightarrow> vptr \<Rightarrow> cdl_cap_ref except_monad"
-  where "cdl_lookup_pt_slot pd vptr \<equiv>
-    doE pd_slot \<leftarrow> returnOk (cdl_lookup_pd_slot pd vptr);
-        pdcap \<leftarrow> liftE $ cdl_get_pde pd_slot;
-        (case pdcap of cdl_cap.PageTableCap PT ref (Fake _) None
-         \<Rightarrow> ( doE pt \<leftarrow> returnOk ref;
-              pt_index \<leftarrow> returnOk ((vptr >> 12) && pt_slot_vaddr_mask);
-              returnOk (pt,unat pt_index)
-         odE)
-        | _ \<Rightarrow> Monads_D.throw)
-    odE"
+definition cdl_lookup_pt_slot :: "cdl_object_id \<Rightarrow> vptr \<Rightarrow> cdl_cap_ref except_monad" where
+  "cdl_lookup_pt_slot pd vptr \<equiv> doE
+     pd_slot \<leftarrow> returnOk (cdl_lookup_pd_slot pd vptr);
+     pdcap \<leftarrow> liftE $ cdl_get_pde pd_slot;
+     case pdcap of cdl_cap.PageTableCap PT ref (Fake _)
+       None \<Rightarrow> doE pt \<leftarrow> returnOk ref;
+                   pt_index \<leftarrow> returnOk ((vptr >> 12) && pt_slot_vaddr_mask);
+                   returnOk (pt, unat pt_index)
+               odE
+     | _ \<Rightarrow> throw
+   odE"
 
-definition
-  cdl_find_pd_for_asid :: "cdl_mapped_addr \<Rightarrow> cdl_object_id except_monad"
-where
+definition cdl_find_pd_for_asid :: "cdl_mapped_addr \<Rightarrow> cdl_object_id except_monad" where
   "cdl_find_pd_for_asid maddr \<equiv> doE
      asid_table \<leftarrow> liftE $ gets cdl_asid_table;
      asid_pool \<leftarrow> returnOk $ asid_table (fst (fst maddr));
-     pd_cap_ref \<leftarrow>
-       case asid_pool of
-         Some (AsidPoolCap ptr _) \<Rightarrow> returnOk (ptr, (snd \<circ> fst) maddr)
-       | _ \<Rightarrow> throw;
+     pd_cap_ref \<leftarrow> case asid_pool of
+                     Some (AsidPoolCap ptr _) \<Rightarrow> returnOk (ptr, (snd \<circ> fst) maddr)
+                   | _ \<Rightarrow> throw;
      pd_cap \<leftarrow> liftE $ get_cap pd_cap_ref;
      case pd_cap of PageTableCap PD pd _ _ \<Rightarrow> returnOk pd | _ \<Rightarrow> throw
-   odE "
+   odE"
 
 definition cdl_page_mapping_entries ::
   "vptr \<Rightarrow> nat \<Rightarrow> cdl_object_id \<Rightarrow> cdl_cap_ref except_monad"
   where
   "cdl_page_mapping_entries vptr pgsz pd \<equiv>
-   if pgsz = 12 then doE
-     p \<leftarrow> cdl_lookup_pt_slot pd vptr;
-          returnOk p
-   odE
-   else if pgsz = 16 then doE
-     p \<leftarrow> cdl_lookup_pt_slot pd vptr;
-          returnOk p
+     if pgsz = 12 then doE
+       p \<leftarrow> cdl_lookup_pt_slot pd vptr;
+            returnOk p
      odE
-   else if pgsz = sectionBits then doE
-     p \<leftarrow> returnOk $ cdl_lookup_pd_slot pd vptr;
-          returnOk p
-   odE
-   else if pgsz = superSectionBits then doE
-     p \<leftarrow> returnOk $ cdl_lookup_pd_slot pd vptr;
-          returnOk p
-   odE
-   else throw"
+     else if pgsz = 16 then doE
+       p \<leftarrow> cdl_lookup_pt_slot pd vptr;
+            returnOk p
+       odE
+     else if pgsz = sectionBits then doE
+       p \<leftarrow> returnOk $ cdl_lookup_pd_slot pd vptr;
+            returnOk p
+     odE
+     else if pgsz = superSectionBits then doE
+       p \<leftarrow> returnOk $ cdl_lookup_pd_slot pd vptr;
+            returnOk p
+     odE
+     else throw"
 
-definition
-  cdl_page_table_mapped :: "cdl_mapped_addr \<Rightarrow> cdl_object_id \<Rightarrow> (cdl_cap_ref option) k_monad"
-where
+definition cdl_page_table_mapped ::
+  "cdl_mapped_addr \<Rightarrow> cdl_object_id \<Rightarrow> (cdl_cap_ref option) k_monad" where
   "cdl_page_table_mapped maddr pt_id \<equiv> doE
      pd \<leftarrow> cdl_find_pd_for_asid maddr;
      pd_slot \<leftarrow> returnOk (cdl_lookup_pd_slot pd (snd maddr));
      pdcap \<leftarrow> liftE $ cdl_get_pde pd_slot;
-     (case pdcap of
-       cdl_cap.PageTableCap PT ref (Fake _) None \<Rightarrow>
-         (returnOk $ if ref = pt_id then Some pd_slot else None)
-     | _ \<Rightarrow> returnOk None )
-   odE <catch> (K (return None))"
+     case pdcap of
+       PageTableCap PT ref (Fake _) None \<Rightarrow> returnOk $ if ref = pt_id then Some pd_slot else None
+     | _ \<Rightarrow> returnOk None
+   odE <catch> K (return None)"
 
-text \<open>
-  Unmap a frame.
-\<close>
 
-definition
- "might_throw \<equiv> returnOk () \<sqinter> throw"
+text \<open>Unmap a frame.\<close>
 
-definition
-  unmap_page :: "cdl_mapped_addr  \<Rightarrow> cdl_object_id \<Rightarrow> nat \<Rightarrow> unit k_monad"
-where
-  "unmap_page maddr frame_id pgsz \<equiv>
-    doE
-      pd \<leftarrow> cdl_find_pd_for_asid maddr;
-      pslot \<leftarrow> cdl_page_mapping_entries (snd maddr) pgsz pd;
-      might_throw;
-      liftE $ delete_cap_simple pslot;
-      returnOk ()
-    odE <catch> (K $ return ())"
+definition might_throw :: "('a + unit) k_monad" where
+   "might_throw \<equiv> returnOk () \<sqinter> throw"
+
+definition unmap_page :: "cdl_mapped_addr  \<Rightarrow> cdl_object_id \<Rightarrow> nat \<Rightarrow> unit k_monad" where
+  "unmap_page maddr frame_id pgsz \<equiv> doE
+     pd \<leftarrow> cdl_find_pd_for_asid maddr;
+     pslot \<leftarrow> cdl_page_mapping_entries (snd maddr) pgsz pd;
+     might_throw;
+     liftE $ delete_cap_simple pslot;
+     returnOk ()
+   odE <catch> (K $ return ())"
 
 
 text \<open>
   Unmap a page table.
 
-  This hits the same problems as 'unmap_page', so we also
-  non-deterministically choose a bunch of page-tables to unmap.
-\<close>
-definition
-  unmap_page_table  :: "cdl_mapped_addr \<Rightarrow> cdl_object_id  \<Rightarrow> unit k_monad"
-where
-  "unmap_page_table maddr pt_id\<equiv>
-    do
-      pt_slot \<leftarrow> cdl_page_table_mapped maddr pt_id;
-      case pt_slot of (Some slot) \<Rightarrow> delete_cap_simple slot
-      | None \<Rightarrow> return ()
-    od"
-
+  This hits the same problems as 'unmap_page', so we also non-deterministically choose a bunch of
+  page-tables to unmap.\<close>
+definition unmap_page_table  :: "cdl_mapped_addr \<Rightarrow> cdl_object_id  \<Rightarrow> unit k_monad" where
+  "unmap_page_table maddr pt_id \<equiv> do
+     pt_slot \<leftarrow> cdl_page_table_mapped maddr pt_id;
+     case pt_slot of
+       Some slot \<Rightarrow> delete_cap_simple slot
+     | None \<Rightarrow> return ()
+   od"
 
 end

--- a/spec/capDL/PageTable_D.thy
+++ b/spec/capDL/PageTable_D.thy
@@ -4,193 +4,173 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * Operations on page table objects and frames.
- *)
+(* Operations on page table objects and frames. *)
 
 theory PageTable_D
-imports
-  Invocations_D
-  CSpace_D
+  imports
+    Invocations_D
+    CSpace_D
 begin
 
 (* Return the set of all PD/PT slots in the given PD. *)
-definition
-  all_pd_pt_slots :: "cdl_object \<Rightarrow> cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_ref set"
-where
-  "all_pd_pt_slots pd pd_id state \<equiv> {(pd_id, y). y \<in> dom (object_slots pd)}
-     \<union> {(x, y). \<exists> a b c. (object_slots pd) a = Some (PageTableCap PT x b c) \<and> x \<in> dom (cdl_objects state)}"
+definition all_pd_pt_slots :: "cdl_object \<Rightarrow> cdl_object_id \<Rightarrow> cdl_state \<Rightarrow> cdl_cap_ref set" where
+  "all_pd_pt_slots pd pd_id state \<equiv>
+     {(pd_id, y). y \<in> dom (object_slots pd)} \<union>
+     {(x, y). \<exists>a b c. object_slots pd a = Some (PageTableCap PT x b c) \<and>
+                      x \<in> dom (cdl_objects state)}"
 
-definition
-  "cdl_get_pt_mapped_addr cap \<equiv>
-    case cap of PageTableCap _ pid ctype maddr \<Rightarrow>  maddr
-    | _ \<Rightarrow> None"
+definition cdl_get_pt_mapped_addr :: "cdl_cap \<Rightarrow> cdl_mapped_addr option" where
+  "cdl_get_pt_mapped_addr cap \<equiv> case cap of PageTableCap _ pid ctype maddr \<Rightarrow> maddr | _ \<Rightarrow> None"
 
 (* Decode a page table intent into an invocation. *)
-definition
-  decode_page_table_invocation :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow>
-      cdl_page_table_intent \<Rightarrow> cdl_page_table_invocation except_monad"
-where
-  "decode_page_table_invocation target target_ref caps intent \<equiv> case intent of
-    \<comment> \<open>
-      Map the given PageTable into the given PageDirectory at the given
-      virtual address.
+definition decode_page_table_invocation ::
+  "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_page_table_intent \<Rightarrow>
+   cdl_page_table_invocation except_monad"
+  where
+  "decode_page_table_invocation target target_ref caps intent \<equiv>
+     case intent of
+       \<comment> \<open>Map the given PageTable into the given PageDirectory at the given virtual address.
 
-      The concrete implementation only allows a PageTable to be mapped
-      once at any point in time, but we don't enforce that here.
-     \<close>
-    PageTableMapIntent vaddr attr \<Rightarrow>
-      doE
-        case cdl_get_pt_mapped_addr target of Some a \<Rightarrow> throw
-        | None \<Rightarrow> returnOk ();
-        \<comment> \<open>Ensure that a PD was passed in.\<close>
-        pd \<leftarrow> throw_on_none $ get_index caps 0;
-        (pd_object_id, asid) \<leftarrow>
-          case (fst pd) of
-              PageTableCap PD x _ (Some (asid, _)) \<Rightarrow> returnOk (x, asid)
-            | _ \<Rightarrow> throw;
+           The concrete implementation only allows a PageTable to be mapped
+           once at any point in time, but we don't enforce that here.\<close>
+       PageTableMapIntent vaddr attr \<Rightarrow> doE
+         case cdl_get_pt_mapped_addr target of
+           Some a \<Rightarrow> throw
+         | None \<Rightarrow> returnOk ();
+         \<comment> \<open>Ensure that a PD was passed in.\<close>
+         pd \<leftarrow> throw_on_none $ get_index caps 0;
+         (pd_object_id, asid) \<leftarrow> case fst pd of
+                                   PageTableCap PD x _ (Some (asid, _)) \<Rightarrow> returnOk (x, asid)
+                                 | _ \<Rightarrow> throw;
 
-        target_slot \<leftarrow> returnOk $ cdl_lookup_pd_slot pd_object_id vaddr;
+         target_slot \<leftarrow> returnOk $ cdl_lookup_pd_slot pd_object_id vaddr;
 
-        new_attribs \<leftarrow> returnOk $ validate_pt_vm_attributes attr;
+         new_attribs \<leftarrow> returnOk $ validate_pt_vm_attributes attr;
 
-        returnOk $ PageTableMap (PageTableCap PT (cap_object target) Real (Some (asid,vaddr && ~~ mask sectionBits)))
-          (PageTableCap PT (cap_object target) (Fake new_attribs) None) target_ref target_slot
-      odE \<sqinter> throw
-    \<comment> \<open>Unmap this PageTable.\<close>
-    | PageTableUnmapIntent \<Rightarrow> (
-        case target of PageTableCap PT pid ctype maddr \<Rightarrow>
-        (returnOk $ PageTableUnmap maddr pid target_ref)
-        | _ \<Rightarrow> throw
-      ) \<sqinter> throw
-  "
+         returnOk $
+           PageTableMap
+             (PageTableCap PT (cap_object target) Real (Some (asid,vaddr && ~~ mask sectionBits)))
+             (PageTableCap PT (cap_object target) (Fake new_attribs) None) target_ref target_slot
+       odE \<sqinter> throw
+     \<comment> \<open>Unmap this PageTable.\<close>
+     | PageTableUnmapIntent \<Rightarrow>
+        (case target of
+           PageTableCap PT pid ctype maddr \<Rightarrow> returnOk $ PageTableUnmap maddr pid target_ref
+         | _ \<Rightarrow> throw)
+        \<sqinter> throw"
 
 (* Decode a page table intent into an invocation. *)
-definition
-  decode_page_directory_invocation :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow>
-      cdl_page_directory_intent \<Rightarrow> cdl_page_directory_invocation except_monad"
-where
+definition decode_page_directory_invocation ::
+  "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_page_directory_intent \<Rightarrow>
+   cdl_page_directory_invocation except_monad"
+  where
   "decode_page_directory_invocation target target_ref caps intent \<equiv>
-      (returnOk $ PageDirectoryNothing) \<sqinter>
-      (returnOk $ PageDirectoryFlush Unify)  \<sqinter>  (returnOk $ PageDirectoryFlush Clean)  \<sqinter>
-      (returnOk $ PageDirectoryFlush CleanInvalidate )  \<sqinter> (returnOk $ PageDirectoryFlush Invalidate)
-      \<sqinter> throw "
+     returnOk PageDirectoryNothing \<sqinter>
+     returnOk (PageDirectoryFlush Unify) \<sqinter>
+     returnOk (PageDirectoryFlush Clean) \<sqinter>
+     returnOk (PageDirectoryFlush CleanInvalidate) \<sqinter>
+     returnOk (PageDirectoryFlush Invalidate) \<sqinter>
+     throw "
 
 (* Decode a page intent into an invocation. *)
-definition
-  decode_page_invocation :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow>
-      cdl_page_intent \<Rightarrow> cdl_page_invocation except_monad"
-where
-  "decode_page_invocation target target_ref caps intent \<equiv> case intent of
-      \<comment> \<open>
-        Map the given Page into the given PageDirectory or PageTable at
-        the given virtual address.
+definition decode_page_invocation ::
+  "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_page_intent \<Rightarrow>
+   cdl_page_invocation except_monad"
+  where
+  "decode_page_invocation target target_ref caps intent \<equiv>
+     case intent of
+       \<comment> \<open>Map the given Page into the given PageDirectory or PageTable at the given virtual address.
 
-        The concrete implementation only allows a Page to be mapped
-        once at any point in time, but we don't enforce that here.
-       \<close>
-      PageMapIntent vaddr rights attr \<Rightarrow>
-        doE
-          \<comment> \<open>Ensure that a PD was passed in.\<close>
-          pd \<leftarrow> throw_on_none $ get_index caps 0;
-          (pd_object_id, asid) \<leftarrow>
-            case (fst pd) of
-                PageTableCap PD x _ (Some (asid, _)) \<Rightarrow> returnOk (x, asid)
-              | _ \<Rightarrow> throw;
+          The concrete implementation only allows a Page to be mapped once at any point in time,
+          but we don't enforce that here.\<close>
+       PageMapIntent vaddr rights attr \<Rightarrow> doE
+         \<comment> \<open>Ensure that a PD was passed in.\<close>
+         pd \<leftarrow> throw_on_none $ get_index caps 0;
+         (pd_object_id, asid) \<leftarrow> case fst pd of
+                                   PageTableCap PD x _ (Some (asid, _)) \<Rightarrow> returnOk (x, asid)
+                                 | _ \<Rightarrow> throw;
 
-          \<comment> \<open>Collect mapping from target cap.\<close>
-          (frame,sz,dev) \<leftarrow> returnOk $ (case target of FrameCap dev p R sz m mp \<Rightarrow> (p,sz,dev));
+         \<comment> \<open>Collect mapping from target cap.\<close>
+         (frame, sz, dev) \<leftarrow> returnOk (case target of FrameCap dev p R sz m mp \<Rightarrow> (p, sz, dev));
 
-          target_slots \<leftarrow> cdl_page_mapping_entries vaddr sz pd_object_id;
+         target_slots \<leftarrow> cdl_page_mapping_entries vaddr sz pd_object_id;
 
-          \<comment> \<open>Calculate rights.\<close>
-          new_rights \<leftarrow> returnOk $ validate_vm_rights $ cap_rights target \<inter> rights;
+         \<comment> \<open>Calculate rights.\<close>
+         new_rights \<leftarrow> returnOk $ validate_vm_rights $ cap_rights target \<inter> rights;
 
-          \<comment> \<open>Calculate attribs.\<close>
-          new_attribs \<leftarrow> returnOk $ validate_vm_attributes attr (pageForPageBits sz);
+         \<comment> \<open>Calculate attribs.\<close>
+         new_attribs \<leftarrow> returnOk $ validate_vm_attributes attr (pageForPageBits sz);
 
-          \<comment> \<open>Return the map intent.\<close>
-          returnOk $ PageMap (FrameCap dev frame (cap_rights target) sz Real (Some (asid,vaddr)))
-            (FrameCap False frame new_rights sz (Fake new_attribs) None) target_ref target_slots
-        odE \<sqinter> throw
+         \<comment> \<open>Return the map intent.\<close>
+         returnOk $
+           PageMap
+             (FrameCap dev frame (cap_rights target) sz Real (Some (asid,vaddr)))
+             (FrameCap False frame new_rights sz (Fake new_attribs) None) target_ref target_slots
+       odE \<sqinter> throw
 
-    \<comment> \<open>Unmap this PageTable.\<close>
-    | PageUnmapIntent \<Rightarrow> doE
-        (frame, asid, sz) \<leftarrow> (case target of
-           FrameCap _ p R sz m mp \<Rightarrow> returnOk (p, mp , sz)
-        | _ \<Rightarrow> throw);
-      (returnOk $ PageUnmap asid frame target_ref sz) \<sqinter> throw
-      odE
+     \<comment> \<open>Unmap this PageTable.\<close>
+     | PageUnmapIntent \<Rightarrow> doE
+         (frame, asid, sz) \<leftarrow> case target of
+                               FrameCap _ p R sz m mp \<Rightarrow> returnOk (p, mp , sz)
+                             | _ \<Rightarrow> throw;
+         returnOk (PageUnmap asid frame target_ref sz) \<sqinter> throw
+       odE
 
-    \<comment> \<open>Flush the caches associated with this page.\<close>
-    | PageFlushCachesIntent \<Rightarrow>
-       (returnOk $ PageFlushCaches Unify)  \<sqinter>  (returnOk $ PageFlushCaches Clean)  \<sqinter>
-      (returnOk $ PageFlushCaches CleanInvalidate )  \<sqinter> (returnOk $ PageFlushCaches Invalidate)
-      \<sqinter> throw
+     \<comment> \<open>Flush the caches associated with this page.\<close>
+     | PageFlushCachesIntent \<Rightarrow>
+         returnOk (PageFlushCaches Unify) \<sqinter>
+         returnOk (PageFlushCaches Clean) \<sqinter>
+         returnOk (PageFlushCaches CleanInvalidate) \<sqinter>
+         returnOk (PageFlushCaches Invalidate) \<sqinter>
+         throw
 
-    | PageGetAddressIntent \<Rightarrow> returnOk PageGetAddress
-
-  "
+    | PageGetAddressIntent \<Rightarrow> returnOk PageGetAddress"
 
 (* Invoke a page table. *)
-definition
-  invoke_page_directory :: "cdl_page_directory_invocation \<Rightarrow> unit k_monad"
-where
-  "invoke_page_directory params \<equiv> case params of
-      PageDirectoryFlush flush  => return ()
-    | PageDirectoryNothing => return ()
-  "
+definition invoke_page_directory :: "cdl_page_directory_invocation \<Rightarrow> unit k_monad" where
+  "invoke_page_directory params \<equiv> return ()"
 
 (* Invoke a page table. *)
-definition
-  invoke_page_table :: "cdl_page_table_invocation \<Rightarrow> unit k_monad"
-where
-  "invoke_page_table params \<equiv> case params of
-      PageTableMap real_pt_cap pt_cap pt_cap_ref pd_target_slot \<Rightarrow>
-        do set_cap pt_cap_ref real_pt_cap;
-           \<comment> \<open>
-             We install the Page Table into the Page Directory.  The
-             concrete kernel uses hardware-defined PDEs (Page Directory
-             Entries). Our abstract spec just uses caps.
-            \<close>
-           insert_cap_orphan pt_cap pd_target_slot
-        od
+definition invoke_page_table :: "cdl_page_table_invocation \<Rightarrow> unit k_monad" where
+  "invoke_page_table params \<equiv>
+     case params of
+       PageTableMap real_pt_cap pt_cap pt_cap_ref pd_target_slot \<Rightarrow> do
+         set_cap pt_cap_ref real_pt_cap;
+          \<comment> \<open>We install the Page Table into the Page Directory.  The concrete kernel uses
+              hardware-defined Page Directory Entries. capDL just uses caps.\<close>
+          insert_cap_orphan pt_cap pd_target_slot
+       od
     | PageTableUnmap mapped_addr pt_id pt_cap_ref \<Rightarrow> do
-        (case mapped_addr of Some maddr \<Rightarrow> do
-                 unmap_page_table maddr pt_id;
-                 clear_object_caps pt_id \<sqinter> return ()
-               od
-          | _ \<Rightarrow> return ());
+        case mapped_addr of
+          Some maddr \<Rightarrow> do
+            unmap_page_table maddr pt_id;
+            clear_object_caps pt_id \<sqinter> return ()
+          od
+        | _ \<Rightarrow> return ();
         cap \<leftarrow> get_cap pt_cap_ref;
         set_cap pt_cap_ref (reset_mem_mapping cap)
-        od
-
-  "
+      od"
 
 (* Invoke a page. *)
-definition
-  invoke_page :: "cdl_page_invocation \<Rightarrow> unit k_monad"
-where
-  "invoke_page params \<equiv> case params of
-      PageMap frame_cap pseudo_frame_cap frame_cap_ref target_slot \<Rightarrow>
-          \<comment> \<open>Clear out the target slots.\<close>
-        do
-          set_cap frame_cap_ref frame_cap;
-          set_cap target_slot pseudo_frame_cap
-        od
+definition invoke_page :: "cdl_page_invocation \<Rightarrow> unit k_monad" where
+  "invoke_page params \<equiv>
+     case params of
+       PageMap frame_cap pseudo_frame_cap frame_cap_ref target_slot \<Rightarrow> do
+         \<comment> \<open>Clear out the target slots.\<close>
+         set_cap frame_cap_ref frame_cap;
+         set_cap target_slot pseudo_frame_cap
+       od
 
-    | PageUnmap mapped_addr frame_id frame_cap_ref pgsz \<Rightarrow> do
-        (case mapped_addr of
-          Some maddr \<Rightarrow> unmap_page maddr frame_id pgsz
-        | _ \<Rightarrow> return ());
-        cap \<leftarrow> get_cap frame_cap_ref;
-        set_cap frame_cap_ref (reset_mem_mapping cap)
-      od
+     | PageUnmap mapped_addr frame_id frame_cap_ref pgsz \<Rightarrow> do
+         case mapped_addr of
+           Some maddr \<Rightarrow> unmap_page maddr frame_id pgsz
+         | _ \<Rightarrow> return ();
+         cap \<leftarrow> get_cap frame_cap_ref;
+         set_cap frame_cap_ref (reset_mem_mapping cap)
+       od
 
     | PageFlushCaches flush \<Rightarrow> return ()
 
-    | PageGetAddress \<Rightarrow> return ()
-
-  "
+    | PageGetAddress \<Rightarrow> return ()"
 
 end

--- a/spec/capDL/PageTable_D.thy
+++ b/spec/capDL/PageTable_D.thy
@@ -8,7 +8,6 @@
 
 theory PageTable_D
   imports
-    Invocations_D
     CSpace_D
 begin
 

--- a/spec/capDL/Schedule_D.thy
+++ b/spec/capDL/Schedule_D.thy
@@ -5,49 +5,35 @@
  *)
 
 theory Schedule_D
-imports KHeap_D
+  imports KHeap_D
 begin
 
-(*
- * Collect the set of runnable threads in the system.
- *)
-definition
-  all_active_tcbs :: "cdl_state \<Rightarrow> cdl_object_id set"
-where
-  "all_active_tcbs state \<equiv> {x \<in> dom (cdl_objects state).
-      \<exists> a. (cdl_objects state) x = Some (Tcb a)
-          \<and> ( ((cdl_tcb_caps a) tcb_pending_op_slot) = (Some RunningCap) \<or> ((cdl_tcb_caps a) tcb_pending_op_slot) = (Some RestartCap))}"
+(* Collect the set of runnable threads in the system. *)
+definition all_active_tcbs :: "cdl_state \<Rightarrow> cdl_object_id set" where
+  "all_active_tcbs state \<equiv>
+     {x \<in> dom (cdl_objects state). \<exists>a. cdl_objects state x = Some (Tcb a) \<and>
+                                       (cdl_tcb_caps a tcb_pending_op_slot = Some RunningCap \<or>
+                                        cdl_tcb_caps a tcb_pending_op_slot = Some RestartCap)}"
 
-definition
-  active_tcbs_in_domain :: "domain \<Rightarrow> cdl_state \<Rightarrow> cdl_object_id set"
-where
-  "active_tcbs_in_domain domain state  = {x \<in> dom (cdl_objects state).
-      \<exists> a. (cdl_objects state) x = Some (Tcb a)
-          \<and> ( ((cdl_tcb_caps a) tcb_pending_op_slot) = (Some RunningCap) \<or> ((cdl_tcb_caps a) tcb_pending_op_slot) = (Some RestartCap))
-          \<and> cdl_tcb_domain a = domain }"
+definition active_tcbs_in_domain :: "domain \<Rightarrow> cdl_state \<Rightarrow> cdl_object_id set" where
+  "active_tcbs_in_domain domain state \<equiv>
+     {x \<in> dom (cdl_objects state). \<exists>a. cdl_objects state x = Some (Tcb a) \<and>
+                                       (cdl_tcb_caps a tcb_pending_op_slot = Some RunningCap \<or>
+                                        cdl_tcb_caps a tcb_pending_op_slot = Some RestartCap) \<and>
+                                       cdl_tcb_domain a = domain }"
 
-(*
- * Switch to a new thread.
- *)
-definition
-  switch_to_thread :: "cdl_object_id option \<Rightarrow> unit k_monad"
-where
-  "switch_to_thread target \<equiv>
-     modify (\<lambda> t. t\<lparr> cdl_current_thread := target \<rparr>)"
+(* Switch to a new thread. *)
+definition switch_to_thread :: "cdl_object_id option \<Rightarrow> unit k_monad" where
+  "switch_to_thread target \<equiv> modify (\<lambda> t. t\<lparr> cdl_current_thread := target \<rparr>)"
 
-definition
-  change_current_domain :: "unit k_monad"
-where
+definition change_current_domain :: "unit k_monad" where
   "change_current_domain = do
      next_domain \<leftarrow> select UNIV;
-     modify      (\<lambda>s. s\<lparr> cdl_current_domain := next_domain \<rparr>)
+     modify (\<lambda>s. s\<lparr> cdl_current_domain := next_domain \<rparr>)
    od"
-(*
- * Scheduling is fully nondeterministic at this level.
- *)
-definition
-  schedule :: "unit k_monad"
-where
+
+(* Scheduling is fully nondeterministic at this level. *)
+definition schedule :: "unit k_monad" where
   "schedule \<equiv> do
      change_current_domain;
      next_domain \<leftarrow> gets cdl_current_domain;
@@ -59,7 +45,4 @@ where
      switch_to_thread None
    od"
 
-
 end
-
-

--- a/spec/capDL/Structures_D.thy
+++ b/spec/capDL/Structures_D.thy
@@ -5,8 +5,8 @@
  *)
 
 theory Structures_D
-imports
-  Arch_Structs_D
+  imports
+    Arch_Structs_D
 begin
 
 arch_requalify_consts (D)

--- a/spec/capDL/Syscall_D.thy
+++ b/spec/capDL/Syscall_D.thy
@@ -4,62 +4,48 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * System calls
- *)
+(* System calls *)
 
 theory Syscall_D
-imports
-  Schedule_D
-  Decode_D
-  "ExecSpec.Event_H"
+  imports
+    Schedule_D
+    Decode_D
+    ExecSpec.Event_H
 begin
 
-(*
- * Perform system calls.
- *
- * Each system call is broken into three stages:
- *
- *   (1) Cap validation, where we ensure that all caps passed
- *       into the system call are valid;
- *
- *   (2) Argument validation, where we ensure that the requested
- *       operation is valid and permitted; and
- *
- *   (3) Syscall execution, where we carry out the actual
- *       operation.
- *
- * For this function, the user passes us in 5 functions:
- *
- *   (1, 2) A cap validation function, and an error handler;
- *   (3, 4) A argument validation function, and an error handler;
- *   (5)    A syscall execution function.
- *
- * This function returns an item of type "'c", and may also
- * return an exception if operation (3) above was preempted
- * by an interrupt.
- *)
+(* Perform system calls.
 
-definition
-syscall :: "
-  ('a fault_monad) \<Rightarrow> (unit k_monad) \<Rightarrow>
-  ('a \<Rightarrow> 'b except_monad) \<Rightarrow> (unit k_monad) \<Rightarrow>
-  ('b \<Rightarrow> unit preempt_monad) \<Rightarrow> unit preempt_monad"
-where
-  "syscall
-      cap_decoder_fn decode_error_handler_fn
-      arg_decode_fn arg_error_handler_fn
-      perform_syscall_fn \<equiv>
-    cap_decoder_fn
-    <handle>
-      (\<lambda> _. liftE $ decode_error_handler_fn)
-    <else>
-      (\<lambda> a. ((arg_decode_fn a)
-        <handle>
-          (\<lambda> _. liftE $ arg_error_handler_fn)
-        <else>
-          perform_syscall_fn))
-  "
+   Each system call is broken into three stages:
+
+     (1) Cap validation, where we ensure that all caps passed into the system call are valid;
+     (2) Argument validation, where we ensure that the requested operation is valid and permitted;
+         and
+     (3) Syscall execution, where we carry out the actual operation.
+
+   For this function, the user passes us in 5 functions:
+
+     (1, 2) A cap validation function, and an error handler;
+     (3, 4) A argument validation function, and an error handler;
+     (5)    A syscall execution function.
+
+   This function returns an item of type "'c", and may also return an exception if operation (3)
+   above was preempted by an interrupt. *)
+
+definition syscall ::
+  "('a fault_monad) \<Rightarrow> unit k_monad \<Rightarrow> ('a \<Rightarrow> 'b except_monad) \<Rightarrow> unit k_monad \<Rightarrow>
+   ('b \<Rightarrow> unit preempt_monad) \<Rightarrow> unit preempt_monad"
+  where
+  "syscall cap_decoder_fn decode_error_handler_fn arg_decode_fn arg_error_handler_fn
+           perform_syscall_fn \<equiv>
+     cap_decoder_fn
+       <handle>
+         (\<lambda>_. liftE $ decode_error_handler_fn)
+       <else>
+         (\<lambda>a. (arg_decode_fn a
+                <handle>
+                  (\<lambda>_. liftE $ arg_error_handler_fn)
+                <else>
+                  perform_syscall_fn))"
 
 fun perform_invocation :: "bool \<Rightarrow> bool \<Rightarrow> cdl_invocation \<Rightarrow> unit preempt_monad" where
     "perform_invocation is_call can_block (InvokeUntyped untyped_params) =
@@ -96,166 +82,143 @@ fun perform_invocation :: "bool \<Rightarrow> bool \<Rightarrow> cdl_invocation 
   | "perform_invocation is_call can_block (InvokeVCPU vcpu_params) =
        liftE (invoke_vcpu vcpu_params)"
 
-definition ep_related_cap :: "cdl_cap \<Rightarrow> bool"
-where "ep_related_cap cap \<equiv> case cap of
- cdl_cap.EndpointCap o_id badge rights \<Rightarrow> True
-| cdl_cap.NotificationCap o_id badge rights \<Rightarrow> True
-| cdl_cap.ReplyCap o_id rights \<Rightarrow> True
-\<comment> \<open>these are like EP caps in the sense that their syscall has no intent argument or label:\<close>
-| cdl_cap.SGISignalCap irq target \<Rightarrow> True
-| _ \<Rightarrow> False"
+definition ep_related_cap :: "cdl_cap \<Rightarrow> bool" where
+  "ep_related_cap cap \<equiv>
+     case cap of
+       EndpointCap o_id badge rights \<Rightarrow> True
+     | NotificationCap o_id badge rights \<Rightarrow> True
+     | ReplyCap o_id rights \<Rightarrow> True
+     \<comment> \<open>these are like EP caps in the sense that their syscall has no intent argument or label:\<close>
+     | SGISignalCap irq target \<Rightarrow> True
+     | _ \<Rightarrow> False"
 
-definition "has_restart_cap \<equiv> \<lambda>tcb_id. do
-  t \<leftarrow> get_thread tcb_id;
-  return ((cdl_tcb_caps t) tcb_pending_op_slot = Some cdl_cap.RestartCap)
-  od"
+definition has_restart_cap :: "cdl_object_id \<Rightarrow> bool k_monad" where
+  "has_restart_cap \<equiv> \<lambda>tcb_id. do
+     t \<leftarrow> get_thread tcb_id;
+     return (cdl_tcb_caps t tcb_pending_op_slot = Some RestartCap)
+   od"
 
-definition
-  handle_invocation :: "bool \<Rightarrow> bool \<Rightarrow> unit preempt_monad"
-where
-  "handle_invocation is_call can_block \<equiv>
-    doE
-      thread_ptr \<leftarrow> liftE $ gets_the cdl_current_thread;
-      thread \<leftarrow> liftE $ get_thread thread_ptr;
-      full_intent \<leftarrow> returnOk $ cdl_tcb_intent thread;
+definition handle_invocation :: "bool \<Rightarrow> bool \<Rightarrow> unit preempt_monad" where
+  "handle_invocation is_call can_block \<equiv> doE
+     thread_ptr \<leftarrow> liftE $ gets_the cdl_current_thread;
+     thread \<leftarrow> liftE $ get_thread thread_ptr;
+     full_intent \<leftarrow> returnOk $ cdl_tcb_intent thread;
 
-      intent \<leftarrow> returnOk $ cdl_intent_op full_intent;
-      invoked_cptr \<leftarrow> returnOk $ cdl_intent_cap full_intent;
-      extra_cap_cptrs \<leftarrow> returnOk $ cdl_intent_extras full_intent;
+     intent \<leftarrow> returnOk $ cdl_intent_op full_intent;
+     invoked_cptr \<leftarrow> returnOk $ cdl_intent_cap full_intent;
+     extra_cap_cptrs \<leftarrow> returnOk $ cdl_intent_extras full_intent;
 
-      syscall
-        \<comment> \<open>Lookup all caps presented.\<close>
-        (doE
-          (cap, cap_ref) \<leftarrow> lookup_cap_and_slot thread_ptr invoked_cptr;
-          extra_caps \<leftarrow> lookup_extra_caps thread_ptr extra_cap_cptrs;
-          returnOk (cap, cap_ref, extra_caps)
-        odE)
-        \<comment> \<open>If that failed, send off a fault IPC (if we did a blocking operation).\<close>
-        (when can_block $ handle_fault)
+     syscall
+       \<comment> \<open>Lookup all caps presented.\<close>
+       (doE
+         (cap, cap_ref) \<leftarrow> lookup_cap_and_slot thread_ptr invoked_cptr;
+         extra_caps \<leftarrow> lookup_extra_caps thread_ptr extra_cap_cptrs;
+         returnOk (cap, cap_ref, extra_caps)
+       odE)
+       \<comment> \<open>If that failed, send off a fault IPC (if we did a blocking operation).\<close>
+       (when can_block $ handle_fault)
 
-        \<comment> \<open>Decode the user's intent.\<close>
-        (\<lambda> (cap, cap_ref, extra_caps).
+       \<comment> \<open>Decode the user's intent.\<close>
+       (\<lambda>(cap, cap_ref, extra_caps).
           case intent of
-              None \<Rightarrow> (if ep_related_cap cap then
-                decode_invocation cap cap_ref extra_caps undefined
-                else throw)
-            | Some intent' \<Rightarrow>
-                decode_invocation cap cap_ref extra_caps intent')
+            None \<Rightarrow> if ep_related_cap cap
+                    then decode_invocation cap cap_ref extra_caps undefined
+                    else throw
+          | Some intent' \<Rightarrow> decode_invocation cap cap_ref extra_caps intent')
 
-        \<comment> \<open>If that stuffed up, we do nothing more than corrupt the frames.\<close>
-        (do corrupt_ipc_buffer thread_ptr True;
-            when is_call (mark_tcb_intent_error thread_ptr True)
-         od)
+       \<comment> \<open>If that stuffed up, we do nothing more than corrupt the frames.\<close>
+       (do corrupt_ipc_buffer thread_ptr True;
+           when is_call (mark_tcb_intent_error thread_ptr True)
+        od)
 
-        \<comment> \<open>Invoke the system call.\<close>
-        (\<lambda> inv. doE
-            liftE $ set_cap (thread_ptr,tcb_pending_op_slot) RestartCap;
-            perform_invocation is_call can_block inv;
-            restart \<leftarrow> liftE $ has_restart_cap thread_ptr;
-            whenE restart $ liftE (do
-                       corrupt_ipc_buffer thread_ptr True;
-                       when (is_call) (mark_tcb_intent_error thread_ptr False);
-                       set_cap (thread_ptr,tcb_pending_op_slot) RunningCap
-            od)
-            odE)
-  odE
-  "
+       \<comment> \<open>Invoke the system call.\<close>
+       (\<lambda>inv. doE
+          liftE $ set_cap (thread_ptr,tcb_pending_op_slot) RestartCap;
+          perform_invocation is_call can_block inv;
+          restart \<leftarrow> liftE $ has_restart_cap thread_ptr;
+          whenE restart $ liftE (do
+            corrupt_ipc_buffer thread_ptr True;
+            when (is_call) (mark_tcb_intent_error thread_ptr False);
+            set_cap (thread_ptr,tcb_pending_op_slot) RunningCap
+          od)
+        odE)
+  odE"
 
-definition
-  handle_recv :: "unit k_monad"
-where
-  "handle_recv \<equiv>
-    do
-      \<comment> \<open>Get the current thread.\<close>
-      tcb_id \<leftarrow> gets_the cdl_current_thread;
-      tcb \<leftarrow> get_thread tcb_id;
-      \<comment> \<open>Get the endpoint it is trying to receive from.\<close>
-      (doE
-        ep_cptr \<leftarrow> returnOk $ cdl_intent_cap (cdl_tcb_intent tcb);
-        ep_cap \<leftarrow> lookup_cap tcb_id ep_cptr;
-        (case ep_cap of
-          EndpointCap o_id badge rights \<Rightarrow>
-            if Read \<in> rights then
-              (liftE $ do
+definition handle_recv :: "unit k_monad" where
+  "handle_recv \<equiv> do
+     \<comment> \<open>Get the current thread.\<close>
+     tcb_id \<leftarrow> gets_the cdl_current_thread;
+     tcb \<leftarrow> get_thread tcb_id;
+     \<comment> \<open>Get the endpoint it is trying to receive from.\<close>
+     doE
+       ep_cptr \<leftarrow> returnOk $ cdl_intent_cap (cdl_tcb_intent tcb);
+       ep_cap \<leftarrow> lookup_cap tcb_id ep_cptr;
+       case ep_cap of
+         EndpointCap o_id badge rights \<Rightarrow>
+           if Read \<in> rights
+           then (liftE $ do
                    delete_cap_simple (tcb_id, tcb_caller_slot);
                    receive_ipc tcb_id (cap_object ep_cap) (Grant \<in> rights)
-                od) \<sqinter> throw
-            else
-              throw
-        | NotificationCap o_id badge rights \<Rightarrow>
-            if Read \<in> rights then
-              (liftE $ recv_signal tcb_id ep_cap) \<sqinter> throw
-            else
-              throw
-        | _ \<Rightarrow>
-            throw)
-      odE)
-      <catch>
-        (\<lambda> _. handle_fault)
-    od
-  "
+                 od)
+                \<sqinter> throw
+           else throw
+       | NotificationCap o_id badge rights \<Rightarrow>
+           if Read \<in> rights then liftE (recv_signal tcb_id ep_cap) \<sqinter> throw else throw
+       | _ \<Rightarrow> throw
+     odE
+     <catch> (\<lambda> _. handle_fault)
+   od"
 
-definition
-  handle_reply :: "unit k_monad"
-where
-  "handle_reply \<equiv>
-    do
-      tcb_id \<leftarrow> gets_the cdl_current_thread;
-      caller_cap \<leftarrow> get_cap (tcb_id, tcb_caller_slot);
+definition handle_reply :: "unit k_monad" where
+  "handle_reply \<equiv> do
+     tcb_id \<leftarrow> gets_the cdl_current_thread;
+     caller_cap \<leftarrow> get_cap (tcb_id, tcb_caller_slot);
+     case caller_cap of
+       ReplyCap target rights \<Rightarrow>
+         do_reply_transfer tcb_id target (tcb_id, tcb_caller_slot) (Grant \<in> rights)
+     | NullCap \<Rightarrow> return ()
+     | _ \<Rightarrow> fail
+   od"
 
-      case caller_cap of
-          ReplyCap target rights \<Rightarrow> do_reply_transfer tcb_id target (tcb_id, tcb_caller_slot) (Grant \<in> rights)
-        | NullCap \<Rightarrow> return ()
-        | _ \<Rightarrow> fail
-    od
-  "
+definition handle_hypervisor_fault :: "unit k_monad" where
+  "handle_hypervisor_fault \<equiv> return ()"
 
-definition handle_hypervisor_fault :: "unit k_monad"
-where "handle_hypervisor_fault \<equiv> return ()"
-
-definition
-  handle_syscall :: "syscall \<Rightarrow> unit preempt_monad"
-where
+definition handle_syscall :: "syscall \<Rightarrow> unit preempt_monad" where
   "handle_syscall sys \<equiv>
-    case sys of
-      SysSend  \<Rightarrow> handle_invocation False True
-    | SysNBSend \<Rightarrow> handle_invocation False False
-    | SysCall \<Rightarrow> handle_invocation True True
-    | SysRecv \<Rightarrow> liftE $ handle_recv
-    | SysYield \<Rightarrow> returnOk ()
-    | SysReply \<Rightarrow> liftE $ handle_reply
-    | SysReplyRecv \<Rightarrow> liftE $ do
-        handle_reply;
-        handle_recv
-      od
-    | SysNBRecv \<Rightarrow> liftE $ handle_recv"
+     case sys of
+       SysSend  \<Rightarrow> handle_invocation False True
+     | SysNBSend \<Rightarrow> handle_invocation False False
+     | SysCall \<Rightarrow> handle_invocation True True
+     | SysRecv \<Rightarrow> liftE $ handle_recv
+     | SysYield \<Rightarrow> returnOk ()
+     | SysReply \<Rightarrow> liftE $ handle_reply
+     | SysReplyRecv \<Rightarrow> liftE $ do
+         handle_reply;
+         handle_recv
+       od
+     | SysNBRecv \<Rightarrow> liftE $ handle_recv"
 
-definition
-  handle_event :: "event \<Rightarrow> unit preempt_monad"
-where
-  "handle_event ev \<equiv> case ev of
-      SyscallEvent sys \<Rightarrow> handle_syscall sys
-    | UnknownSyscall n \<Rightarrow> liftE $ handle_fault
-    | UserLevelFault a b \<Rightarrow> liftE $ handle_fault
-    | VMFaultEvent c \<Rightarrow> liftE $ handle_fault
-    | Interrupt \<Rightarrow> liftE $ handle_pending_interrupts
-    | HypervisorEvent w \<Rightarrow> liftE $ handle_hypervisor_fault
-    "
+definition handle_event :: "event \<Rightarrow> unit preempt_monad" where
+  "handle_event ev \<equiv>
+     case ev of
+       SyscallEvent sys \<Rightarrow> handle_syscall sys
+     | UnknownSyscall n \<Rightarrow> liftE $ handle_fault
+     | UserLevelFault a b \<Rightarrow> liftE $ handle_fault
+     | VMFaultEvent c \<Rightarrow> liftE $ handle_fault
+     | Interrupt \<Rightarrow> liftE $ handle_pending_interrupts
+     | HypervisorEvent w \<Rightarrow> liftE $ handle_hypervisor_fault"
 
-definition
-  call_kernel :: "event \<Rightarrow> unit k_monad"
-where
-  "call_kernel ev \<equiv>
-    do
-      \<comment> \<open>Deal with the event.\<close>
-      handle_event ev
-        <handle> (\<lambda> _. liftE handle_pending_interrupts);
-      schedule;
-      t \<leftarrow> gets cdl_current_thread;
-      case t of Some thread \<Rightarrow> do
-       restart \<leftarrow> has_restart_cap thread;
-       when restart $ set_cap (thread, tcb_pending_op_slot) RunningCap
-      od | None \<Rightarrow> return ()
-    od"
+definition call_kernel :: "event \<Rightarrow> unit k_monad" where
+  "call_kernel ev \<equiv> do
+     handle_event ev <handle> (\<lambda> _. liftE handle_pending_interrupts);
+     schedule;
+     t \<leftarrow> gets cdl_current_thread;
+     case t of
+       Some thread \<Rightarrow> do
+         restart \<leftarrow> has_restart_cap thread;
+         when restart $ set_cap (thread, tcb_pending_op_slot) RunningCap
+       od
+     | None \<Rightarrow> return ()
+   od"
 
 end

--- a/spec/capDL/Tcb_D.thy
+++ b/spec/capDL/Tcb_D.thy
@@ -4,305 +4,288 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * Operations on thread control blocks.
- *)
+(* Operations on thread control blocks. *)
 
 theory Tcb_D
-imports Invocations_D CSpace_D ExecSpec.Structs_B
+  imports
+    Invocations_D
+    CSpace_D
+    ExecSpec.Structs_B
 begin
 
-definition cdl_update_cnode_cap_data :: "cdl_cap \<Rightarrow> machine_word \<Rightarrow> cdl_cap"
-where "cdl_update_cnode_cap_data cap data  \<equiv>
-  case cap of cdl_cap.CNodeCap oid _ _ sz \<Rightarrow> if data\<noteq>0 then
-    (let reserved_bits = 3; guard_bits = 18; guard_size_bits = 5; new_guard_size = unat ((data >> reserved_bits) && mask guard_size_bits);
-        new_guard =
-          (data >> reserved_bits + guard_size_bits) && mask (min (unat ((data >> reserved_bits) && mask guard_size_bits)) guard_bits)
-    in CNodeCap oid new_guard new_guard_size sz)
-    else cap
-  | _ \<Rightarrow> cap"
+definition cdl_update_cnode_cap_data :: "cdl_cap \<Rightarrow> machine_word \<Rightarrow> cdl_cap" where
+  "cdl_update_cnode_cap_data cap data  \<equiv>
+     case cap of CNodeCap oid _ _ sz \<Rightarrow>
+       if data \<noteq> 0 then
+         let
+           reserved_bits = 3; \<comment> \<open>FIXME: magic numbers\<close>
+           guard_bits = 18;
+           guard_size_bits = 5;
+           new_guard_size = unat ((data >> reserved_bits) && mask guard_size_bits);
+           new_guard = (data >> reserved_bits + guard_size_bits) &&
+                       mask (min (unat ((data >> reserved_bits) && mask guard_size_bits)) guard_bits)
+         in
+           CNodeCap oid new_guard new_guard_size sz
+       else cap
+     | _ \<Rightarrow> cap"
 
-definition cdl_same_arch_obj_as :: "cdl_cap \<Rightarrow> cdl_cap \<Rightarrow> bool"
-where "cdl_same_arch_obj_as capa capb \<equiv>
-  case capa of AsidPoolCap x _ \<Rightarrow> (
-        case capb of AsidPoolCap y _ \<Rightarrow>  y = x
-        | _ \<Rightarrow> False)
-  | AsidControlCap \<Rightarrow> (
-       case capb of AsidControlCap \<Rightarrow> True
-        | _ \<Rightarrow> False)
-  | FrameCap dev ra _ sa _ _ \<Rightarrow> (
-       case capb of FrameCap dev' rb _ sb _ _ \<Rightarrow> rb = ra \<and> sb = sa \<and> dev = dev'
-        | _ \<Rightarrow> False)
-  | cdl_cap.PageTableCap l a _ _ \<Rightarrow> (
-       case capb of cdl_cap.PageTableCap l' b _ _ \<Rightarrow> b = a \<and> l' = l
-        | _ \<Rightarrow> False)
-  | _ \<Rightarrow> False"
+definition cdl_same_arch_obj_as :: "cdl_cap \<Rightarrow> cdl_cap \<Rightarrow> bool" where
+  "cdl_same_arch_obj_as capa capb \<equiv>
+     case capa of
+       AsidPoolCap x _ \<Rightarrow> (case capb of AsidPoolCap y _ \<Rightarrow> y = x | _ \<Rightarrow> False)
+     | AsidControlCap \<Rightarrow> (case capb of AsidControlCap \<Rightarrow> True | _ \<Rightarrow> False)
+     | FrameCap dev ra _ sa _ _ \<Rightarrow>
+         (case capb of FrameCap dev' rb _ sb _ _ \<Rightarrow> rb = ra \<and> sb = sa \<and> dev = dev' | _ \<Rightarrow> False)
+     | PageTableCap l a _ _ \<Rightarrow>
+         (case capb of PageTableCap l' b _ _ \<Rightarrow> b = a \<and> l' = l | _ \<Rightarrow> False)
+     | _ \<Rightarrow> False"
 
-definition
-  decode_tcb_invocation :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow>
-      cdl_tcb_intent \<Rightarrow> cdl_tcb_invocation except_monad"
-where
-  "decode_tcb_invocation target slot caps intent \<equiv> case intent of
-       \<comment> \<open>Read another thread's registers.\<close>
-       TcbReadRegistersIntent suspend flags count \<Rightarrow>
-         returnOk (ReadRegisters (cap_object target) suspend 0 0) \<sqinter> throw
+definition decode_tcb_invocation ::
+  "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_tcb_intent \<Rightarrow>
+   cdl_tcb_invocation except_monad" where
+  "decode_tcb_invocation target slot caps intent \<equiv>
+     case intent of
+        \<comment> \<open>Read another thread's registers.\<close>
+        TcbReadRegistersIntent suspend flags count \<Rightarrow>
+          returnOk (ReadRegisters (cap_object target) suspend 0 0) \<sqinter> throw
 
-       \<comment> \<open>Write another thread's registers.\<close>
-     | TcbWriteRegistersIntent resume flags count regs \<Rightarrow>
-         returnOk (WriteRegisters (cap_object target) resume [0] 0) \<sqinter> throw
+        \<comment> \<open>Write another thread's registers.\<close>
+      | TcbWriteRegistersIntent resume flags count regs \<Rightarrow>
+          returnOk (WriteRegisters (cap_object target) resume [0] 0) \<sqinter> throw
 
-       \<comment> \<open>Copy registers from one thread to another.\<close>
-     | TcbCopyRegistersIntent suspend_source resume_target f1 f2 f3 \<Rightarrow>
-         doE
-           (source_cap, _) \<leftarrow> throw_on_none $ get_index caps 0;
-           source_tcb \<leftarrow> (
-              case source_cap of
-                  TcbCap x \<Rightarrow> returnOk x
-                | _ \<Rightarrow> throw);
-           target_tcb \<leftarrow> returnOk $ cap_object target;
-           returnOk (CopyRegisters target_tcb source_tcb suspend_source resume_target f1 f2 0)
-         odE \<sqinter> throw
-
-       \<comment> \<open>Suspend the target thread.\<close>
-     | TcbSuspendIntent \<Rightarrow>
-         returnOk (Suspend (cap_object target)) \<sqinter> throw
-
-       \<comment> \<open>Resume the target thread.\<close>
-     | TcbResumeIntent \<Rightarrow>
-         returnOk (Resume (cap_object target)) \<sqinter> throw
-
-       \<comment> \<open>Configure: target, fault_ep, mcp, priority, cspace_root_data, vspace_root_data, buffer\<close>
-     | TcbConfigureIntent fault_ep cspace_root_data vspace_root_data buffer \<Rightarrow>
-         doE
-           cspace_root \<leftarrow> throw_on_none $ get_index caps 0;
-           vspace_root \<leftarrow> throw_on_none $ get_index caps 1;
-           buffer_frame \<leftarrow> throw_on_none $ get_index caps 2;
-           cspace_root_cap_ref \<leftarrow> returnOk $ (cdl_update_cnode_cap_data (fst cspace_root) cspace_root_data,snd cspace_root);
-           vspace_root_cap_ref \<leftarrow> returnOk $ vspace_root;
-           buffer_frame_opt \<leftarrow> returnOk $ (if (buffer \<noteq> 0) then Some (reset_mem_mapping (fst buffer_frame), snd buffer_frame) else None);
-           returnOk (ThreadControl (cap_object target) slot (Some fault_ep)
-               (Some cspace_root_cap_ref) (Some vspace_root_cap_ref) (buffer_frame_opt))
-         odE \<sqinter> throw
-
-       \<comment> \<open>Modify a thread's maximum control priority.\<close>
-     | TcbSetMCPriorityIntent mcp \<Rightarrow>
-         doE
-           auth_cap \<leftarrow> throw_on_none $ get_index caps 0;
-           returnOk (ThreadControl (cap_object target) slot None None None None)
-         odE \<sqinter> throw
-
-       \<comment> \<open>Modify a thread's priority.\<close>
-     | TcbSetPriorityIntent priority \<Rightarrow>
-         doE
-           auth_cap \<leftarrow> throw_on_none $ get_index caps 0;
-           returnOk (ThreadControl (cap_object target) slot None None None None)
-         odE \<sqinter> throw
-
-       \<comment> \<open>Modify a thread's mcp and priority at the same time.\<close>
-     | TcbSetSchedParamsIntent mcp priority \<Rightarrow>
-         doE
-           auth_cap \<leftarrow> throw_on_none $ get_index caps 0;
-           returnOk (ThreadControl (cap_object target) slot None None None None)
-         odE \<sqinter> throw
-
-       \<comment> \<open>Modify a thread's IPC buffer.\<close>
-     | TcbSetIPCBufferIntent buffer \<Rightarrow>
-         doE
-           buffer_frame \<leftarrow> throw_on_none $ get_index caps 0;
-           buffer_frame_opt \<leftarrow> returnOk $ (if (buffer \<noteq> 0) then Some (reset_mem_mapping (fst buffer_frame), snd buffer_frame) else None);
-           returnOk (ThreadControl (cap_object target) slot None None None buffer_frame_opt)
-         odE \<sqinter> throw
-
-       \<comment> \<open>Update the various spaces (CSpace/VSpace) of a thread.\<close>
-     | TcbSetSpaceIntent fault_ep cspace_root_data vspace_root_data \<Rightarrow>
-         doE
-           cspace_root \<leftarrow> throw_on_none $ get_index caps 0;
-           vspace_root \<leftarrow> throw_on_none $ get_index caps 1;
-           cspace_root_cap_ref \<leftarrow> returnOk $ (cdl_update_cnode_cap_data (fst cspace_root) cspace_root_data,snd cspace_root);
-           vspace_root_cap_ref \<leftarrow> returnOk $ vspace_root;
-           returnOk (ThreadControl (cap_object target) slot (Some fault_ep)
-               (Some cspace_root_cap_ref) (Some vspace_root_cap_ref) None)
+        \<comment> \<open>Copy registers from one thread to another.\<close>
+      | TcbCopyRegistersIntent suspend_source resume_target f1 f2 f3 \<Rightarrow> doE
+          (source_cap, _) \<leftarrow> throw_on_none $ get_index caps 0;
+          source_tcb \<leftarrow> case source_cap of TcbCap x \<Rightarrow> returnOk x | _ \<Rightarrow> throw;
+          target_tcb \<leftarrow> returnOk $ cap_object target;
+          returnOk (CopyRegisters target_tcb source_tcb suspend_source resume_target f1 f2 0)
         odE \<sqinter> throw
-     | TcbBindNTFNIntent \<Rightarrow> doE
-           (ntfn_cap, _) \<leftarrow> throw_on_none $ get_index caps 0;
-           returnOk (NotificationControl (cap_object target) (Some (cap_object ntfn_cap)))
+
+        \<comment> \<open>Suspend the target thread.\<close>
+      | TcbSuspendIntent \<Rightarrow>
+          returnOk (Suspend (cap_object target)) \<sqinter> throw
+
+        \<comment> \<open>Resume the target thread.\<close>
+      | TcbResumeIntent \<Rightarrow>
+          returnOk (Resume (cap_object target)) \<sqinter> throw
+
+        \<comment> \<open>Configure: target, fault_ep, mcp, priority, cspace_root_data, vspace_root_data, buffer\<close>
+      | TcbConfigureIntent fault_ep cspace_root_data vspace_root_data buffer \<Rightarrow> doE
+          cspace_root \<leftarrow> throw_on_none $ get_index caps 0;
+          vspace_root \<leftarrow> throw_on_none $ get_index caps 1;
+          buffer_frame \<leftarrow> throw_on_none $ get_index caps 2;
+          cspace_root_cap_ref \<leftarrow> returnOk (cdl_update_cnode_cap_data (fst cspace_root)
+                                                                     cspace_root_data,
+                                           snd cspace_root);
+          vspace_root_cap_ref \<leftarrow> returnOk $ vspace_root;
+          buffer_frame_opt \<leftarrow> returnOk (if buffer \<noteq> 0
+                                        then Some (reset_mem_mapping (fst buffer_frame),
+                                                   snd buffer_frame)
+                                        else None);
+          returnOk $ ThreadControl (cap_object target) slot (Some fault_ep)
+                                   (Some cspace_root_cap_ref) (Some vspace_root_cap_ref)
+                                   (buffer_frame_opt)
          odE \<sqinter> throw
-     | TcbUnbindNTFNIntent \<Rightarrow> returnOk (NotificationControl (cap_object target) None) \<sqinter> throw
-     | TcbSetTLSBaseIntent \<Rightarrow> returnOk (SetTLSBase (cap_object target)) \<sqinter> throw
-     | TcbSetFlagsIntent set_flags clear_flags \<Rightarrow>
-         returnOk (SetFlags (cap_object target) (set_flags && tcbFlagMask) (clear_flags && tcbFlagMask)) \<sqinter> throw"
+
+        \<comment> \<open>Modify a thread's maximum control priority.\<close>
+      | TcbSetMCPriorityIntent mcp \<Rightarrow> doE
+          auth_cap \<leftarrow> throw_on_none $ get_index caps 0;
+          returnOk $ ThreadControl (cap_object target) slot None None None None
+        odE \<sqinter> throw
+
+        \<comment> \<open>Modify a thread's priority.\<close>
+      | TcbSetPriorityIntent priority \<Rightarrow> doE
+          auth_cap \<leftarrow> throw_on_none $ get_index caps 0;
+          returnOk $ ThreadControl (cap_object target) slot None None None None
+        odE \<sqinter> throw
+
+        \<comment> \<open>Modify a thread's mcp and priority at the same time.\<close>
+      | TcbSetSchedParamsIntent mcp priority \<Rightarrow> doE
+          auth_cap \<leftarrow> throw_on_none $ get_index caps 0;
+          returnOk $ ThreadControl (cap_object target) slot None None None None
+        odE \<sqinter> throw
+
+        \<comment> \<open>Modify a thread's IPC buffer.\<close>
+      | TcbSetIPCBufferIntent buffer \<Rightarrow> doE
+          buffer_frame \<leftarrow> throw_on_none $ get_index caps 0;
+          buffer_frame_opt \<leftarrow> returnOk (if buffer \<noteq> 0
+                                        then Some (reset_mem_mapping (fst buffer_frame),
+                                                   snd buffer_frame)
+                                        else None);
+          returnOk (ThreadControl (cap_object target) slot None None None buffer_frame_opt)
+        odE \<sqinter> throw
+
+        \<comment> \<open>Update the various spaces (CSpace/VSpace) of a thread.\<close>
+      | TcbSetSpaceIntent fault_ep cspace_root_data vspace_root_data \<Rightarrow> doE
+          cspace_root \<leftarrow> throw_on_none $ get_index caps 0;
+          vspace_root \<leftarrow> throw_on_none $ get_index caps 1;
+          cspace_root_cap_ref \<leftarrow> returnOk (cdl_update_cnode_cap_data (fst cspace_root)
+                                                                     cspace_root_data,
+                                           snd cspace_root);
+          vspace_root_cap_ref \<leftarrow> returnOk $ vspace_root;
+          returnOk $ ThreadControl (cap_object target) slot (Some fault_ep)
+                                   (Some cspace_root_cap_ref) (Some vspace_root_cap_ref) None
+         odE \<sqinter> throw
+      | TcbBindNTFNIntent \<Rightarrow> doE
+          (ntfn_cap, _) \<leftarrow> throw_on_none $ get_index caps 0;
+          returnOk (NotificationControl (cap_object target) (Some (cap_object ntfn_cap)))
+        odE \<sqinter> throw
+      | TcbUnbindNTFNIntent \<Rightarrow> returnOk (NotificationControl (cap_object target) None) \<sqinter> throw
+      | TcbSetTLSBaseIntent \<Rightarrow> returnOk (SetTLSBase (cap_object target)) \<sqinter> throw
+      | TcbSetFlagsIntent set_flags clear_flags \<Rightarrow>
+          returnOk (SetFlags (cap_object target)
+                             (set_flags && tcbFlagMask)
+                             (clear_flags && tcbFlagMask))
+          \<sqinter> throw"
 
 
 (* Delete the given slot of a TCB. *)
-
-definition
-  tcb_empty_thread_slot :: "cdl_object_id \<Rightarrow> cdl_cnode_index \<Rightarrow> unit preempt_monad"
-where
+definition tcb_empty_thread_slot :: "cdl_object_id \<Rightarrow> cdl_cnode_index \<Rightarrow> unit preempt_monad" where
   "tcb_empty_thread_slot target_tcb target_slot \<equiv> doE
-    cap \<leftarrow> liftE $ get_cap (target_tcb,target_slot);
-    whenE (cap \<noteq> NullCap) $
-      delete_cap  (target_tcb, target_slot)
-  odE"
+     cap \<leftarrow> liftE $ get_cap (target_tcb,target_slot);
+     whenE (cap \<noteq> NullCap) $ delete_cap (target_tcb, target_slot)
+   odE"
 
-(* Update the given slot of a TCB with a new cap, delete the previous
- * capability that was in the slot. *)
-
-definition
-  tcb_update_thread_slot :: "cdl_object_id \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cnode_index \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) \<Rightarrow> unit preempt_monad"
-where
-  "tcb_update_thread_slot target_tcb tcb_cap_slot target_slot pcap \<equiv>
-         liftE (do
-           thread_cap \<leftarrow> get_cap tcb_cap_slot;
-           when (thread_cap = TcbCap target_tcb)
-           (insert_cap_child (fst pcap) (snd pcap) (target_tcb, target_slot)
-            \<sqinter> insert_cap_sibling (fst pcap) (snd pcap) (target_tcb,target_slot))
-         od)"
+(* Update the given slot of a TCB with a new cap, delete the previous capability in the slot. *)
+definition tcb_update_thread_slot ::
+  "cdl_object_id \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cnode_index \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) \<Rightarrow> unit preempt_monad"
+  where
+  "tcb_update_thread_slot target_tcb tcb_cap_slot target_slot pcap \<equiv> liftE (do
+     thread_cap \<leftarrow> get_cap tcb_cap_slot;
+     when (thread_cap = TcbCap target_tcb)
+          (insert_cap_child (fst pcap) (snd pcap) (target_tcb, target_slot) \<sqinter>
+           insert_cap_sibling (fst pcap) (snd pcap) (target_tcb,target_slot))
+   od)"
 
 (* Update a thread's CSpace root. *)
-definition
-  tcb_update_cspace_root :: "cdl_object_id \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap \<times> cdl_cap_ref \<Rightarrow> unit preempt_monad"
-where
-  "tcb_update_cspace_root target_tcb tcb_cap_ref croot \<equiv>
-  doE
+definition tcb_update_cspace_root ::
+  "cdl_object_id \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap \<times> cdl_cap_ref \<Rightarrow> unit preempt_monad"
+  where
+  "tcb_update_cspace_root target_tcb tcb_cap_ref croot \<equiv> doE
      tcb_empty_thread_slot target_tcb tcb_cspace_slot;
      src_cap \<leftarrow> liftE $ get_cap (snd croot);
-     whenE (is_cnode_cap src_cap \<and> (cap_object src_cap = cap_object (fst croot)))
-       $ tcb_update_thread_slot target_tcb tcb_cap_ref tcb_cspace_slot croot
-  odE"
+     whenE (is_cnode_cap src_cap \<and> cap_object src_cap = cap_object (fst croot)) $
+       tcb_update_thread_slot target_tcb tcb_cap_ref tcb_cspace_slot croot
+   odE"
 
 (* Update a thread's VSpace root. *)
-definition
-  tcb_update_vspace_root :: "cdl_object_id \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) \<Rightarrow> unit preempt_monad"
-where
-  "tcb_update_vspace_root target_tcb tcb_cap_ref vroot \<equiv>
-  doE
+definition tcb_update_vspace_root ::
+  "cdl_object_id \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) \<Rightarrow> unit preempt_monad"
+  where
+  "tcb_update_vspace_root target_tcb tcb_cap_ref vroot \<equiv> doE
      tcb_empty_thread_slot target_tcb tcb_vspace_slot;
      src_cap \<leftarrow> liftE $ get_cap (snd vroot);
-     whenE (cdl_same_arch_obj_as (fst vroot) src_cap)
-       $ tcb_update_thread_slot target_tcb tcb_cap_ref tcb_vspace_slot vroot
-  odE"
-
-
+     whenE (cdl_same_arch_obj_as (fst vroot) src_cap) $
+       tcb_update_thread_slot target_tcb tcb_cap_ref tcb_vspace_slot vroot
+   odE"
 
 (* Modify the TCB's intent to indicate an error during decode. *)
-definition
-  mark_tcb_intent_error :: "cdl_object_id \<Rightarrow> bool \<Rightarrow> unit k_monad"
-where
+definition mark_tcb_intent_error :: "cdl_object_id \<Rightarrow> bool \<Rightarrow> unit k_monad" where
   "mark_tcb_intent_error target_tcb has_error \<equiv>
-      update_thread target_tcb (\<lambda>t. (t\<lparr>cdl_tcb_intent := (cdl_tcb_intent t)\<lparr>cdl_intent_error := has_error\<rparr>\<rparr>))"
+     update_thread target_tcb
+       (\<lambda>t. (t\<lparr>cdl_tcb_intent := (cdl_tcb_intent t)\<lparr>cdl_intent_error := has_error\<rparr>\<rparr>))"
 
 (* Update a thread's IPC buffer. *)
+definition tcb_update_ipc_buffer ::
+  "cdl_object_id \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) \<Rightarrow> unit preempt_monad"
+  where
+  "tcb_update_ipc_buffer target_tcb tcb_cap_ref ipc_buffer \<equiv> doE
+     tcb_empty_thread_slot target_tcb tcb_ipcbuffer_slot;
+     liftE $ corrupt_tcb_intent target_tcb;
+     src_cap \<leftarrow> liftE $ get_cap (snd ipc_buffer);
+     whenE (cdl_same_arch_obj_as (fst ipc_buffer) src_cap) $
+       tcb_update_thread_slot target_tcb tcb_cap_ref tcb_ipcbuffer_slot ipc_buffer
+   odE"
 
-definition
-  tcb_update_ipc_buffer :: "cdl_object_id \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) \<Rightarrow> unit preempt_monad"
-where
-  "tcb_update_ipc_buffer target_tcb tcb_cap_ref ipc_buffer \<equiv>
-     doE
-       tcb_empty_thread_slot target_tcb tcb_ipcbuffer_slot;
-       liftE $ corrupt_tcb_intent target_tcb;
-       src_cap \<leftarrow> liftE $ get_cap (snd ipc_buffer);
-       whenE (cdl_same_arch_obj_as (fst ipc_buffer) src_cap)
-         $ tcb_update_thread_slot target_tcb tcb_cap_ref tcb_ipcbuffer_slot ipc_buffer
-     odE
-"
+(* Resume a thread, aborting any pending operation, and revoking any incoming reply caps. *)
+definition restart :: "cdl_object_id \<Rightarrow> unit k_monad" where
+  "restart target_tcb \<equiv> do
+     cap \<leftarrow> get_cap (target_tcb, tcb_pending_op_slot);
+     when (cap \<noteq> RestartCap \<and> cap \<noteq> RunningCap) $ do
+       cancel_ipc target_tcb;
+       set_cap (target_tcb, tcb_replycap_slot) (MasterReplyCap target_tcb);
+       set_cap (target_tcb, tcb_pending_op_slot) (RestartCap)
+     od
+   od"
 
-(* Resume a thread, aborting any pending operation, and revoking
- * any incoming reply caps. *)
-definition
-  restart :: "cdl_object_id \<Rightarrow> unit k_monad"
-where
-  "restart target_tcb \<equiv>
-  do
-     cap \<leftarrow> KHeap_D.get_cap (target_tcb,tcb_pending_op_slot);
-     when (cap \<noteq> RestartCap \<and> cap\<noteq> RunningCap)
-     (do
-       CSpace_D.cancel_ipc target_tcb;
-       KHeap_D.set_cap (target_tcb,tcb_replycap_slot) (cdl_cap.MasterReplyCap target_tcb);
-       KHeap_D.set_cap (target_tcb,tcb_pending_op_slot) (cdl_cap.RestartCap)
-      od)
-  od"
+(* Suspend a thread, aborting any pending operation, and revoking any incoming reply caps. *)
+definition suspend :: "cdl_object_id \<Rightarrow> unit k_monad" where
+  "suspend target_tcb \<equiv> do
+     cancel_ipc target_tcb;
+     set_cap (target_tcb, tcb_pending_op_slot) NullCap
+   od"
 
-(* Suspend a thread, aborting any pending operation, and revoking
- * any incoming reply caps. *)
-definition
-  suspend :: "cdl_object_id \<Rightarrow> unit k_monad"
-where
-  "suspend target_tcb \<equiv> CSpace_D.cancel_ipc target_tcb >>= K (KHeap_D.set_cap (target_tcb,tcb_pending_op_slot) cdl_cap.NullCap)"
+definition bind_notification :: "cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> unit k_monad" where
+  "bind_notification tcb_id ntfn_id \<equiv>
+     set_cap (tcb_id, tcb_boundntfn_slot) (BoundNotificationCap ntfn_id)"
 
-definition
-  bind_notification :: "cdl_object_id \<Rightarrow> cdl_object_id \<Rightarrow> unit k_monad"
-where
-  "bind_notification tcb_id ntfn_id \<equiv> set_cap (tcb_id, tcb_boundntfn_slot) (BoundNotificationCap ntfn_id)"
+definition invoke_tcb :: "cdl_tcb_invocation \<Rightarrow> unit preempt_monad" where
+  "invoke_tcb params \<equiv>
+     case params of
+       \<comment> \<open>Modify a thread's registers.\<close>
+       WriteRegisters target_tcb resume _ _ \<Rightarrow>
+         liftE $ do
+           corrupt_tcb_intent target_tcb;
+           when resume $ restart target_tcb
+         od
 
-definition
-  invoke_tcb :: "cdl_tcb_invocation \<Rightarrow> unit preempt_monad"
-where
-  "invoke_tcb params \<equiv> case params of
-    \<comment> \<open>Modify a thread's registers.\<close>
-      WriteRegisters target_tcb resume _ _ \<Rightarrow>
-        liftE $
-        do
-          corrupt_tcb_intent target_tcb;
-          when resume $ restart target_tcb
-        od
+       \<comment> \<open>Read a thread's registers.\<close>
+     | ReadRegisters src_tcb _ _ _ \<Rightarrow>
+         liftE $ suspend src_tcb \<sqinter> return ()
 
-    \<comment> \<open>Read a thread's registers.\<close>
-    | ReadRegisters src_tcb _ _ _ \<Rightarrow>
-        liftE $ suspend src_tcb \<sqinter> return ()
+     \<comment> \<open>Copy registers from one thread to another\<close>
+     | CopyRegisters target_tcb source_tcb _ _ _ _ _ \<Rightarrow>
+         liftE $ do
+           suspend source_tcb \<sqinter> return ();
+           restart target_tcb \<sqinter> return ();
+           corrupt_tcb_intent target_tcb
+         od
 
-    \<comment> \<open>Copy registers from one thread to another\<close>
-    | CopyRegisters target_tcb source_tcb _ _ _ _ _ \<Rightarrow>
-        liftE $
-        do
-          suspend source_tcb \<sqinter> return ();
-          restart target_tcb \<sqinter> return ();
-          corrupt_tcb_intent target_tcb
-       od
+     \<comment> \<open>Suspend this thread.\<close>
+     | Suspend target_tcb \<Rightarrow>
+         liftE $ suspend target_tcb \<sqinter> return ()
 
-    \<comment> \<open>Suspend this thread.\<close>
-    | Suspend target_tcb \<Rightarrow>
-        liftE $ suspend target_tcb \<sqinter> return ()
+     \<comment> \<open>Resume this thread.\<close>
+     | Resume target_tcb \<Rightarrow>
+         liftE $ restart target_tcb
 
-    \<comment> \<open>Resume this thread.\<close>
-    | Resume target_tcb \<Rightarrow>
-        liftE $ restart target_tcb
+     \<comment> \<open>Update a thread's options.\<close>
+     | ThreadControl target_tcb tcb_cap_slot faultep croot vroot ipc_buffer \<Rightarrow> doE
+         case faultep of
+            Some x \<Rightarrow> liftE $ update_thread target_tcb (\<lambda>tcb. tcb\<lparr>cdl_tcb_fault_endpoint := x\<rparr>)
+         | None \<Rightarrow> returnOk ();
 
-    \<comment> \<open>Update a thread's options.\<close>
-    | ThreadControl target_tcb tcb_cap_slot faultep croot vroot ipc_buffer \<Rightarrow>
-        doE
-          case faultep of
-              Some x \<Rightarrow> liftE $ update_thread target_tcb (\<lambda>tcb. tcb\<lparr>cdl_tcb_fault_endpoint := x\<rparr>)
-            | None \<Rightarrow> returnOk ();
+         \<comment> \<open>Possibly update CSpace\<close>
+         case croot of
+           Some x \<Rightarrow> tcb_update_cspace_root target_tcb tcb_cap_slot x
+         | None \<Rightarrow> returnOk ();
 
-          \<comment> \<open>Possibly update CSpace\<close>
-          case croot of
-              Some x \<Rightarrow> tcb_update_cspace_root target_tcb tcb_cap_slot x
-            | None \<Rightarrow> returnOk ();
+         \<comment> \<open>Possibly update VSpace\<close>
+         case vroot of
+           Some x \<Rightarrow> tcb_update_vspace_root target_tcb tcb_cap_slot x
+         | None \<Rightarrow> returnOk ();
 
-          \<comment> \<open>Possibly update VSpace\<close>
-          case vroot of
-              Some x \<Rightarrow> tcb_update_vspace_root target_tcb tcb_cap_slot x
-            | None \<Rightarrow> returnOk ();
-
-          \<comment> \<open>Possibly update Ipc Buffer\<close>
-          case ipc_buffer of
-              Some x \<Rightarrow> tcb_update_ipc_buffer target_tcb tcb_cap_slot x
-            | None \<Rightarrow> (returnOk () \<sqinter> (doE tcb_empty_thread_slot target_tcb tcb_ipcbuffer_slot;
-                 liftE $ corrupt_tcb_intent target_tcb odE))
-        odE
-    | NotificationControl tcb ntfn \<Rightarrow>
-          liftE $ (case ntfn of
-             Some ntfn_id \<Rightarrow> bind_notification tcb ntfn_id
-           | None \<Rightarrow> unbind_notification tcb)
-    | SetTLSBase tcb \<Rightarrow> liftE $ corrupt_tcb_intent tcb
-    | SetFlags tcb set_flags clear_flags \<Rightarrow> liftE $ corrupt_tcb_intent tcb"
+         \<comment> \<open>Possibly update Ipc Buffer\<close>
+         case ipc_buffer of
+           Some x \<Rightarrow> tcb_update_ipc_buffer target_tcb tcb_cap_slot x
+         | None \<Rightarrow> returnOk () \<sqinter>
+                   doE
+                     tcb_empty_thread_slot target_tcb tcb_ipcbuffer_slot;
+                     liftE $ corrupt_tcb_intent target_tcb
+                   odE
+       odE
+     | NotificationControl tcb ntfn \<Rightarrow>
+         liftE (case ntfn of
+                  Some ntfn_id \<Rightarrow> bind_notification tcb ntfn_id
+                | None \<Rightarrow> unbind_notification tcb)
+     | SetTLSBase tcb \<Rightarrow> liftE $ corrupt_tcb_intent tcb
+     | SetFlags tcb set_flags clear_flags \<Rightarrow> liftE $ corrupt_tcb_intent tcb"
 
 
 (* Domain invocations *)
-
-definition
-  decode_domain_invocation :: "(cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_domain_intent \<Rightarrow> cdl_domain_invocation except_monad"
-where
+definition decode_domain_invocation ::
+  "(cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_domain_intent \<Rightarrow> cdl_domain_invocation except_monad"
+  where
   "decode_domain_invocation caps intent \<equiv> case intent of
      DomainSetIntent d \<Rightarrow>
        returnOk (InvokeSetDomain (cap_object (fst (hd caps))) d) \<sqinter> throw
@@ -311,25 +294,17 @@ where
    | DomainScheduleConfigureIntent idx domain duration \<Rightarrow>
        returnOk (InvokeDomainScheduleConfigure idx domain duration) \<sqinter> throw"
 
-definition
-  set_domain :: "cdl_object_id \<Rightarrow> domain \<Rightarrow> unit k_monad"
-where
+definition set_domain :: "cdl_object_id \<Rightarrow> domain \<Rightarrow> unit k_monad" where
   "set_domain tcb d \<equiv> update_thread tcb (\<lambda>t. (t\<lparr>cdl_tcb_domain := d \<rparr>))"
 
-definition
-  dom_schedule_set_start :: "nat \<Rightarrow> unit k_monad"
-where
+definition dom_schedule_set_start :: "nat \<Rightarrow> unit k_monad" where
   "dom_schedule_set_start start \<equiv> modify (\<lambda>s. s\<lparr> cdl_dom_start := start \<rparr>)"
 
-definition
-  dom_schedule_configure :: "nat \<Rightarrow> word8 \<Rightarrow> domain_duration \<Rightarrow> unit k_monad"
-where
+definition dom_schedule_configure :: "nat \<Rightarrow> word8 \<Rightarrow> domain_duration \<Rightarrow> unit k_monad" where
   "dom_schedule_configure idx domain duration \<equiv>
      modify (\<lambda>s. s\<lparr> cdl_dom_schedule := (cdl_dom_schedule s)[idx := (domain, duration)] \<rparr>)"
 
-definition
-  invoke_domain :: "cdl_domain_invocation \<Rightarrow> unit k_monad"
-where
+definition invoke_domain :: "cdl_domain_invocation \<Rightarrow> unit k_monad" where
   "invoke_domain params \<equiv> case params of
      InvokeSetDomain tcb d \<Rightarrow> set_domain tcb d
    | InvokeDomainScheduleSetStart start \<Rightarrow> dom_schedule_set_start start

--- a/spec/capDL/Tcb_D.thy
+++ b/spec/capDL/Tcb_D.thy
@@ -8,7 +8,6 @@
 
 theory Tcb_D
   imports
-    Invocations_D
     CSpace_D
     ExecSpec.Structs_B
 begin

--- a/spec/capDL/Types_D.thy
+++ b/spec/capDL/Types_D.thy
@@ -11,7 +11,6 @@ theory Types_D
     ASpec.VMRights_A
     ASpec.Machine_A
     Intents_D
-    Arch_Structs_D
     Lib.Lib
     Lib.SplitRule
     "HOL-Combinatorics.Transposition" (* for Fun.swap *)

--- a/spec/capDL/Types_D.thy
+++ b/spec/capDL/Types_D.thy
@@ -4,23 +4,18 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * CapDL Types
- *
- * This file introduces many of the high-level types used in this
- * specification.
- *)
+(* High-level types (caps, objects) used in the capDL model *)
 
 theory Types_D
-imports
-  "ASpec.VMRights_A"
-  ASpec.Machine_A
-  Intents_D
-  Arch_Structs_D
-  "Lib.Lib"
-  "Lib.SplitRule"
-  "HOL-Combinatorics.Transposition" (* for Fun.swap *)
-  "ExecSpec.Arch_Kernel_Config_Lemmas"
+  imports
+    ASpec.VMRights_A
+    ASpec.Machine_A
+    Intents_D
+    Arch_Structs_D
+    Lib.Lib
+    Lib.SplitRule
+    "HOL-Combinatorics.Transposition" (* for Fun.swap *)
+    ExecSpec.Arch_Kernel_Config_Lemmas
 begin
 
 arch_requalify_types
@@ -94,9 +89,7 @@ type_synonym cdl_mapped_addr = "cdl_asid \<times> machine_word"
 type_synonym vptr = machine_word
 
 (* Number of bits of a badge we can use. *)
-definition
-  badge_bits :: nat
-where
+definition badge_bits :: nat where
   "badge_bits \<equiv> 28"
 
 (* FrameCaps, PageTableCaps and PageDirectoryCaps can either be
@@ -105,24 +98,19 @@ where
  *)
 datatype cdl_frame_cap_type = Real | Fake cdl_raw_vmattrs
 
-(*
- * Kernel capabilities.
- *
- * Such capabilities (or "caps") give the holder particular rights to
- * a kernel object or system hardware.
- *
- * Caps have attributes such as the object they point to, the rights
- * they give the holder, or how the holder is allowed to interact with
- * the target object.
- *
- * Note that frame and page tables caps (and later objects) are generic in the architecture
- * they model and parameterised in the type of object they represent (e.g. which level of
- * page table object). Level 0 is the bottom level where page table walks end, and max_pt_level
- * is the highest level where the root page table is. The model is essentially the same as in
- * ASpec for AARCH64. See there for more documentation on how it works. capDL generalises levels
- * to nat and page table types to all types that are used by any of the seL4 architectures.
- *)
+(* Kernel capabilities.
 
+   They give the holder particular rights to a kernel object or system hardware.
+
+   Caps have attributes such as the object they point to, the rights they give the holder, or how
+   the holder is allowed to interact with the target object.
+
+   Note that frame and page tables caps (and later objects) are generic in the architecture
+   they model and parameterised in the type of object they represent (e.g. which level of
+   page table object). Level 0 is the bottom level where page table walks end, and max_pt_level
+   is the highest level where the root page table is. The model is essentially the same as in
+   ASpec for AARCH64. See there for more documentation on how it works. capDL generalises levels
+   to nat and page table types to all types that are used by any of the seL4 architectures. *)
 datatype cdl_cap =
     NullCap
 
@@ -136,9 +124,7 @@ datatype cdl_cap =
   | TcbCap cdl_object_id
   | DomainCap
 
-  (*
-   * Capabilities representing threads waiting in endpoint queues.
-   *)
+  (* Capabilities representing threads waiting in endpoint queues. *)
   (* thread, badge, is call, can grant, can grant reply, is fault ipc *)
   | PendingSyncSendCap cdl_object_id cdl_badge bool bool bool bool
   (* thread, is waiting for reply, can grant *)
@@ -191,18 +177,16 @@ datatype cdl_cap =
 
 type_synonym cdl_cap_map = "cdl_cnode_index \<Rightarrow> cdl_cap option"
 
-(*
- * The cap derivation tree (CDT).
- *
- * This tree records how certain caps are derived from others. This
- * information is important because it affects how caps are revoked; if an
- * entity revokes a particular cap, all of the cap's children (as
- * recorded in the CDT) are also revoked.
- *
- * At this point in time, we leave the definition of the CDT quite
- * abstract. This may be made more concrete in the future allowing us to
- * reason about revocation.
- *)
+(* The cap derivation tree (CDT).
+
+   This tree records how certain caps are derived from others. This
+   information is important because it affects how caps are revoked; if an
+   entity revokes a particular cap, all of the cap's children (as
+   recorded in the CDT) are also revoked.
+
+   At this point in time, we leave the definition of the CDT quite
+   abstract. This may be made more concrete in the future allowing us to
+   reason about revocation. *)
 type_synonym cdl_cdt = "cdl_cap_ref \<Rightarrow> cdl_cap_ref option"
 
 translations
@@ -215,8 +199,7 @@ translations
 (* Kernel objects *)
 
 (* Extra data carried in the capDL state that holds no meaning in the proofs,
-   but is required for generating an executable system initialiser
-*)
+   but is required for generating an executable system initialiser *)
 record cdl_tcb_extra =
   cdl_tcb_prio    :: prio
   cdl_tcb_mcp     :: prio
@@ -241,9 +224,8 @@ record cdl_cnode =
 record cdl_asid_pool =
   cdl_asid_pool_caps :: cdl_cap_map
 
-(* Extra "frame fill" data. The executable initialiser requires this
- * so that it can load pages for components. For now, we only support
- * FileData, which is copied from a linked cpio archive. *)
+(* Extra "frame fill" data. The executable initialiser requires this so that it can load pages for
+   components. For now, we only support FileData, which is copied from a linked cpio archive. *)
 record cdl_frame_fill =
   cdl_frame_fill_filename :: string
   cdl_frame_fill_file_offset :: machine_word
@@ -257,12 +239,10 @@ record cdl_frame =
 record cdl_irq_node =
   cdl_irq_node_caps :: cdl_cap_map
 
-(*
- * Kernel objects.
- *
- * These are in-memory objects that may, over the course of the system
- * execution, be created or deleted by users.
- *)
+(* Kernel objects.
+
+   These are in-memory objects that may, over the course of the system execution, be created or
+   deleted by users. *)
 datatype cdl_object =
     Endpoint
   | Notification
@@ -282,45 +262,43 @@ type_synonym cdl_heap = "cdl_object_id \<Rightarrow> cdl_object option"
 translations
   (type) "cdl_heap" <=(type) "32 word \<Rightarrow> cdl_object option"
 
-(*
- * The current state of the system.
- *
- * The state record contains the following primary pieces of information:
- *
- * arch:
- *   The architecture of the system. This affects what capabilities and
- *   kernel objects could possibly be present. In the current kernel
- *   arch will not change at runtime.
- *
- * objects:
- *   The objects that currently exist in the system.
- *
- * cdt:
- *   The cap derivation tree of the system.
- *
- * current_thread:
- *   The currently running thread. Operations will always be performed
- *   on behalf of this thread.
- *
- * irq_node:
- *   Which IRQs are mapped to which notifications.
- *
- * asid_table:
- *   The first level of the asid table, containing capabilities to all
- *   of the ASIDPools.
- *
- * current_domain:
- *   The currently running domain.
- *
- * dom_schedule:
- *   The domain schedule.
- *
- * dom_start:
- *   The start index in cdl_dom_schedule to resume at when the domain end marker is reached.
- *
- * Since scheduling in capDL is fully non-determinist, we do not need to model the current index
- * in the domain schedule.
- *)
+(* The current state of the system.
+
+   The state record contains the following primary pieces of information:
+
+   arch:
+     The architecture of the system. This affects what capabilities and
+     kernel objects could possibly be present. In the current kernel
+     arch will not change at runtime.
+
+   objects:
+     The objects that currently exist in the system.
+
+   cdt:
+     The cap derivation tree of the system.
+
+   current_thread:
+     The currently running thread. Operations will always be performed
+     on behalf of this thread.
+
+   irq_node:
+     Which IRQs are mapped to which notifications.
+
+   asid_table:
+     The first level of the asid table, containing capabilities to all
+     of the ASIDPools.
+
+   current_domain:
+     The currently running domain.
+
+   dom_schedule:
+     The domain schedule.
+
+   dom_start:
+     The start index in cdl_dom_schedule to resume at when the domain end marker is reached.
+
+   Since scheduling in capDL is fully non-deterministic, we do not need to model the current index
+   in the domain schedule. *)
 record cdl_state =
   cdl_arch           :: cdl_arch
   cdl_objects        :: cdl_heap
@@ -333,9 +311,7 @@ record cdl_state =
   cdl_dom_start      :: nat
 
 (* Return the type of an object. *)
-definition
-  object_type :: "cdl_object \<Rightarrow> cdl_object_type"
-where
+definition object_type :: "cdl_object \<Rightarrow> cdl_object_type" where
   "object_type x \<equiv>
     case x of
         Untyped \<Rightarrow> UntypedType
@@ -351,25 +327,19 @@ where
 
 lemmas object_type_simps = object_type_def[split_simps cdl_object.split]
 
-definition
-  asid_high_bits :: nat where
+definition asid_high_bits :: nat where
   "asid_high_bits \<equiv> LENGTH(asid_high_len)"
 
-definition
-  asid_low_bits :: nat where
+definition asid_low_bits :: nat where
   "asid_low_bits \<equiv> LENGTH(asid_low_len)"
 
-definition
-  asid_bits :: nat where
+definition asid_bits :: nat where
   "asid_bits \<equiv> asid_high_bits + asid_low_bits"
 
-(*
- * Each TCB contains a number of cap slots, each with a specific
- * purpose. These constants define the purpose of each slot.
- *
- * The specific list of slots is chosen to be consistent with the output
- * of the CapDL-tool.
- *)
+(* Each TCB contains a number of cap slots, each with a specific purpose. These constants define
+   the purpose of each slot.
+
+   The specific list of slots is chosen to be consistent with the output of the capDL-tool. *)
 definition "tcb_cspace_slot     = (0 :: cdl_cnode_index)"
 definition "tcb_vspace_slot     = (1 :: cdl_cnode_index)"
 definition "tcb_replycap_slot   = (2 :: cdl_cnode_index)"
@@ -379,10 +349,10 @@ definition "tcb_pending_op_slot = (5 :: cdl_cnode_index)"
 definition "tcb_boundntfn_slot  = (8 :: cdl_cnode_index)"
 definition "tcb_boundvcpu_slot  = (9 :: cdl_cnode_index)"
 
-definition
+definition tcb_slots_list :: "cdl_cnode_index list" where
   "tcb_slots_list \<equiv> [0 ..< tcb_pending_op_slot + 1] @ [tcb_boundntfn_slot, tcb_boundvcpu_slot]"
 
-abbreviation
+abbreviation tcb_slots :: "cdl_cnode_index set" where
   "tcb_slots \<equiv> set tcb_slots_list"
 
 lemmas tcb_slots_def = tcb_slots_list_def
@@ -398,15 +368,9 @@ lemmas tcb_slot_defs =
   tcb_boundvcpu_slot_def
   tcb_slots_list_def
 
-(*
- * Getters and setters for various data types.
- *)
+(* Getters and setters for various data types. *)
 
-(* Capability getters / setters *)
-
-fun
-  cap_objects :: "cdl_cap \<Rightarrow> cdl_object_id set"
-where
+fun cap_objects :: "cdl_cap \<Rightarrow> cdl_object_id set" where
     "cap_objects (IOPageTableCap x) = {x}"
   | "cap_objects (IOSpaceCap x) = {x}"
   | "cap_objects (IOPortsCap x _) = {x}"
@@ -419,7 +383,7 @@ where
   | "cap_objects (ReplyCap x _) = {x}"
   | "cap_objects (NotificationCap x _ _) = {x}"
   | "cap_objects (EndpointCap x _ _) = {x}"
-  | "cap_objects (UntypedCap _ x a) = x"
+  | "cap_objects (UntypedCap _ x _) = x"
   | "cap_objects (ZombieCap x) = {x}"
   | "cap_objects (PendingSyncSendCap x _ _ _ _ _) = {x}"
   | "cap_objects (PendingSyncRecvCap x _ _) = {x}"
@@ -428,29 +392,24 @@ where
   | "cap_objects (VCPUCap x) = {x}"
   | "cap_objects _ = {}"
 
-definition
-  cap_has_object :: "cdl_cap \<Rightarrow> bool"
-where
-  "cap_has_object cap \<equiv> case cap of
-     NullCap          \<Rightarrow> False
-  | IrqControlCap     \<Rightarrow> False
-  | IrqHandlerCap _   \<Rightarrow> False
-  | SGISignalCap _ _  \<Rightarrow> False
-  | AsidControlCap    \<Rightarrow> False
-  | IOSpaceMasterCap  \<Rightarrow> False
-  | RestartCap        \<Rightarrow> False
-  | RunningCap        \<Rightarrow> False
-  | DomainCap         \<Rightarrow> False
-  | SMCCap _          \<Rightarrow> False
-  | _                 \<Rightarrow> True"
+definition cap_has_object :: "cdl_cap \<Rightarrow> bool" where
+  "cap_has_object cap \<equiv>
+     case cap of
+       NullCap           \<Rightarrow> False
+     | IrqControlCap     \<Rightarrow> False
+     | IrqHandlerCap _   \<Rightarrow> False
+     | SGISignalCap _ _  \<Rightarrow> False
+     | AsidControlCap    \<Rightarrow> False
+     | IOSpaceMasterCap  \<Rightarrow> False
+     | RestartCap        \<Rightarrow> False
+     | RunningCap        \<Rightarrow> False
+     | DomainCap         \<Rightarrow> False
+     | SMCCap _          \<Rightarrow> False
+     | _                 \<Rightarrow> True"
 
-definition
-  cap_object :: "cdl_cap \<Rightarrow> cdl_object_id"
-where
-  "cap_object cap \<equiv>
-     if cap_has_object cap
-     then (LEAST c. c \<in> cap_objects cap)
-     else undefined"
+(* Untypeds contain a set of cap_objects; return the smallest of these for increased determinism *)
+definition cap_object :: "cdl_cap \<Rightarrow> cdl_object_id" where
+  "cap_object cap \<equiv> if cap_has_object cap then LEAST c. c \<in> cap_objects cap else undefined"
 
 lemma cap_object_simps[simp]:
   "cap_object (IOPageTableCap x) = x"
@@ -475,156 +434,138 @@ lemma cap_object_simps[simp]:
      (metis (full_types) LeastI)+
 
 definition update_cap_badge :: "cdl_badge \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap" where
-  "update_cap_badge x c \<equiv> case c of
-     NotificationCap f1 _ f3 \<Rightarrow> NotificationCap f1 x f3
-   | EndpointCap f1 _ f3     \<Rightarrow> EndpointCap f1 x f3
-   | SMCCap _                \<Rightarrow> SMCCap x
-   | _ \<Rightarrow> c"
+  "update_cap_badge x c \<equiv>
+     case c of
+       NotificationCap f1 _ f3 \<Rightarrow> NotificationCap f1 x f3
+     | EndpointCap f1 _ f3     \<Rightarrow> EndpointCap f1 x f3
+     | SMCCap _                \<Rightarrow> SMCCap x
+     | _ \<Rightarrow> c"
 
 definition all_cdl_rights :: "cdl_right set" where
   "all_cdl_rights = {Read, Write, Grant, GrantReply}"
 
 definition cap_rights :: "cdl_cap \<Rightarrow> cdl_right set" where
-  "cap_rights c \<equiv> case c of
-     FrameCap _ _ _  _ _ _ \<Rightarrow> cdl_cap_rights c
-   | NotificationCap _ _ _ \<Rightarrow> cdl_cap_rights c
-   | EndpointCap _ _ _     \<Rightarrow> cdl_cap_rights c
-   | ReplyCap _ _          \<Rightarrow> cdl_cap_rights c
-   | _ \<Rightarrow> all_cdl_rights"
+  "cap_rights c \<equiv>
+     case c of
+       FrameCap _ _ _  _ _ _ \<Rightarrow> cdl_cap_rights c
+     | NotificationCap _ _ _ \<Rightarrow> cdl_cap_rights c
+     | EndpointCap _ _ _     \<Rightarrow> cdl_cap_rights c
+     | ReplyCap _ _          \<Rightarrow> cdl_cap_rights c
+     | _                     \<Rightarrow> all_cdl_rights"
 
-definition
-  update_cap_rights :: "cdl_right set \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap"
-where
-  "update_cap_rights r c \<equiv> case c of
-      FrameCap dev f1 _ f2 f3 f4 \<Rightarrow> FrameCap dev f1 (validate_vm_rights r) f2 f3 f4
-    | NotificationCap f1 f2 _ \<Rightarrow> NotificationCap f1 f2 (r - {Grant, GrantReply})
-    | EndpointCap f1 f2 _ \<Rightarrow> EndpointCap f1 f2 r
-    | ReplyCap f1 _ \<Rightarrow> ReplyCap f1 (r - {Read, GrantReply} \<union> {Write})
-    | _ \<Rightarrow> c"
+definition update_cap_rights :: "cdl_right set \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap" where
+  "update_cap_rights r c \<equiv>
+     case c of
+       FrameCap dev f1 _ f2 f3 f4 \<Rightarrow> FrameCap dev f1 (validate_vm_rights r) f2 f3 f4
+     | NotificationCap f1 f2 _ \<Rightarrow> NotificationCap f1 f2 (r - {Grant, GrantReply})
+     | EndpointCap f1 f2 _ \<Rightarrow> EndpointCap f1 f2 r
+     | ReplyCap f1 _ \<Rightarrow> ReplyCap f1 (r - {Read, GrantReply} \<union> {Write})
+     | _ \<Rightarrow> c"
 
-definition
-  update_mapping_cap_status :: "cdl_frame_cap_type \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap"
-where
- "update_mapping_cap_status r c \<equiv> case c of
+definition update_mapping_cap_status :: "cdl_frame_cap_type \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap" where
+ "update_mapping_cap_status r c \<equiv>
+    case c of
       FrameCap dev f1 f2 f3 _ f4 \<Rightarrow> FrameCap dev f1 f2 f3 r f4
     | PageTableCap l pt1 _ pt2 \<Rightarrow> PageTableCap l pt1 r pt2
     | _ \<Rightarrow> c"
 
-primrec (nonexhaustive) cap_guard :: "cdl_cap \<Rightarrow> cdl_cap_guard"
-where
+primrec (nonexhaustive) cap_guard :: "cdl_cap \<Rightarrow> cdl_cap_guard" where
   "cap_guard (CNodeCap _ x _ _) = x"
 
-definition
-  update_cap_guard :: "cdl_cap_guard \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap"
-where
-  "update_cap_guard x c \<equiv> case c of
-      CNodeCap f1 _ f3 f4 \<Rightarrow> CNodeCap f1 x f3 f4
-    | _ \<Rightarrow> c"
+definition update_cap_guard :: "cdl_cap_guard \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap" where
+  "update_cap_guard x c \<equiv>
+     case c of
+       CNodeCap f1 _ f3 f4 \<Rightarrow> CNodeCap f1 x f3 f4
+     | _ \<Rightarrow> c"
 
-primrec (nonexhaustive) cap_guard_size :: "cdl_cap \<Rightarrow> cdl_cap_guard_size"
-where
+primrec (nonexhaustive) cap_guard_size :: "cdl_cap \<Rightarrow> cdl_cap_guard_size" where
   "cap_guard_size (CNodeCap _ _ x _ ) = x"
 
-definition
-  cnode_cap_size :: "cdl_cap \<Rightarrow> cdl_size_bits"
-where
-  "cnode_cap_size cap \<equiv> case cap of
-      CNodeCap _ _ _ x \<Rightarrow> x
-    | _ \<Rightarrow> 0"
+definition cnode_cap_size :: "cdl_cap \<Rightarrow> cdl_size_bits" where
+  "cnode_cap_size cap \<equiv>
+     case cap of
+       CNodeCap _ _ _ x \<Rightarrow> x
+     | _ \<Rightarrow> 0"
 
-definition
-  update_cap_guard_size :: "cdl_cap_guard_size \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap"
-where
-  "update_cap_guard_size x c \<equiv> case c of
-      CNodeCap f1 f2 _ f3 \<Rightarrow> CNodeCap f1 f2 x f3
-    | _ \<Rightarrow> c"
+definition update_cap_guard_size :: "cdl_cap_guard_size \<Rightarrow> cdl_cap \<Rightarrow> cdl_cap" where
+  "update_cap_guard_size x c \<equiv>
+     case c of
+       CNodeCap f1 f2 _ f3 \<Rightarrow> CNodeCap f1 f2 x f3
+     | _ \<Rightarrow> c"
 
-definition
-  cap_vmattrs :: "cdl_cap \<Rightarrow> cdl_raw_vmattrs"
-where
-  "cap_vmattrs cap \<equiv> case cap of
-      FrameCap _ _ _ _ (Fake attr) _ \<Rightarrow> attr
-    | PageTableCap _ _ (Fake attr) _ \<Rightarrow> attr"
+definition cap_vmattrs :: "cdl_cap \<Rightarrow> cdl_raw_vmattrs" where
+  "cap_vmattrs cap \<equiv>
+     case cap of
+       FrameCap _ _ _ _ (Fake attr) _ \<Rightarrow> attr
+     | PageTableCap _ _ (Fake attr) _ \<Rightarrow> attr"
 
-definition
-  frame_cap_size :: "cdl_cap \<Rightarrow> cdl_size_bits"
-where
-  "frame_cap_size cap \<equiv> case cap of
-      FrameCap _ _ _ x _ _ \<Rightarrow> x
-    | _ \<Rightarrow> 0"
+definition frame_cap_size :: "cdl_cap \<Rightarrow> cdl_size_bits" where
+  "frame_cap_size cap \<equiv>
+     case cap of
+       FrameCap _ _ _ x _ _ \<Rightarrow> x
+     | _ \<Rightarrow> 0"
 
 (* Kernel object getters / setters *)
-definition
-  object_slots :: "cdl_object \<Rightarrow> cdl_cap_map"
-where
-  "object_slots obj \<equiv> case obj of
-    PageTable _ x \<Rightarrow> x
-  | AsidPool x \<Rightarrow> cdl_asid_pool_caps x
-  | CNode x \<Rightarrow> cdl_cnode_caps x
-  | Tcb x \<Rightarrow> cdl_tcb_caps x
-  | IRQNode x \<Rightarrow> cdl_irq_node_caps x
-  | _ \<Rightarrow> Map.empty"
+definition object_slots :: "cdl_object \<Rightarrow> cdl_cap_map" where
+  "object_slots obj \<equiv>
+     case obj of
+       PageTable _ x \<Rightarrow> x
+     | AsidPool x \<Rightarrow> cdl_asid_pool_caps x
+     | CNode x \<Rightarrow> cdl_cnode_caps x
+     | Tcb x \<Rightarrow> cdl_tcb_caps x
+     | IRQNode x \<Rightarrow> cdl_irq_node_caps x
+     | _ \<Rightarrow> Map.empty"
 
-definition
-  update_slots :: "cdl_cap_map \<Rightarrow> cdl_object \<Rightarrow> cdl_object"
-where
-  "update_slots new_val obj \<equiv> case obj of
-    PageTable l x \<Rightarrow> PageTable l new_val
-  | AsidPool x \<Rightarrow> AsidPool (x\<lparr>cdl_asid_pool_caps := new_val\<rparr>)
-  | CNode x \<Rightarrow> CNode (x\<lparr>cdl_cnode_caps := new_val\<rparr>)
-  | Tcb x \<Rightarrow> Tcb (x\<lparr>cdl_tcb_caps := new_val\<rparr>)
-  | IRQNode x \<Rightarrow> IRQNode (x\<lparr>cdl_irq_node_caps := new_val\<rparr>)
-  | _ \<Rightarrow> obj"
+definition update_slots :: "cdl_cap_map \<Rightarrow> cdl_object \<Rightarrow> cdl_object" where
+  "update_slots new_val obj \<equiv>
+     case obj of
+       PageTable l x \<Rightarrow> PageTable l new_val
+     | AsidPool x \<Rightarrow> AsidPool (x\<lparr>cdl_asid_pool_caps := new_val\<rparr>)
+     | CNode x \<Rightarrow> CNode (x\<lparr>cdl_cnode_caps := new_val\<rparr>)
+     | Tcb x \<Rightarrow> Tcb (x\<lparr>cdl_tcb_caps := new_val\<rparr>)
+     | IRQNode x \<Rightarrow> IRQNode (x\<lparr>cdl_irq_node_caps := new_val\<rparr>)
+     | _ \<Rightarrow> obj"
 
-definition
-  has_slots :: "cdl_object \<Rightarrow> bool"
-where
-  "has_slots obj \<equiv> case obj of
-    PageTable _ _ \<Rightarrow> True
-  | AsidPool _ \<Rightarrow> True
-  | CNode _ \<Rightarrow> True
-  | Tcb _ \<Rightarrow> True
-  | IRQNode _ \<Rightarrow> True
-  | _ \<Rightarrow> False"
+definition has_slots :: "cdl_object \<Rightarrow> bool" where
+  "has_slots obj \<equiv>
+     case obj of
+       PageTable _ _ \<Rightarrow> True
+     | AsidPool _ \<Rightarrow> True
+     | CNode _ \<Rightarrow> True
+     | Tcb _ \<Rightarrow> True
+     | IRQNode _ \<Rightarrow> True
+     | _ \<Rightarrow> False"
 
 
-definition
-  cap_free_ids :: "cdl_cap \<Rightarrow> cdl_object_id set"
-where
-  "cap_free_ids cap \<equiv> (case cap of
-     UntypedCap _ _ free_ids \<Rightarrow> free_ids
-   | _ \<Rightarrow> {})"
+definition cap_free_ids :: "cdl_cap \<Rightarrow> cdl_object_id set" where
+  "cap_free_ids cap \<equiv> case cap of UntypedCap _ _ free_ids \<Rightarrow> free_ids | _ \<Rightarrow> {}"
 
-definition
-  remove_free_ids :: "cdl_cap \<Rightarrow> cdl_object_id set \<Rightarrow> cdl_cap"
-where
-  "remove_free_ids cap obj_ids \<equiv> case cap of
-     UntypedCap dev c a \<Rightarrow> UntypedCap dev c (a - obj_ids)
-   | _ \<Rightarrow> cap"
+definition remove_free_ids :: "cdl_cap \<Rightarrow> cdl_object_id set \<Rightarrow> cdl_cap" where
+  "remove_free_ids cap obj_ids \<equiv>
+     case cap of
+       UntypedCap dev c a \<Rightarrow> UntypedCap dev c (a - obj_ids)
+     | _ \<Rightarrow> cap"
 
-definition cap_irq :: "cdl_cap \<Rightarrow> cdl_irq"
-where
-  "cap_irq cap \<equiv> case cap of
-      IrqHandlerCap x \<Rightarrow> x
-    | _ \<Rightarrow> undefined"
+definition cap_irq :: "cdl_cap \<Rightarrow> cdl_irq" where
+  "cap_irq cap \<equiv> case cap of IrqHandlerCap x \<Rightarrow> x | _ \<Rightarrow> undefined"
 
-(*************
- * Cap types *
- *************)
+
+(* Cap types *)
 
 definition cap_type :: "cdl_cap \<Rightarrow> cdl_object_type option" where
-  "cap_type x \<equiv> case x of
-    UntypedCap _ _ _       \<Rightarrow> Some UntypedType
-  | EndpointCap _ _ _      \<Rightarrow> Some EndpointType
-  | NotificationCap _ _ _  \<Rightarrow> Some NotificationType
-  | TcbCap _               \<Rightarrow> Some TcbType
-  | CNodeCap _ _ _ _       \<Rightarrow> Some CNodeType
-  | AsidPoolCap _ _        \<Rightarrow> Some AsidPoolType
-  | PageTableCap t _ _ _   \<Rightarrow> Some (PageTableType t)
-  | FrameCap _ _ _ f _ _   \<Rightarrow> Some (FrameType f)
-  | IrqHandlerCap _        \<Rightarrow> Some IRQNodeType
-  | VCPUCap _              \<Rightarrow> Some VCPUType
-  | _                      \<Rightarrow> None "
+  "cap_type x \<equiv>
+     case x of
+       UntypedCap _ _ _       \<Rightarrow> Some UntypedType
+     | EndpointCap _ _ _      \<Rightarrow> Some EndpointType
+     | NotificationCap _ _ _  \<Rightarrow> Some NotificationType
+     | TcbCap _               \<Rightarrow> Some TcbType
+     | CNodeCap _ _ _ _       \<Rightarrow> Some CNodeType
+     | AsidPoolCap _ _        \<Rightarrow> Some AsidPoolType
+     | PageTableCap t _ _ _   \<Rightarrow> Some (PageTableType t)
+     | FrameCap _ _ _ f _ _   \<Rightarrow> Some (FrameType f)
+     | IrqHandlerCap _        \<Rightarrow> Some IRQNodeType
+     | VCPUCap _              \<Rightarrow> Some VCPUType
+     | _                      \<Rightarrow> None "
 
 (* FIXME: use datatype discriminators instead *)
 abbreviation "is_untyped_cap cap    \<equiv> cap_type cap = Some UntypedType"
@@ -687,33 +628,25 @@ lemma update_cap_guard_size [simp]:
 
 
 
-definition is_pending_cap :: "cdl_cap \<Rightarrow> bool"
-where "is_pending_cap c \<equiv> case c of
-  PendingSyncRecvCap _ _ _ \<Rightarrow> True
-  | PendingNtfnRecvCap _ \<Rightarrow> True
-  | PendingSyncSendCap _ _ _ _ _ _ \<Rightarrow> True
-  | _ \<Rightarrow> False"
+definition is_pending_cap :: "cdl_cap \<Rightarrow> bool" where
+  "is_pending_cap c \<equiv>
+     case c of
+       PendingSyncRecvCap _ _ _ \<Rightarrow> True
+     | PendingNtfnRecvCap _ \<Rightarrow> True
+     | PendingSyncSendCap _ _ _ _ _ _ \<Rightarrow> True
+     | _ \<Rightarrow> False"
 
 
-(*
- * Object constructors.
- *)
+(* Object constructors *)
 
-(* Create a capability map that contains no caps. *)
-definition
-  empty_cap_map :: "nat \<Rightarrow> cdl_cap_map"
-where
-  "empty_cap_map sz \<equiv> (\<lambda>a. if a < 2^sz then (Some NullCap) else None)"
+(* Create a capability map of specified size that contains no caps. *)
+definition empty_cap_map :: "nat \<Rightarrow> cdl_cap_map" where
+  "empty_cap_map sz \<equiv> \<lambda>a. if a < 2^sz then Some NullCap else None"
 
-(* Create an empty CNode. *)
-definition
-  empty_cnode :: "nat \<Rightarrow> cdl_cnode"
-where
+definition empty_cnode :: "nat \<Rightarrow> cdl_cnode" where
   "empty_cnode sz = \<lparr> cdl_cnode_caps = empty_cap_map sz, cdl_cnode_size_bits = sz \<rparr>"
 
-definition
-  empty_irq_node :: cdl_irq_node
-where
+definition empty_irq_node :: cdl_irq_node where
   "empty_irq_node \<equiv> \<lparr> cdl_irq_node_caps = empty_cap_map 0 \<rparr>"
 
 definition default_tcb_extra_data :: "cdl_tcb_extra" where
@@ -725,26 +658,23 @@ definition default_tcb_extra_data :: "cdl_tcb_extra" where
      cdl_tcb_ipc_buf = 1,
      cdl_tcb_init = [],
      cdl_tcb_flags = 0
-  \<rparr>"
+   \<rparr>"
 
-(* Standard empty TCB object. *)
-definition
-  default_tcb :: "domain \<Rightarrow> cdl_tcb"
-where
+definition default_tcb :: "domain \<Rightarrow> cdl_tcb" where
   "default_tcb current_domain = \<lparr>
-    cdl_tcb_caps = \<lambda>n. if n \<in> tcb_slots then Some NullCap else None,
-    cdl_tcb_fault_endpoint = 0,
-    cdl_tcb_intent = \<lparr>
-      cdl_intent_op = None,
-      cdl_intent_error = False,
-      cdl_intent_cap = 0,
-      cdl_intent_extras = [],
-      cdl_intent_recv_slot = None
-      \<rparr>,
-    cdl_tcb_has_fault = False,
-    cdl_tcb_domain = current_domain,
-    cdl_tcb_extra = default_tcb_extra_data
-    \<rparr>"
+     cdl_tcb_caps = \<lambda>n. if n \<in> tcb_slots then Some NullCap else None,
+     cdl_tcb_fault_endpoint = 0,
+     cdl_tcb_intent = \<lparr>
+       cdl_intent_op = None,
+       cdl_intent_error = False,
+       cdl_intent_cap = 0,
+       cdl_intent_extras = [],
+       cdl_intent_recv_slot = None
+     \<rparr>,
+     cdl_tcb_has_fault = False,
+     cdl_tcb_domain = current_domain,
+     cdl_tcb_extra = default_tcb_extra_data
+   \<rparr>"
 
 definition default_frame_fill_data :: "cdl_frame_fill list" where
   "default_frame_fill_data \<equiv> []"
@@ -764,7 +694,7 @@ definition pt_type_index_bits :: "cdl_pt_type \<Rightarrow> nat" where
      | PDPT   \<Rightarrow> pt_size_index
      | PML4   \<Rightarrow> pt_size_index"
 
-definition
+definition max_pt_level :: "'a::numeral" where
   "max_pt_level \<equiv>
      case cdl_ARCH of
        AARCH32 \<Rightarrow> 1
@@ -800,41 +730,40 @@ abbreviation pt_translation_bits :: "nat \<Rightarrow> nat" where
 lemmas pt_translation_bits_def = pt_type_index_bits_def cdl_level_type_def
 
 (* Return a newly constructed object of the given type. *)
-definition
-  default_object :: "cdl_object_type \<Rightarrow> nat \<Rightarrow> domain \<Rightarrow> cdl_object option"
-where
+definition default_object :: "cdl_object_type \<Rightarrow> nat \<Rightarrow> domain \<Rightarrow> cdl_object option" where
   "default_object ty sz current_domain \<equiv>
-    case ty of
-        UntypedType \<Rightarrow> Some Untyped
-      | EndpointType \<Rightarrow> Some Endpoint
-      | NotificationType \<Rightarrow> Some Notification
-      | TcbType \<Rightarrow> Some (Tcb (default_tcb current_domain))
-      | CNodeType \<Rightarrow> Some (CNode (empty_cnode sz))
-      | AsidPoolType \<Rightarrow> Some (AsidPool \<lparr> cdl_asid_pool_caps = empty_cap_map asid_low_bits \<rparr>)
-      | PageTableType t \<Rightarrow> Some (PageTable t (empty_cap_map (pt_type_index_bits t)))
-      | FrameType sz \<Rightarrow> Some (Frame \<lparr> cdl_frame_size_bits = sz,
-                                      cdl_frame_fills = default_frame_fill_data \<rparr>)
-      | IRQNodeType \<Rightarrow> Some (IRQNode empty_irq_node)
-      | VCPUType \<Rightarrow> Some VCPU"
+     case ty of
+       UntypedType \<Rightarrow> Some Untyped
+     | EndpointType \<Rightarrow> Some Endpoint
+     | NotificationType \<Rightarrow> Some Notification
+     | TcbType \<Rightarrow> Some (Tcb (default_tcb current_domain))
+     | CNodeType \<Rightarrow> Some (CNode (empty_cnode sz))
+     | AsidPoolType \<Rightarrow> Some (AsidPool \<lparr> cdl_asid_pool_caps = empty_cap_map asid_low_bits \<rparr>)
+     | PageTableType t \<Rightarrow> Some (PageTable t (empty_cap_map (pt_type_index_bits t)))
+     | FrameType sz \<Rightarrow> Some (Frame \<lparr> cdl_frame_size_bits = sz,
+                                    cdl_frame_fills = default_frame_fill_data \<rparr>)
+     | IRQNodeType \<Rightarrow> Some (IRQNode empty_irq_node)
+     | VCPUType \<Rightarrow> Some VCPU"
 
 (* FIXME: bad name; also shadows Random.pick *)
-abbreviation "pick S \<equiv> SOME x. x \<in> S"
+abbreviation pick :: "'a set \<Rightarrow> 'a" where
+  "pick S \<equiv> SOME x. x \<in> S"
 
 (* Construct a cap for a new object. *)
-definition
-  default_cap :: "cdl_object_type \<Rightarrow> cdl_object_id set \<Rightarrow> cdl_size_bits \<Rightarrow> bool \<Rightarrow> cdl_cap"
-where
+definition default_cap ::
+  "cdl_object_type \<Rightarrow> cdl_object_id set \<Rightarrow> cdl_size_bits \<Rightarrow> bool \<Rightarrow> cdl_cap"
+  where
   "default_cap t id_set sz dev \<equiv>
-    case t of
-        EndpointType \<Rightarrow> EndpointCap (pick id_set) 0 UNIV
-      | NotificationType \<Rightarrow> NotificationCap (THE i. i \<in> id_set) 0 {Read,Write}
-      | TcbType \<Rightarrow> TcbCap (pick id_set)
-      | CNodeType \<Rightarrow> CNodeCap (pick id_set) 0 0 sz
-      | IRQNodeType \<Rightarrow> IrqHandlerCap undefined
-      | UntypedType \<Rightarrow> UntypedCap dev id_set id_set
-      | AsidPoolType \<Rightarrow> AsidPoolCap (pick id_set) 0
-      | PageTableType l \<Rightarrow> PageTableCap l (pick id_set) Real None
-      | FrameType frame_size \<Rightarrow> FrameCap dev (pick id_set) {Read, Write} frame_size Real None
-      | VCPUType \<Rightarrow> VCPUCap (pick id_set)"
+     case t of
+       EndpointType \<Rightarrow> EndpointCap (pick id_set) 0 UNIV
+     | NotificationType \<Rightarrow> NotificationCap (THE i. i \<in> id_set) 0 {Read,Write}
+     | TcbType \<Rightarrow> TcbCap (pick id_set)
+     | CNodeType \<Rightarrow> CNodeCap (pick id_set) 0 0 sz
+     | IRQNodeType \<Rightarrow> IrqHandlerCap undefined
+     | UntypedType \<Rightarrow> UntypedCap dev id_set id_set
+     | AsidPoolType \<Rightarrow> AsidPoolCap (pick id_set) 0
+     | PageTableType l \<Rightarrow> PageTableCap l (pick id_set) Real None
+     | FrameType frame_size \<Rightarrow> FrameCap dev (pick id_set) {Read, Write} frame_size Real None
+     | VCPUType \<Rightarrow> VCPUCap (pick id_set)"
 
 end

--- a/spec/capDL/Untyped_D.thy
+++ b/spec/capDL/Untyped_D.thy
@@ -4,56 +4,54 @@
  * SPDX-License-Identifier: GPL-2.0-only
  *)
 
-(*
- * Operations on untyped memory objects.
- *)
+(* Operations on untyped memory objects. *)
 
 theory Untyped_D
-imports Invocations_D CSpace_D Structures_D
+  imports
+    Invocations_D
+    CSpace_D
+    Structures_D
 begin
 
-definition
-  decode_untyped_invocation :: "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow>
-      cdl_untyped_intent \<Rightarrow> cdl_untyped_invocation except_monad"
-where
-  "decode_untyped_invocation untyped_cap untyped_ref caps intent \<equiv> case intent of
-     UntypedRetypeIntent type size_bits node_index node_depth node_offset node_window \<Rightarrow>
-       doE
+definition decode_untyped_invocation ::
+  "cdl_cap \<Rightarrow> cdl_cap_ref \<Rightarrow> (cdl_cap \<times> cdl_cap_ref) list \<Rightarrow> cdl_untyped_intent \<Rightarrow>
+   cdl_untyped_invocation except_monad"
+  where
+  "decode_untyped_invocation untyped_cap untyped_ref caps intent \<equiv>
+     case intent of
+       UntypedRetypeIntent type size_bits node_index node_depth node_offset node_window \<Rightarrow> doE
          (root_cap, root_slot) \<leftarrow> throw_on_none $ get_index caps 0;
 
          \<comment> \<open>Lookup the destination slots.\<close>
-         target_node \<leftarrow> if node_depth = 0 then
-             returnOk root_cap
-           else
-             doE
-               target_slot \<leftarrow> lookup_slot_for_cnode_op root_cap node_index (unat node_depth);
-               liftE $ get_cap target_slot
-             odE;
+         target_node \<leftarrow>
+           if node_depth = 0
+           then returnOk root_cap
+           else doE
+             target_slot \<leftarrow> lookup_slot_for_cnode_op root_cap node_index (unat node_depth);
+             liftE $ get_cap target_slot
+           odE;
 
          \<comment> \<open>Ensure it is a CNode cap.\<close>
          unlessE (is_cnode_cap target_node) throw;
 
          \<comment> \<open>Find our target slots.\<close>
          slots \<leftarrow> returnOk $ map (\<lambda>n. (cap_object target_node, n))
-               [unat node_offset ..< unat node_offset + unat node_window];
+                                 [unat node_offset ..< unat node_offset + unat node_window];
          mapME_x ensure_empty slots;
 
-         \<comment> \<open>Work out what names are available. If we haven't haven't already been typed into something we can reuse our names.\<close>
+         \<comment> \<open>Work out what names are available. If we haven't haven't already been typed into
+             something we can reuse our names.\<close>
          s \<leftarrow> liftE $ get;
          has_kids \<leftarrow> returnOk $ has_children untyped_ref s;
 
          returnOk $ Retype untyped_ref type (unat size_bits) slots has_kids (unat node_window)
-       odE \<sqinter> throw"
+       odE
+       \<sqinter> throw"
 
 (* Zero out a set of addresses. *)
-definition
-  detype :: "cdl_object_id set \<Rightarrow> cdl_state \<Rightarrow> cdl_state"
-where
+definition detype :: "cdl_object_id set \<Rightarrow> cdl_state \<Rightarrow> cdl_state" where
   "detype detype_set s \<equiv>
-     (s\<lparr> cdl_objects :=
-         (\<lambda>x. if x \<in> detype_set then
-           Some Untyped
-         else cdl_objects s x)\<rparr>)"
+     s\<lparr>cdl_objects := \<lambda>x. if x \<in> detype_set then Some Untyped else cdl_objects s x\<rparr>"
 
 (* Return a list of num_objects sets for requested the request number of objects;
    if the object type is not UntypedType, the sets contain a singleton ptr for the
@@ -67,35 +65,30 @@ definition generate_range ::
              [0 ..< num_objects]"
 
 definition create_objects :: "(cdl_object_id set) list \<Rightarrow> cdl_object option \<Rightarrow> unit k_monad"
-where
+  where
   "create_objects target_object_ids object \<equiv>
-    (modify (\<lambda>s. s\<lparr>cdl_objects := (\<lambda>x.
-     if {x} \<in> set target_object_ids then
-      object
-     else
-      cdl_objects s x)\<rparr>))"
+     modify (\<lambda>s. s\<lparr>cdl_objects := (\<lambda>x. if {x} \<in> set target_object_ids
+                                       then object
+                                       else cdl_objects s x)\<rparr>)"
 
 
 (* Insert a cap for a new object in the given location. *)
-definition
-  create_cap :: "cdl_object_type \<Rightarrow> nat \<Rightarrow> cdl_cap_ref \<Rightarrow> bool \<Rightarrow> (cdl_cap_ref \<times> cdl_object_id set) \<Rightarrow> unit k_monad"
-where
-  "create_cap new_type sz parent_slot dev \<equiv> \<lambda>(dest_slot, obj_refs).
-  do
-    old_cap \<leftarrow> get_cap dest_slot;
-    assert (old_cap = NullCap);
-    set_cap dest_slot (default_cap new_type obj_refs sz dev);
-    set_parent dest_slot parent_slot
-  od"
+definition create_cap ::
+  "cdl_object_type \<Rightarrow> nat \<Rightarrow> cdl_cap_ref \<Rightarrow> bool \<Rightarrow> (cdl_cap_ref \<times> cdl_object_id set) \<Rightarrow> unit k_monad"
+  where
+  "create_cap new_type sz parent_slot dev \<equiv> \<lambda>(dest_slot, obj_refs). do
+     old_cap \<leftarrow> get_cap dest_slot;
+     assert (old_cap = NullCap);
+     set_cap dest_slot (default_cap new_type obj_refs sz dev);
+     set_parent dest_slot parent_slot
+   od"
 
 (* This returns the set of unused ptrs while explicitly checking for overflow *)
 definition update_range :: "cdl_object_id set \<Rightarrow> cdl_object_id \<Rightarrow> nat \<Rightarrow> cdl_object_id set" where
   "update_range old_range ptr idx \<equiv>
      if idx = 0
      then old_range
-     else if (ptr \<le> ptr + of_nat idx)
-       then old_range - {..<ptr + of_nat idx}
-       else {}"
+     else if ptr \<le> ptr + of_nat idx then old_range - {..<ptr + of_nat idx} else {}"
 
 definition update_available_range ::
   "cdl_object_id \<Rightarrow> nat \<Rightarrow> cdl_cap_ref \<Rightarrow> cdl_cap \<Rightarrow> unit k_monad"
@@ -108,44 +101,33 @@ definition update_available_range ::
 definition retype_region ::
   "nat \<Rightarrow> cdl_object_type \<Rightarrow> (cdl_object_id set list) \<Rightarrow> ((cdl_object_id set) list) k_monad"
   where
-  "retype_region target_bits target_type target_object_ids \<equiv>
-    do
-      \<comment> \<open>Get a list of target locations. We are happy with any unused name
-         within the target range.\<close>
+  "retype_region target_bits target_type target_object_ids \<equiv> do
+     if target_type \<noteq> UntypedType
+     then do
+       current_domain \<leftarrow> gets cdl_current_domain;
+       create_objects target_object_ids (default_object target_type target_bits current_domain)
+     od
+     else return ();
 
-      if (target_type \<noteq> UntypedType) then
-       do
-         current_domain \<leftarrow> gets cdl_current_domain;
-         create_objects target_object_ids (default_object target_type target_bits current_domain)
-       od
-      else return ();
+     return target_object_ids
+   od"
 
-      \<comment> \<open>Get a list of target locations. We are happy with any unused name
-         within the target range.\<close>
-      return target_object_ids
-    od"
+primrec (nonexhaustive) untyped_is_device :: "cdl_cap \<Rightarrow> bool" where
+  "untyped_is_device (UntypedCap d _ _) = d"
 
-primrec (nonexhaustive)
-  untyped_is_device :: "cdl_cap \<Rightarrow> bool"
-where
-    "untyped_is_device (UntypedCap d _ _) = d"
-
-definition
-  reset_untyped_cap :: "cdl_cap_ref \<Rightarrow> unit preempt_monad"
-where
+definition reset_untyped_cap :: "cdl_cap_ref \<Rightarrow> unit preempt_monad" where
   "reset_untyped_cap cref \<equiv> doE
-    cap \<leftarrow> liftE $ get_cap cref;
-    whenE (available_range cap \<noteq> cap_objects cap) $ doE
-      liftE $ modify (detype (cap_objects cap));
-      new_rans \<leftarrow> liftE $ select {xs. (\<forall>S \<in> set xs.
-              S \<subseteq> cap_objects cap \<and> available_range cap \<subset> S)
-          \<and> xs \<noteq> [] \<and> List.last xs = cap_objects cap};
-      mapME_x (\<lambda>r. doE
-        liftE $ set_cap cref $ set_available_range cap r;
-        returnOk () \<sqinter> throw
-      odE) new_rans
-    odE
-  odE"
+     cap \<leftarrow> liftE $ get_cap cref;
+     whenE (available_range cap \<noteq> cap_objects cap) $ doE
+       liftE $ modify (detype (cap_objects cap));
+       new_rans \<leftarrow> liftE $ select {xs. (\<forall>S \<in> set xs. S \<subseteq> cap_objects cap \<and> available_range cap \<subset> S)
+                                       \<and> xs \<noteq> [] \<and> List.last xs = cap_objects cap};
+       mapME_x (\<lambda>r. doE
+         liftE $ set_cap cref $ set_available_range cap r;
+         returnOk () \<sqinter> throw
+       odE) new_rans
+     odE
+   odE"
 
 definition pte_bits :: nat where
   "pte_bits \<equiv> if word_bits = 32 then 2 else 3"
@@ -174,42 +156,43 @@ definition keep_if :: "('a \<Rightarrow> bool) \<Rightarrow> 'a \<Rightarrow> 'a
 abbreviation min_of_range :: "'a set \<Rightarrow> 'a set \<Rightarrow> 'a::linorder" where
   "min_of_range r1 r2 \<equiv> Min (keep_if ((\<noteq>) {}) r1 r2)"
 
-definition
-  invoke_untyped :: "cdl_untyped_invocation \<Rightarrow> unit preempt_monad"
-where
-  "invoke_untyped params \<equiv> case params of
-     Retype untyped_ref new_type type_size target_slots has_kids num_objects \<Rightarrow>
-   doE
-     unlessE has_kids $ reset_untyped_cap untyped_ref;
-       liftE $ do
-         untyped_cap  \<leftarrow> get_cap untyped_ref;
+definition invoke_untyped :: "cdl_untyped_invocation \<Rightarrow> unit preempt_monad" where
+  "invoke_untyped params \<equiv>
+     case params of
+       Retype untyped_ref new_type type_size target_slots has_kids num_objects \<Rightarrow> doE
+         unlessE has_kids $ reset_untyped_cap untyped_ref;
+         liftE $ do
+           untyped_cap \<leftarrow> get_cap untyped_ref;
 
-         base_ptr     \<leftarrow> return $ Min (untyped_cap_range untyped_cap);
+           base_ptr \<leftarrow> return $ Min (untyped_cap_range untyped_cap);
 
-         \<comment> \<open>If we have overflow, then the available range will be empty,
-            but the index is considered to have wrapped back around to zero.\<close>
-         next_ptr     \<leftarrow> return $ min_of_range (available_range untyped_cap)
-                                               (untyped_cap_range untyped_cap);
+           \<comment> \<open>If we have overflow, then the available range will be empty,
+              but the index is considered to have wrapped back around to zero.\<close>
+           next_ptr \<leftarrow> return $ min_of_range (available_range untyped_cap)
+                                             (untyped_cap_range untyped_cap);
 
-         \<comment> \<open> Check if the ptr needs aligning \<close>
-         aligned_ptr  \<leftarrow> return $ if has_kids then alignUp next_ptr (obj_bits_cdl new_type type_size) else next_ptr;
+           \<comment> \<open> Check if the ptr needs aligning \<close>
+           aligned_ptr \<leftarrow> return $ if has_kids
+                                   then alignUp next_ptr (obj_bits_cdl new_type type_size)
+                                   else next_ptr;
 
-         new_obj_refs \<leftarrow> return $ generate_range (aligned_ptr) new_type (obj_bits_cdl new_type type_size) num_objects;
-         new_idx      \<leftarrow> return $ aligned_ptr + (of_nat num_objects << (obj_bits_cdl new_type type_size)) - base_ptr;
+           new_obj_refs \<leftarrow> return $ generate_range (aligned_ptr) new_type
+                                                   (obj_bits_cdl new_type type_size) num_objects;
+           new_idx      \<leftarrow> return $ aligned_ptr
+                                    + (of_nat num_objects << (obj_bits_cdl new_type type_size))
+                                    - base_ptr;
 
-         update_available_range base_ptr (unat (new_idx)) untyped_ref untyped_cap;
+           update_available_range base_ptr (unat (new_idx)) untyped_ref untyped_cap;
 
-         \<comment> \<open>Construct new objects within the covered range.\<close>
-         retype_region type_size new_type new_obj_refs;
+           \<comment> \<open>Construct new objects within the covered range.\<close>
+           retype_region type_size new_type new_obj_refs;
 
-         \<comment> \<open>Construct caps for the new objects.\<close>
-         mapM_x (create_cap new_type type_size untyped_ref (untyped_is_device untyped_cap)) (zip target_slots new_obj_refs);
+           \<comment> \<open>Construct caps for the new objects.\<close>
+           mapM_x (create_cap new_type type_size untyped_ref (untyped_is_device untyped_cap))
+                  (zip target_slots new_obj_refs);
 
-         \<comment> \<open>Ideally, we should return back to the user how many
-            objects were created.\<close>
-
-         return ()
-       od
-    odE"
+           return ()
+         od
+       odE"
 
 end

--- a/spec/capDL/Untyped_D.thy
+++ b/spec/capDL/Untyped_D.thy
@@ -8,9 +8,7 @@
 
 theory Untyped_D
   imports
-    Invocations_D
     CSpace_D
-    Structures_D
 begin
 
 definition decode_untyped_invocation ::

--- a/spec/capDL/VMAttributes_D.thy
+++ b/spec/capDL/VMAttributes_D.thy
@@ -7,8 +7,8 @@
 (* Abstract model of VM attributes. *)
 
 theory VMAttributes_D
-imports
-  ArchVMAttributes_D
+  imports
+    ArchVMAttributes_D
 begin
 
 arch_requalify_types (A)


### PR DESCRIPTION
Restyle capDL spec according to current style guide.

- definition/function style
- indentation
- parentheses
- comment style
- minor adjustments to comment contents
- some (rare) changes might affect proofs:
  - changes to some bound names
  - removal/addition of $
  - change of = into ==
- no other content changes, in particular no change of if/case into when/maybeM or other monad idioms or other things that could be expressed much more nicely than they are. 

In a separate commit:
- remove imports that are already included transitively by other imports.

- very minor proof fixup in DRefine

Main problem is how to review this one. The diff is probably terrible. I might be best to open up the branch in Isabelle and look at the finished files if they are now in style.