### PR TITLE
spec+proofs: consolidate maxIRQ definition in Platform.thy

### DIFF
--- a/proof/crefine/AARCH64/ArchMove_C.thy
+++ b/proof/crefine/AARCH64/ArchMove_C.thy
@@ -10,6 +10,10 @@ theory ArchMove_C
 imports Move_C
 begin
 
+(* FIXME arch-split: CRefine was before Kernel_Config.maxIRQ was wrapped in Platform.maxIRQ_def *)
+arch_requalify_facts maxIRQ_def
+declare maxIRQ_def[simp]
+
 lemma aligned_no_overflow_less: (* FIXME AARCH64: move to Word_Lib *)
   "\<lbrakk> is_aligned p n; p + 2 ^ n \<noteq> 0 \<rbrakk> \<Longrightarrow> p < p + 2 ^ n"
   by (erule word_leq_minus_one_le) (erule is_aligned_no_overflow)

--- a/proof/crefine/ARM/ArchMove_C.thy
+++ b/proof/crefine/ARM/ArchMove_C.thy
@@ -12,6 +12,10 @@ theory ArchMove_C
 imports Move_C
 begin
 
+(* FIXME arch-split: CRefine was before Kernel_Config.maxIRQ was wrapped in Platform.maxIRQ_def *)
+arch_requalify_facts maxIRQ_def
+declare maxIRQ_def[simp]
+
 lemma ps_clear_is_aligned_ksPSpace_None:
   "\<lbrakk>ps_clear p n s; is_aligned p n; 0<d; d \<le> mask n\<rbrakk>
    \<Longrightarrow> ksPSpace s (p + d) = None"

--- a/proof/crefine/ARM/Refine_C.thy
+++ b/proof/crefine/ARM/Refine_C.thy
@@ -72,7 +72,7 @@ lemma checkInterrupt_ccorres:
     apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> Kernel_Config.maxIRQ)"
                     in hoare_post_imp)
      apply (solves clarsimp)
-    apply (wpsimp wp: getActiveIRQ_le_maxIRQ)
+    apply (wpsimp wp: getActiveIRQ_le_maxIRQ[simplified])
     apply assumption
    apply assumption
   apply (clarsimp simp: invs'_def valid_state'_def)

--- a/proof/crefine/ARM_HYP/ArchMove_C.thy
+++ b/proof/crefine/ARM_HYP/ArchMove_C.thy
@@ -12,6 +12,10 @@ theory ArchMove_C
 imports Move_C
 begin
 
+(* FIXME arch-split: CRefine was before Kernel_Config.maxIRQ was wrapped in Platform.maxIRQ_def *)
+arch_requalify_facts maxIRQ_def
+declare maxIRQ_def[simp]
+
 (* FIXME move: need a theory on top of CSpec that arches can share *)
 (* word size corresponding to a C int (e.g. 32 bit signed on x64 and ARM *)
 type_synonym int_sword = "machine_word_len signed word"

--- a/proof/crefine/RISCV64/ADT_C.thy
+++ b/proof/crefine/RISCV64/ADT_C.thy
@@ -295,7 +295,7 @@ lemma cirqstate_cancel:
 definition
   "cint_state_to_H cnode cirqs \<equiv>
    InterruptState (ptr_val cnode)
-     (\<lambda>i::6 word. if i \<le> scast RISCV64.maxIRQ then cirqstate_to_H (index cirqs (unat i))
+     (\<lambda>i::6 word. if i \<le> maxIRQ then cirqstate_to_H (index cirqs (unat i))
                 else irqstate.IRQInactive)"
 
 lemma cint_rel_to_H:
@@ -306,7 +306,7 @@ lemma cint_rel_to_H:
   apply (cases "ksInterruptState s")
   apply (rename_tac "fun")
   apply (clarsimp simp: cinterrupt_relation_def cint_state_to_H_def
-                        RISCV64.maxIRQ_def Kernel_C.maxIRQ_def)
+                        maxIRQ_def Kernel_C.maxIRQ_def)
   apply (rule ext)
   apply clarsimp
   apply (drule spec, erule impE, assumption)

--- a/proof/crefine/RISCV64/Delete_C.thy
+++ b/proof/crefine/RISCV64/Delete_C.thy
@@ -897,7 +897,7 @@ lemma finaliseSlot_ccorres:
                                 arch_cap_has_cleanup'_def
                          split: option.split capability.splits)
           apply (auto dest!: ctes_of_valid'
-                       simp: valid_cap'_def Kernel_C.maxIRQ_def RISCV64.maxIRQ_def
+                       simp: valid_cap'_def Kernel_C.maxIRQ_def maxIRQ_def
                              unat_ucast word_le_nat_alt cleanup_info_wf'_def arch_cleanup_info_wf'_def)[1]
          subgoal by (auto dest!: valid_capAligned ctes_of_valid'
                           simp: isCap_simps final_matters'_def o_def)

--- a/proof/crefine/RISCV64/Finalise_C.thy
+++ b/proof/crefine/RISCV64/Finalise_C.thy
@@ -2187,7 +2187,7 @@ lemma finaliseCap_ccorres:
    apply (rule ccorres_if_lhs)
     apply (simp add: Collect_False Collect_True Let_def
                 del: Collect_const)
-    apply (rule_tac P="(capIRQ cap) \<le>  RISCV64.maxIRQ" in ccorres_gen_asm)
+    apply (rule_tac P="(capIRQ cap) \<le> maxIRQ" in ccorres_gen_asm)
     apply (rule ccorres_rhs_assoc)+
     apply csymbr
     apply csymbr

--- a/proof/crefine/RISCV64/Interrupt_C.thy
+++ b/proof/crefine/RISCV64/Interrupt_C.thy
@@ -92,7 +92,7 @@ proof -
                     ghost_assertion_data_set_def)
   apply (clarsimp simp: cte_at_irq_node' ucast_nat_def)
   apply (clarsimp simp: cte_wp_at_ctes_of badge_derived'_def
-                        Collect_const_mem unat_gt_0 valid_cap_simps' RISCV64.maxIRQ_def)
+                        Collect_const_mem unat_gt_0 valid_cap_simps' maxIRQ_def)
   apply (drule word_le_nat_alt[THEN iffD1])
   apply clarsimp
   apply (drule valid_globals_ex_cte_cap_irq[where irq=irq])
@@ -276,7 +276,7 @@ lemma decodeIRQHandlerInvocation_ccorres:
      apply (auto dest: st_tcb_at_idle_thread' ctes_of_valid')[6]
     apply (drule ctes_of_valid')
      apply fastforce
-    apply (clarsimp simp add:valid_cap_simps' RISCV64.maxIRQ_def)
+    apply (clarsimp simp add:valid_cap_simps' maxIRQ_def)
     apply (erule order.trans,simp)
   apply (auto dest: st_tcb_at_idle_thread' ctes_of_valid')
   done
@@ -367,8 +367,8 @@ lemma isIRQActive_ccorres:
   done
 
 lemma Platform_maxIRQ:
-  "RISCV64.maxIRQ = scast Kernel_C.maxIRQ"
-   by (simp add: RISCV64.maxIRQ_def Kernel_C.maxIRQ_def)
+  "maxIRQ = scast Kernel_C.maxIRQ"
+   by (simp add: maxIRQ_def Kernel_C.maxIRQ_def)
 
 lemma Arch_invokeIRQControl_ccorres:
   "ccorres (K (K \<bottom>) \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')

--- a/proof/crefine/RISCV64/Syscall_C.thy
+++ b/proof/crefine/RISCV64/Syscall_C.thy
@@ -1533,7 +1533,7 @@ lemma ucast_maxIRQ_is_less:
     by (simp)+
 
 lemma validIRQcastingLess:
-  "Kernel_C.maxIRQ <s ucast b \<Longrightarrow> RISCV64.maxIRQ < b"
+  "Kernel_C.maxIRQ <s ucast b \<Longrightarrow> maxIRQ < b"
   by (simp add: Platform_maxIRQ scast_maxIRQ_is_less is_up_def target_size source_size)
 
 lemma scast_maxIRQ_is_not_less:

--- a/proof/crefine/X64/ADT_C.thy
+++ b/proof/crefine/X64/ADT_C.thy
@@ -304,7 +304,7 @@ lemma cirqstate_cancel:
 definition
   "cint_state_to_H cnode cirqs \<equiv>
    InterruptState (ptr_val cnode)
-     (\<lambda>i::8 word. if i \<le> scast X64.maxIRQ then cirqstate_to_H (index cirqs (unat i))
+     (\<lambda>i::8 word. if i \<le> scast maxIRQ then cirqstate_to_H (index cirqs (unat i))
                 else irqstate.IRQInactive)"
 
 lemma cint_rel_to_H:
@@ -315,7 +315,7 @@ lemma cint_rel_to_H:
   apply (cases "ksInterruptState s")
   apply (rename_tac "fun")
   apply (clarsimp simp: cinterrupt_relation_def cint_state_to_H_def
-                        X64.maxIRQ_def Kernel_C.maxIRQ_def)
+                        maxIRQ_def Kernel_C.maxIRQ_def)
   apply (rule ext)
   apply clarsimp
   apply (drule spec, erule impE, assumption)

--- a/proof/crefine/X64/Delete_C.thy
+++ b/proof/crefine/X64/Delete_C.thy
@@ -896,7 +896,7 @@ lemma finaliseSlot_ccorres:
           apply (clarsimp simp: capRemovable_def cte_wp_at_ctes_of cap_has_cleanup'_def
                          split: option.split capability.splits)
            apply (auto dest!: ctes_of_valid'
-                        simp: valid_cap'_def Kernel_C.maxIRQ_def X64.maxIRQ_def
+                        simp: valid_cap'_def Kernel_C.maxIRQ_def maxIRQ_def
                               unat_ucast word_le_nat_alt cleanup_info_wf'_def arch_cleanup_info_wf'_def)[1]
           apply (clarsimp simp: capRemovable_def cte_wp_at_ctes_of arch_cap_has_cleanup'_def
                          split: option.split capability.splits)

--- a/proof/crefine/X64/Finalise_C.thy
+++ b/proof/crefine/X64/Finalise_C.thy
@@ -2682,7 +2682,7 @@ lemma finaliseCap_ccorres:
    apply (rule ccorres_if_lhs)
     apply (simp add: Collect_False Collect_True Let_def
                 del: Collect_const)
-    apply (rule_tac P="(capIRQ cap) \<le>  X64.maxIRQ" in ccorres_gen_asm)
+    apply (rule_tac P="(capIRQ cap) \<le> maxIRQ" in ccorres_gen_asm)
     apply (rule ccorres_rhs_assoc)+
     apply csymbr
     apply csymbr
@@ -2743,13 +2743,13 @@ lemma finaliseCap_ccorres:
    apply (frule cap_get_tag_to_H, erule(1) cap_get_tag_isCap [THEN iffD2])
    apply (frule(1) ccap_relation_IRQHandler_mask)
    apply (clarsimp simp: isCap_simps irqInvalid_def
-                      valid_cap'_def X64.maxIRQ_def
+                      valid_cap'_def maxIRQ_def
                       Kernel_C.maxIRQ_def)
     apply (rule irq_opt_relation_Some_ucast'[simplified Kernel_C.maxIRQ_def, simplified])
      apply fastforce
     apply simp
     apply (clarsimp simp: isCap_simps irqInvalid_def
-                      valid_cap'_def X64.maxIRQ_def
+                      valid_cap'_def maxIRQ_def
                       Kernel_C.maxIRQ_def)
    apply fastforce
   apply clarsimp

--- a/proof/crefine/X64/Interrupt_C.thy
+++ b/proof/crefine/X64/Interrupt_C.thy
@@ -94,7 +94,7 @@ proof -
                     ghost_assertion_data_set_def)
   apply (clarsimp simp: cte_at_irq_node' ucast_nat_def)
   apply (clarsimp simp: cte_wp_at_ctes_of badge_derived'_def
-                        Collect_const_mem unat_gt_0 valid_cap_simps' X64.maxIRQ_def)
+                        Collect_const_mem unat_gt_0 valid_cap_simps' maxIRQ_def)
   apply (drule word_le_nat_alt[THEN iffD1])
   apply clarsimp
   apply (drule valid_globals_ex_cte_cap_irq[where irq=irq])
@@ -279,7 +279,7 @@ lemma decodeIRQHandlerInvocation_ccorres:
      apply (auto dest: st_tcb_at_idle_thread' ctes_of_valid')[6]
     apply (drule ctes_of_valid')
      apply fastforce
-    apply (clarsimp simp add:valid_cap_simps' X64.maxIRQ_def)
+    apply (clarsimp simp add:valid_cap_simps' maxIRQ_def)
     apply (erule order.trans,simp)
   apply (auto dest: st_tcb_at_idle_thread' ctes_of_valid')
   done
@@ -373,8 +373,8 @@ lemma isIRQActive_ccorres:
   done
 
 lemma Platform_maxIRQ:
-  "X64.maxIRQ = scast Kernel_C.maxIRQ"
-   by (simp add: X64.maxIRQ_def Kernel_C.maxIRQ_def)
+  "maxIRQ = scast Kernel_C.maxIRQ"
+   by (simp add: maxIRQ_def Kernel_C.maxIRQ_def)
 
 lemma le_maxirq_ucast_explicit:
   "irq \<le> 0x7D \<Longrightarrow> UCAST(8 \<rightarrow> 64) irq < 0x7E"

--- a/proof/crefine/X64/Syscall_C.thy
+++ b/proof/crefine/X64/Syscall_C.thy
@@ -1531,7 +1531,7 @@ lemma ucast_maxIRQ_is_less:
     by (simp)+
 
 lemma validIRQcastingLess:
-  "Kernel_C.maxIRQ <s ucast b \<Longrightarrow> X64.maxIRQ < b"
+  "Kernel_C.maxIRQ <s ucast b \<Longrightarrow> maxIRQ < b"
   by (simp add: Platform_maxIRQ scast_maxIRQ_is_less is_up_def target_size source_size)
 
 lemma scast_maxIRQ_is_not_less:

--- a/proof/infoflow/ARM/ArchIRQMasks_IF.thy
+++ b/proof/infoflow/ARM/ArchIRQMasks_IF.thy
@@ -88,7 +88,7 @@ lemma dmo_getActiveIRQ_return_axiom[IRQMasks_IF_assms, wp]:
   apply (rule hoare_pre, rule dmo_wp)
    apply (insert irq_oracle_max_irq)
    apply (wp dmo_getActiveIRQ_irq_masks)
-  apply clarsimp
+  apply (clarsimp simp: maxIRQ_def)
   done
 
 crunch activate_thread, handle_spurious_irq

--- a/proof/infoflow/ARM/ArchNoninterference.thy
+++ b/proof/infoflow/ARM/ArchNoninterference.thy
@@ -353,7 +353,7 @@ lemma getActiveIRQ_ret_no_dmo[Noninterference_assms, wp]:
   apply (rule hoare_pre)
    apply (insert irq_oracle_max_irq)
    apply (wp dmo_getActiveIRQ_irq_masks)
-  apply clarsimp
+  apply (clarsimp simp: maxIRQ_def)
   done
 
 (*FIXME: Move to scheduler_if*)

--- a/proof/infoflow/refine/ARM/Example_Valid_StateH.thy
+++ b/proof/infoflow/refine/ARM/Example_Valid_StateH.thy
@@ -3099,7 +3099,7 @@ lemma s0H_invs:
   apply (rule conjI)
    apply (clarsimp simp: valid_machine_state'_def s0H_internal_def machine_state0_def)
   apply (rule conjI)
-   apply (clarsimp simp: irqs_masked'_def s0H_internal_def)
+   apply (clarsimp simp: irqs_masked'_def s0H_internal_def maxIRQ_def)
   apply (rule conjI)
    apply (clarsimp simp: sym_heap_def opt_map_def split: option.splits)
    using kh0H_dom_tcb

--- a/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
@@ -52,7 +52,7 @@ lemma decode_irq_control_valid [Interrupt_AI_assms]:
          | wp (once) hoare_drop_imps)+
   apply (clarsimp simp: linorder_not_less word_le_nat_alt unat_ucast mod_le_nat)
   apply (cases caps; clarsimp simp: cte_wp_at_eq_simp)
-  apply (fastforce split: if_split)
+  apply (fastforce split: if_split simp: maxIRQ_def)
   done
 
 lemma get_irq_slot_different_ARCH[Interrupt_AI_assms]:

--- a/proof/invariant-abstract/ARM/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchInterrupt_AI.thy
@@ -50,7 +50,7 @@ lemma decode_irq_control_valid [Interrupt_AI_assms]:
                  split del: if_split cong: if_cong)
   apply (wpsimp wp: ensure_empty_stronger simp: cte_wp_at_eq_simp arch_irq_control_inv_valid_def
         | wp (once) hoare_drop_imps)+
-  apply (clarsimp simp: linorder_not_less word_le_nat_alt unat_ucast mod_le_nat)
+  apply (clarsimp simp: linorder_not_less word_le_nat_alt unat_ucast mod_le_nat maxIRQ_def)
   apply (cases caps ; fastforce simp: cte_wp_at_eq_simp)
   done
 

--- a/proof/invariant-abstract/ARM_HYP/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/ARM_HYP/ArchInterrupt_AI.thy
@@ -51,7 +51,7 @@ lemma decode_irq_control_valid [Interrupt_AI_assms]:
   apply (wpsimp wp: ensure_empty_stronger simp: cte_wp_at_eq_simp arch_irq_control_inv_valid_def
         | wp (once) hoare_drop_imps)+
   apply (clarsimp simp: linorder_not_less word_le_nat_alt unat_ucast mod_le_nat)
-  apply (cases caps ; fastforce simp: cte_wp_at_eq_simp)
+  apply (cases caps ; fastforce simp: cte_wp_at_eq_simp maxIRQ_def)
   done
 
 lemma get_irq_slot_different_ARCH[Interrupt_AI_assms]:

--- a/proof/refine/AARCH64/ArchMachine_R.thy
+++ b/proof/refine/AARCH64/ArchMachine_R.thy
@@ -62,11 +62,9 @@ lemma getActiveIRQ_le_maxIRQ:
   "\<lbrace>irqs_masked' and valid_irq_states'\<rbrace> doMachineOp (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ\<rbrace>"
   apply (simp add: doMachineOp_def split_def)
   apply wp
-  apply clarsimp
+  apply (clarsimp simp: maxIRQ_def)
   apply (drule use_valid, rule getActiveIRQ_le_maxIRQ')
-   prefer 2
-   apply simp
-  apply (simp add: irqs_masked'_def valid_irq_states'_def)
+   apply (simp add: irqs_masked'_def valid_irq_states'_def maxIRQ_def)+
   done
 
 lemma doMachineOp_getActiveIRQ_non_kernel[wp]:

--- a/proof/refine/AARCH64/Arch_R.thy
+++ b/proof/refine/AARCH64/Arch_R.thy
@@ -863,8 +863,8 @@ lemma decodeARMVCPUInvocation_corres:
   (* ack vppi *)
   apply (simp add: decode_vcpu_ack_vppi_def decodeVCPUAckVPPI_def isVCPUCap_def)
   apply (cases args; clarsimp simp: isCap_simps)
-  apply (simp add: arch_check_irq_def rangeCheck_def ucast_nat_def unlessE_def word_le_not_less)
-  apply (clarsimp simp: irq_vppi_event_index_def irqVPPIEventIndex_def IRQ_def toEnum_unat_ucast
+  apply (clarsimp simp: arch_check_irq_def rangeCheck_def whenE_def maxIRQ_def not_less)
+  apply (clarsimp simp: irq_vppi_event_index_def irqVPPIEventIndex_def unlessE_def IRQ_def
                         le_maxIRQ_machine_less_irqBits_val not_less)
   apply (fastforce simp: archinv_relation_def vcpu_invocation_map_def
                    intro: corres_returnOk

--- a/proof/refine/AARCH64/Interrupt_R.thy
+++ b/proof/refine/AARCH64/Interrupt_R.thy
@@ -164,7 +164,7 @@ lemma checkIRQ_corres:
   "corres (ser \<oplus> dc) \<top> \<top> (arch_check_irq irq) (checkIRQ irq)"
   unfolding arch_check_irq_def checkIRQ_def rangeCheck_def
   apply (rule corres_guard_imp)
-    apply (clarsimp simp: minIRQ_def unlessE_whenE not_le)
+    apply (clarsimp simp: minIRQ_def maxIRQ_def unlessE_whenE not_le)
     apply (rule corres_whenE)
       apply fastforce+
   done
@@ -185,7 +185,7 @@ lemma arch_check_irq_valid:
   "\<lbrace>\<top>\<rbrace> arch_check_irq irq \<lbrace>\<lambda>_. (\<lambda>s. irq \<le> Kernel_Config.maxIRQ)\<rbrace>, -"
   unfolding arch_check_irq_def
   apply (wpsimp simp: validE_R_def wp: whenE_throwError_wp)
-  apply (simp add: not_less word_le_nat_alt)
+  apply (simp add: not_less word_le_nat_alt maxIRQ_def)
   done
 
 lemma arch_check_irq_valid':
@@ -283,10 +283,10 @@ lemma decodeIRQControlInvocation_corres:
     apply (auto intro!: corres_guard_imp[OF arch_decodeIRQControlInvocation_corres])[1]
    apply (auto intro!: corres_guard_imp[OF arch_decodeIRQControlInvocation_corres]
                dest!: not_le_imp_less
-               simp: minIRQ_def o_def length_Suc_conv whenE_rangeCheck_eq ucast_nat_def
+               simp: minIRQ_def o_def maxIRQ_def length_Suc_conv whenE_rangeCheck_eq ucast_nat_def
                split: list.splits)[1]
   apply (rule corres_guard_imp)
-    apply (simp add: whenE_rangeCheck_eq)
+    apply (simp add: whenE_rangeCheck_eq maxIRQ_def)
     apply (rule whenE_throwError_corres, clarsimp, fastforce)
     apply (rule_tac F="y \<le> Kernel_Config.maxIRQ" in corres_gen_asm)
     apply (clarsimp simp: toEnum_unat_ucast le_maxIRQ_machine_less_irqBits_val)
@@ -330,7 +330,7 @@ lemma arch_decode_irq_control_valid'[wp]:
           | wpc
           | wp (once) hoare_drop_imps)+
   apply (clarsimp, rule conjI; clarsimp)
-  apply (clarsimp simp: invs_valid_objs' toEnum_unat_ucast
+  apply (clarsimp simp: invs_valid_objs' toEnum_unat_ucast maxIRQ_def
                         le_maxIRQ_machine_less_irqBits_val irq_machine_le_maxIRQ_irq)
   done
 
@@ -347,7 +347,7 @@ lemma decode_irq_control_valid'[wp]:
   apply (wpsimp wp: ensureEmptySlot_stronger isIRQActive_wp whenE_throwError_wp
                 simp: o_def
          | wp (once) hoare_drop_imps)+
-  apply (clarsimp simp: invs_valid_objs' toEnum_unat_ucast
+  apply (clarsimp simp: invs_valid_objs' toEnum_unat_ucast maxIRQ_def
                         le_maxIRQ_machine_less_irqBits_val irq_machine_le_maxIRQ_irq)
   done
 
@@ -980,7 +980,7 @@ lemma handleInterrupt_corres:
                   and (\<lambda>s. irq \<in> non_kernel_IRQs \<longrightarrow> sch_act_not (ksCurThread s) s))
      (handle_interrupt irq) (handleInterrupt irq)"
   (is "corres dc _ (invs' and _ and ?P') _ _")
-  apply (simp add: handle_interrupt_def handleInterrupt_def)
+  apply (simp add: handle_interrupt_def handleInterrupt_def maxIRQ_def)
   apply (rule conjI[rotated]; rule impI)
 
    apply (rule corres_guard_imp)

--- a/proof/refine/ARM/ArchMachine_R.thy
+++ b/proof/refine/ARM/ArchMachine_R.thy
@@ -62,11 +62,9 @@ lemma getActiveIRQ_le_maxIRQ:
   "\<lbrace>irqs_masked' and valid_irq_states'\<rbrace> doMachineOp (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ\<rbrace>"
   apply (simp add: doMachineOp_def split_def)
   apply wp
-  apply clarsimp
+  apply (clarsimp simp: maxIRQ_def)
   apply (drule use_valid, rule getActiveIRQ_le_maxIRQ')
-   prefer 2
-   apply simp
-  apply (simp add: irqs_masked'_def valid_irq_states'_def)
+   apply (simp add: irqs_masked'_def valid_irq_states'_def maxIRQ_def)+
   done
 
 lemma sendSGI_underlying_memory[wp]:

--- a/proof/refine/ARM/Interrupt_R.thy
+++ b/proof/refine/ARM/Interrupt_R.thy
@@ -165,7 +165,7 @@ lemma checkIRQ_corres:
   "corres (ser \<oplus> dc) \<top> \<top> (arch_check_irq irq) (checkIRQ irq)"
   unfolding arch_check_irq_def checkIRQ_def rangeCheck_def
   apply (rule corres_guard_imp)
-    apply (clarsimp simp: minIRQ_def unlessE_whenE not_le)
+    apply (clarsimp simp: minIRQ_def maxIRQ_def unlessE_whenE not_le)
     apply (rule corres_whenE)
       apply fastforce+
   done
@@ -195,7 +195,7 @@ lemma arch_check_irq_maxIRQ_valid:
   "\<lbrace>\<top>\<rbrace> arch_check_irq irq \<lbrace>\<lambda>_ s. irq \<le> Kernel_Config.maxIRQ\<rbrace>, -"
   unfolding arch_check_irq_def
   apply (wpsimp simp: validE_R_def wp: whenE_throwError_wp)
-  apply (simp add: word_not_le)
+  apply (simp add: word_not_le maxIRQ_def)
   done
 
 lemma arch_check_irq_maxIRQ_valid':
@@ -308,7 +308,7 @@ lemma decodeIRQControlInvocation_corres:
                dest!: not_le_imp_less
                simp: minIRQ_def o_def length_Suc_conv whenE_rangeCheck_eq ucast_nat_def
                split: list.splits)[1]
-  apply (simp add: minIRQ_def o_def length_Suc_conv whenE_rangeCheck_eq)
+  apply (simp add: minIRQ_def maxIRQ_def o_def length_Suc_conv whenE_rangeCheck_eq)
   apply (rule corres_guard_imp)
     apply (rule whenE_throwError_corres, clarsimp, clarsimp)
     apply (rule_tac F="y \<le> Kernel_Config.maxIRQ" in corres_gen_asm)
@@ -369,7 +369,7 @@ lemma arch_decode_irq_control_valid'[wp]:
           | wpc
           | wp (once) hoare_drop_imps)+
   apply (clarsimp, rule conjI; clarsimp)
-  apply (clarsimp simp: invs_valid_objs' toEnum_unat_ucast
+  apply (clarsimp simp: invs_valid_objs' toEnum_unat_ucast maxIRQ_def
                         le_maxIRQ_machine_less_irqBits_val irq_machine_le_maxIRQ_irq)
   done
 
@@ -386,7 +386,7 @@ lemma decode_irq_control_valid'[wp]:
   apply (wpsimp wp: ensureEmptySlot_stronger isIRQActive_wp whenE_throwError_wp
                 simp: o_def
          | wp (once) hoare_drop_imps)+
-  apply (clarsimp simp: invs_valid_objs' toEnum_unat_ucast
+  apply (clarsimp simp: invs_valid_objs' toEnum_unat_ucast maxIRQ_def
                         le_maxIRQ_machine_less_irqBits_val irq_machine_le_maxIRQ_irq)
   done
 
@@ -787,7 +787,7 @@ lemma handleInterrupt_corres:
      (einvs) (invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive))
      (handle_interrupt irq) (handleInterrupt irq)"
   (is "corres dc (einvs) ?P' ?f ?g")
-  apply (simp add: handle_interrupt_def handleInterrupt_def )
+  apply (simp add: handle_interrupt_def handleInterrupt_def maxIRQ_def)
   apply (rule conjI[rotated]; rule impI)
 
    apply (rule corres_guard_imp)

--- a/proof/refine/ARM_HYP/ArchMachine_R.thy
+++ b/proof/refine/ARM_HYP/ArchMachine_R.thy
@@ -62,11 +62,9 @@ lemma getActiveIRQ_le_maxIRQ:
   "\<lbrace>irqs_masked' and valid_irq_states'\<rbrace> doMachineOp (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ\<rbrace>"
   apply (simp add: doMachineOp_def split_def)
   apply wp
-  apply clarsimp
+  apply (clarsimp simp: maxIRQ_def)
   apply (drule use_valid, rule getActiveIRQ_le_maxIRQ')
-   prefer 2
-   apply simp
-  apply (simp add: irqs_masked'_def valid_irq_states'_def)
+   apply (simp add: irqs_masked'_def valid_irq_states'_def maxIRQ_def)+
   done
 
 lemma doMachineOp_getActiveIRQ_non_kernel[wp]:

--- a/proof/refine/ARM_HYP/Arch_R.thy
+++ b/proof/refine/ARM_HYP/Arch_R.thy
@@ -865,7 +865,7 @@ lemma decodeARMVCPUInvocation_corres:
   apply (cases args; clarsimp simp: isCap_simps)
   apply (simp add: arch_check_irq_def rangeCheck_def ucast_nat_def minIRQ_def unlessE_def
                    word_le_not_less)
-  apply (case_tac "a > Kernel_Config.maxIRQ"; simp add:  ucast_nat_def word_le_not_less)
+  apply (case_tac "a > Kernel_Config.maxIRQ"; simp add: ucast_nat_def word_le_not_less maxIRQ_def)
   apply (clarsimp simp: irq_vppi_event_index_def irqVPPIEventIndex_def IRQ_def toEnum_unat_ucast
                         le_maxIRQ_machine_less_irqBits_val)
   apply (fastforce simp: archinv_relation_def vcpu_invocation_map_def

--- a/proof/refine/ARM_HYP/Interrupt_R.thy
+++ b/proof/refine/ARM_HYP/Interrupt_R.thy
@@ -164,7 +164,7 @@ lemma checkIRQ_corres:
   "corres (ser \<oplus> dc) \<top> \<top> (arch_check_irq irq) (checkIRQ irq)"
   unfolding arch_check_irq_def checkIRQ_def rangeCheck_def
   apply (rule corres_guard_imp)
-    apply (clarsimp simp: minIRQ_def unlessE_whenE not_le)
+    apply (clarsimp simp: minIRQ_def maxIRQ_def unlessE_whenE not_le)
     apply (rule corres_whenE)
       apply (fastforce simp: ucast_nat_def)+
   done
@@ -194,8 +194,8 @@ crunch arch_check_irq, checkIRQ
 lemma arch_check_irq_maxIRQ_valid:
   "\<lbrace>\<top>\<rbrace> arch_check_irq irq \<lbrace>\<lambda>_ s. irq \<le> Kernel_Config.maxIRQ\<rbrace>, -"
   unfolding arch_check_irq_def
-  apply (wpsimp simp: validE_R_def wp: whenE_throwError_wp)
-  by (simp add: not_less)
+  by (wpsimp simp: validE_R_def wp: whenE_throwError_wp)
+     (simp add: not_less maxIRQ_def)
 
 lemma arch_check_irq_maxIRQ_valid':
   "\<lbrace>\<top>\<rbrace> arch_check_irq y \<lbrace>\<lambda>_ _. y \<le> Kernel_Config.maxIRQ\<rbrace>, \<lbrace>\<lambda>_. \<top>\<rbrace>"
@@ -308,7 +308,7 @@ lemma decodeIRQControlInvocation_corres:
                dest!: not_le_imp_less
                simp: minIRQ_def o_def length_Suc_conv whenE_rangeCheck_eq ucast_nat_def
                split: list.splits)[1]
-  apply (simp add: minIRQ_def o_def length_Suc_conv whenE_rangeCheck_eq)
+  apply (simp add: minIRQ_def maxIRQ_def o_def length_Suc_conv whenE_rangeCheck_eq)
   apply (rule corres_guard_imp)
     apply (rule whenE_throwError_corres, clarsimp, clarsimp)
     apply (rule_tac F="y \<le> Kernel_Config.maxIRQ" in corres_gen_asm)
@@ -369,7 +369,7 @@ lemma arch_decode_irq_control_valid'[wp]:
           | wpc
           | wp (once) hoare_drop_imps)+
   apply (clarsimp, rule conjI; clarsimp)
-  apply (clarsimp simp: invs_valid_objs' toEnum_unat_ucast
+  apply (clarsimp simp: invs_valid_objs' toEnum_unat_ucast maxIRQ_def
                         le_maxIRQ_machine_less_irqBits_val irq_machine_le_maxIRQ_irq)
   done
 
@@ -386,7 +386,7 @@ lemma decode_irq_control_valid'[wp]:
   apply (wpsimp wp: ensureEmptySlot_stronger isIRQActive_wp whenE_throwError_wp
                 simp: o_def
          | wp (once) hoare_drop_imps)+
-  apply (clarsimp simp: invs_valid_objs' toEnum_unat_ucast
+  apply (clarsimp simp: invs_valid_objs' toEnum_unat_ucast maxIRQ_def
                         le_maxIRQ_machine_less_irqBits_val irq_machine_le_maxIRQ_irq)
   done
 
@@ -1047,7 +1047,7 @@ lemma handleInterrupt_corres:
                   and (\<lambda>s. irq \<in> non_kernel_IRQs \<longrightarrow> sch_act_not (ksCurThread s) s))
      (handle_interrupt irq) (handleInterrupt irq)"
   (is "corres dc _ (invs' and _ and ?P') _ _")
-  apply (simp add: handle_interrupt_def handleInterrupt_def)
+  apply (simp add: handle_interrupt_def handleInterrupt_def maxIRQ_def)
   apply (rule conjI[rotated]; rule impI)
 
    apply (rule corres_guard_imp)

--- a/proof/refine/RISCV64/ArchMachine_R.thy
+++ b/proof/refine/RISCV64/ArchMachine_R.thy
@@ -62,11 +62,9 @@ lemma getActiveIRQ_le_maxIRQ:
   "\<lbrace>irqs_masked' and valid_irq_states'\<rbrace> doMachineOp (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ\<rbrace>"
   apply (simp add: doMachineOp_def split_def)
   apply wp
-  apply clarsimp
+  apply (clarsimp simp: maxIRQ_def)
   apply (drule use_valid, rule getActiveIRQ_le_maxIRQ')
-   prefer 2
-   apply simp
-  apply (simp add: irqs_masked'_def valid_irq_states'_def)
+   apply (simp add: irqs_masked'_def valid_irq_states'_def maxIRQ_def)+
   done
 
 lemma frameRegisters_def'[Machine_R_assms]:

--- a/proof/refine/RISCV64/Interrupt_R.thy
+++ b/proof/refine/RISCV64/Interrupt_R.thy
@@ -164,7 +164,7 @@ lemma checkIRQ_corres:
   "corres (ser \<oplus> dc) \<top> \<top> (arch_check_irq irq) (checkIRQ irq)"
   unfolding arch_check_irq_def checkIRQ_def rangeCheck_def
   apply (rule corres_guard_imp)
-    apply (clarsimp simp: minIRQ_def unlessE_whenE not_le)
+    apply (clarsimp simp: minIRQ_def maxIRQ_def unlessE_whenE not_le)
     apply (rule corres_whenE)
       apply (fastforce simp: ucast_nat_def)+
   done
@@ -183,10 +183,10 @@ crunch arch_check_irq, checkIRQ
 
 lemma arch_check_irq_valid:
   "\<lbrace>\<top>\<rbrace> arch_check_irq y \<lbrace>\<lambda>_. (\<lambda>s. unat y \<le> unat maxIRQ \<and> unat y \<noteq> unat irqInvalid)\<rbrace>, -"
-  unfolding arch_check_irq_def
+  unfolding arch_check_irq_def maxIRQ_def
   apply (wpsimp simp: validE_R_def wp: whenE_throwError_wp)
   apply (rule conjI)
-   apply (metis unat_ucast_up_simp[where 'a=6 and 'b=64, simplified] word_le_nat_alt word_le_not_less)
+   apply (clarsimp simp: not_less word_le_nat_alt)
   apply (simp add: unat_ucast_up_simp[where 'a=6 and 'b=64, simplified] irqInvalid_def)
   apply (rule unat_mono[where a=0, simplified])
   apply (simp add: word_neq_0_conv)
@@ -266,9 +266,9 @@ lemma decodeIRQControlInvocation_corres:
                simp: minIRQ_def o_def length_Suc_conv whenE_rangeCheck_eq ucast_nat_def
                split: list.splits)[1]
   apply (rule corres_guard_imp)
-    apply (rule whenE_throwError_corres, clarsimp, clarsimp)
+    apply (rule whenE_throwError_corres, clarsimp simp: maxIRQ_def, clarsimp simp: maxIRQ_def)
     apply (rule_tac F="unat y \<le> unat maxIRQ" in corres_gen_asm)
-    apply (clarsimp simp add: minIRQ_def maxIRQ_def ucast_nat_def)
+    apply (clarsimp simp add: minIRQ_def maxIRQ_def ucast_nat_def toEnum_unat_ucast maxIRQ_def)
     apply (rule corres_split_eqr[OF is_irq_active_corres])
       apply (rule whenE_throwError_corres, clarsimp, clarsimp)
       apply (rule corres_splitEE)
@@ -278,7 +278,7 @@ lemma decodeIRQControlInvocation_corres:
           apply (clarsimp simp: arch_irq_control_inv_relation_def)
          apply (wpsimp wp: isIRQActive_inv arch_check_irq_valid' checkIRQ_inv
                      simp: invs_valid_objs invs_psp_aligned invs_valid_objs'
-                           invs_pspace_aligned' invs_pspace_distinct'
+                           invs_pspace_aligned' invs_pspace_distinct' maxIRQ_def
                 | strengthen invs_valid_objs invs_psp_aligned
                 | wp (once) hoare_drop_imps arch_check_irq_inv)+
    apply (auto split: arch_invocation_label.splits invocation_label.splits
@@ -309,7 +309,8 @@ lemma arch_decode_irq_control_valid'[wp]:
           | wpc
           | wp (once) hoare_drop_imps)+
   apply (clarsimp simp: invs_valid_objs' irq_const_defs unat_word_ariths word_le_nat_alt
-                        not_less unat_le_helper unat_of_nat irqInvalid_def unat_ucast_mask)
+                        not_less unat_le_helper unat_of_nat irqInvalid_def unat_ucast_mask
+                        maxIRQ_def)
   apply (rule conjI)
    apply (meson le_trans word_and_le2 word_less_eq_iff_unsigned)
   apply clarsimp
@@ -330,7 +331,8 @@ lemma decode_irq_control_valid'[wp]:
                 simp: o_def
          | wp (once) hoare_drop_imps)+
   apply (clarsimp simp: invs_valid_objs' irq_const_defs unat_word_ariths word_le_nat_alt
-                        not_less unat_le_helper unat_of_nat irqInvalid_def unat_ucast_mask)
+                        not_less unat_le_helper unat_of_nat irqInvalid_def unat_ucast_mask
+                        maxIRQ_def)
   apply (rule conjI)
    apply (meson le_trans word_and_le2 word_less_eq_iff_unsigned)
   apply clarsimp
@@ -717,7 +719,7 @@ lemma handleInterrupt_corres:
      (invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive))
      (handle_interrupt irq) (handleInterrupt irq)"
   (is "corres dc ?P ?P' ?f ?g")
-  apply (simp add: handle_interrupt_def handleInterrupt_def)
+  apply (simp add: handle_interrupt_def handleInterrupt_def maxIRQ_def)
   apply (rule conjI[rotated]; rule impI)
    apply (rule corres_guard_imp)
      apply (rule corres_split[OF getIRQState_corres,

--- a/proof/refine/X64/ArchMachine_R.thy
+++ b/proof/refine/X64/ArchMachine_R.thy
@@ -62,11 +62,9 @@ lemma getActiveIRQ_le_maxIRQ:
   "\<lbrace>irqs_masked' and valid_irq_states'\<rbrace> doMachineOp (getActiveIRQ in_kernel) \<lbrace>\<lambda>rv s. \<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ\<rbrace>"
   apply (simp add: doMachineOp_def split_def)
   apply wp
-  apply clarsimp
+  apply (clarsimp simp: maxIRQ_def)
   apply (drule use_valid, rule getActiveIRQ_le_maxIRQ')
-   prefer 2
-   apply simp
-  apply (simp add: irqs_masked'_def valid_irq_states'_def)
+   apply (simp add: irqs_masked'_def valid_irq_states'_def maxIRQ_def)+
   done
 
 lemma frameRegisters_def'[Machine_R_assms]:

--- a/proof/refine/X64/Interrupt_R.thy
+++ b/proof/refine/X64/Interrupt_R.thy
@@ -335,7 +335,8 @@ lemma arch_decode_irq_control_valid'[wp]:
           | wp whenE_throwError_wp isIRQActive_wp ensureEmptySlot_stronger
           | wpc
           | wp (once) hoare_drop_imps)+
-  apply (clarsimp simp add: invs_valid_objs' irq_const_defs unat_word_ariths word_le_nat_alt toEnum_unat_ucast_helper_64_8)
+  apply (clarsimp simp: invs_valid_objs' irq_const_defs unat_word_ariths word_le_nat_alt
+                        toEnum_unat_ucast_helper_64_8 maxIRQ_def)
   apply (fastforce simp add: toEnum_unat_ucast'_helper_64_8 unat_add_ucast_helper)+
   done
 
@@ -527,6 +528,7 @@ lemma arch_performIRQControl_corres:
                     | wps)+
     apply (clarsimp simp: invs_def valid_state_def valid_pspace_def cte_wp_at_caps_of_state
                           is_simple_cap_def is_cap_simps arch_irq_control_inv_valid_def
+                          maxIRQ_def[symmetric]
                           safe_parent_for_def order_trans[OF _ maxUserIRQ_le_maxIRQ])
    apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def IRQHandler_valid
                       IRQHandler_valid' is_simple_cap'_def isCap_simps IRQ_def)
@@ -546,6 +548,7 @@ lemma arch_performIRQControl_corres:
                  | wps)+
    apply (clarsimp simp: invs_def valid_state_def valid_pspace_def cte_wp_at_caps_of_state
                             is_simple_cap_def is_cap_simps arch_irq_control_inv_valid_def
+                            maxIRQ_def[symmetric]
                             safe_parent_for_def order_trans[OF _ maxUserIRQ_le_maxIRQ])
   apply (clarsimp simp: invs'_def valid_state'_def valid_pspace'_def IRQHandler_valid
                       IRQHandler_valid' is_simple_cap'_def isCap_simps IRQ_def)
@@ -781,7 +784,7 @@ lemma handleInterrupt_corres:
      (invs' and (\<lambda>s. intStateIRQTable (ksInterruptState s) irq \<noteq> IRQInactive))
      (handle_interrupt irq) (handleInterrupt irq)"
   (is "corres dc ?P ?P' ?f ?g")
-  apply (simp add: handle_interrupt_def handleInterrupt_def)
+  apply (simp add: handle_interrupt_def handleInterrupt_def maxIRQ_def)
   apply (rule conjI[rotated]; rule impI)
    apply (rule corres_guard_imp)
      apply (rule corres_split[OF getIRQState_corres,

--- a/spec/abstract/RISCV64/ArchDecode_A.thy
+++ b/spec/abstract/RISCV64/ArchDecode_A.thy
@@ -32,8 +32,8 @@ section "Architecture-specific Decode Functions"
 definition
   arch_check_irq :: "data \<Rightarrow> (unit,'z::state_ext) se_monad"
 where
-  "arch_check_irq irq \<equiv> whenE (irq > ucast maxIRQ \<or> irq = ucast irqInvalid) $
-                          throwError (RangeError 1 (ucast maxIRQ))"
+  "arch_check_irq irq \<equiv> whenE (irq > maxIRQ \<or> irq = ucast irqInvalid) $
+                          throwError (RangeError 1 maxIRQ)"
 
 definition arch_decode_irq_control_invocation ::
   "data \<Rightarrow> data list \<Rightarrow> cslot_ptr \<Rightarrow> cap list \<Rightarrow> (arch_irq_control_invocation,'z::state_ext) se_monad"

--- a/spec/abstract/RISCV64/ArchInterrupt_A.thy
+++ b/spec/abstract/RISCV64/ArchInterrupt_A.thy
@@ -31,8 +31,4 @@ definition handle_spurious_irq :: "(unit,'z::state_ext) s_monad"
 
 end
 
-(* On Arm architectures, maxIRQ is defined in Kernel_Config. On RISCV64 it is defined manually. *)
-arch_requalify_consts
-  maxIRQ
-
 end

--- a/spec/abstract/X64/ArchInterrupt_A.thy
+++ b/spec/abstract/X64/ArchInterrupt_A.thy
@@ -34,8 +34,4 @@ definition handle_spurious_irq :: "(unit,'z::state_ext) s_monad"
 
 end
 
-(* On Arm architectures, maxIRQ is defined in Kernel_Config. On X64 it is defined manually. *)
-arch_requalify_consts
-  maxIRQ
-
 end

--- a/spec/design/skel/AARCH64/Hardware_H.thy
+++ b/spec/design/skel/AARCH64/Hardware_H.thy
@@ -54,9 +54,9 @@ context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/AARCH64.hs CONTEXT AARCH64_H ONLY wordFromPTE
 
-(* Kernel_Config provides a generic numeral, Haskell expects type irq *)
+(* Platform provides a generic numeral, Haskell expects type irq *)
 abbreviation (input) maxIRQ :: irq where
-  "maxIRQ \<equiv> Kernel_Config.maxIRQ"
+  "maxIRQ \<equiv> Platform.maxIRQ"
 
 end (* context AARCH64 *)
 

--- a/spec/design/skel/ARM/Hardware_H.thy
+++ b/spec/design/skel/ARM/Hardware_H.thy
@@ -24,9 +24,9 @@ context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/ARM.lhs CONTEXT ARM_H ONLY wordFromPDE wordFromPTE
 
-(* Kernel_Config provides a generic numeral, Haskell expects type irq *)
+(* Platform provides a generic numeral, Haskell expects type irq *)
 abbreviation (input) maxIRQ :: irq where
-  "maxIRQ == Kernel_Config.maxIRQ"
+  "maxIRQ \<equiv> Platform.maxIRQ"
 
 (* provide ARM/ARM_HYP machine op in _H global_prefix for arch-split *)
 abbreviation (input) initIRQController where

--- a/spec/design/skel/ARM_HYP/Hardware_H.thy
+++ b/spec/design/skel/ARM_HYP/Hardware_H.thy
@@ -24,9 +24,9 @@ context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/ARM.lhs CONTEXT ARM_HYP_H ONLY hapFromVMRights wordsFromPDE wordsFromPTE
 
-(* Kernel_Config provides a generic numeral, Haskell expects type irq *)
+(* Platform provides a generic numeral, Haskell expects type irq *)
 abbreviation (input) maxIRQ :: irq where
-  "maxIRQ \<equiv> Kernel_Config.maxIRQ"
+  "maxIRQ \<equiv> Platform.maxIRQ"
 
 (* provide ARM/ARM_HYP machine op in _H global_prefix for arch-split *)
 abbreviation (input) initIRQController where

--- a/spec/design/skel/RISCV64/Hardware_H.thy
+++ b/spec/design/skel/RISCV64/Hardware_H.thy
@@ -25,10 +25,9 @@ context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/RISCV64.hs CONTEXT RISCV64_H ONLY wordFromPTE
 
-(* Unlike on Arm architectures, maxIRQ comes from Platform definitions.
-   We provide this abbreviation to match arch-split expectations. *)
+(* Platform provides a generic numeral, Haskell expects type irq *)
 abbreviation (input) maxIRQ :: irq where
-  "maxIRQ \<equiv> Platform.RISCV64.maxIRQ"
+  "maxIRQ \<equiv> Platform.maxIRQ"
 
 end (* context RISCV64 *)
 

--- a/spec/design/skel/X64/Hardware_H.thy
+++ b/spec/design/skel/X64/Hardware_H.thy
@@ -25,10 +25,9 @@ context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/X64.lhs CONTEXT X64_H ONLY wordFromPDE wordFromPTE wordFromPML4E wordFromPDPTE
 
-(* Unlike on Arm architectures, maxIRQ comes from Platform definitions.
-   We provide this abbreviation to match arch-split expectations. *)
+(* Platform provides a generic numeral, Haskell expects type irq *)
 abbreviation (input) maxIRQ :: irq where
-  "maxIRQ \<equiv> Platform.X64.maxIRQ"
+  "maxIRQ \<equiv> Platform.maxIRQ"
 
 end (* context X64 *)
 

--- a/spec/machine/AARCH64/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/AARCH64/Arch_Kernel_Config_Lemmas.thy
@@ -17,11 +17,11 @@ context Arch begin global_naming AARCH64
 (* maxIRQ conditions *)
 
 lemma irqVTimerEvent_le_maxIRQ[simp, intro!]:
-  "irqVTimerEvent \<le> maxIRQ"
+  "irqVTimerEvent \<le> Kernel_Config.maxIRQ"
   by (simp add: irqVTimerEvent_def Kernel_Config.maxIRQ_def)
 
 lemma maxIRQ_less_2p_irqBits:
-  "(maxIRQ::nat) < 2^irqBits"
+  "(Kernel_Config.maxIRQ::nat) < 2^irqBits"
   by (simp add: Kernel_Config.maxIRQ_def Kernel_Config.irqBits_def)
 
 (* follows from value_type definition of irq_len *)
@@ -31,7 +31,7 @@ lemma LENGTH_irq_len_irqBits[simp]: (* [simp] will fire only for simp del: len_o
   by simp
 
 lemma maxIRQ_less_2p_irq_len:
-  "(maxIRQ::nat) < 2^LENGTH(irq_len)"
+  "(Kernel_Config.maxIRQ::nat) < 2^LENGTH(irq_len)"
   using maxIRQ_less_2p_irqBits
   by (simp del: len_of_numeral_defs)
 
@@ -39,33 +39,33 @@ lemma maxIRQ_less_2p_irq_len:
    mentioning numbers: *)
 
 lemma of_nat_maxIRQ[simp]:
-  "of_nat maxIRQ = (maxIRQ::'a::len word)"
+  "of_nat Kernel_Config.maxIRQ = (Kernel_Config.maxIRQ::'a::len word)"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma of_int_maxIRQ[simp]:
-  "of_int maxIRQ = (maxIRQ::'a::len word)"
+  "of_int Kernel_Config.maxIRQ = (Kernel_Config.maxIRQ::'a::len word)"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 (* Safe for [simp] because we don't use maxIRQ at lower than irq_len *)
 lemma unat_maxIRQ[simp]:
-  "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow> unat (maxIRQ::'a word) = maxIRQ"
+  "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow> unat (Kernel_Config.maxIRQ::'a word) = Kernel_Config.maxIRQ"
   by (metis maxIRQ_less_2p_irq_len Word.of_nat_unat of_nat_inverse of_nat_maxIRQ unat_ucast_up_simp)
 
 (* Safe for [simp] because we don't use maxIRQ at lower than irq_len *)
 lemma uint_maxIRQ[simp]:
-  "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow> uint (maxIRQ::'a word) = maxIRQ"
+  "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow> uint (Kernel_Config.maxIRQ::'a word) = Kernel_Config.maxIRQ"
   by (metis Kernel_Config.maxIRQ_def of_nat_numeral uint_nat unat_maxIRQ)
 
 (* Safe for [simp] because we don't use maxIRQ at lower than irq_len *)
 lemma ucast_maxIRQ[simp]:
   "\<lbrakk> LENGTH(irq_len) \<le> LENGTH('a::len); LENGTH(irq_len) \<le> LENGTH('b::len) \<rbrakk> \<Longrightarrow>
-   UCAST ('a \<rightarrow> 'b) maxIRQ = maxIRQ"
+   UCAST ('a \<rightarrow> 'b) Kernel_Config.maxIRQ = Kernel_Config.maxIRQ"
   by (metis of_nat_maxIRQ ucast_nat_def unat_maxIRQ)
 
 (* Safe for [simp] because we don't cast down from irq type *)
 lemma maxIRQ_less_upcast[simp]:
   "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow>
-   (maxIRQ < (ucast irq :: 'a word)) = (maxIRQ < irq)" for irq::irq
+   (Kernel_Config.maxIRQ < (ucast irq :: 'a word)) = (Kernel_Config.maxIRQ < irq)" for irq::irq
   by (simp add: word_less_nat_alt unat_ucast_up_simp)
 
 (* Safe for [simp] because we don't cast down from irq type *)
@@ -78,39 +78,39 @@ lemma maxIRQ_le_upcast[simp]:
    instances is limited and the concrete proofs are much simpler: *)
 
 lemma le_maxIRQ_machine_less_irqBits_val[simplified]:
-  "w \<le> maxIRQ \<Longrightarrow> unat w < 2^LENGTH(irq_len)" for w::machine_word
+  "w \<le> Kernel_Config.maxIRQ \<Longrightarrow> unat w < 2^LENGTH(irq_len)" for w::machine_word
   using maxIRQ_less_2p_irq_len
   by (simp add: word_le_nat_alt)
 
 lemma irq_machine_le_maxIRQ_irq:
-  "irq \<le> Kernel_Config.maxIRQ \<Longrightarrow> (ucast irq::irq) \<le> maxIRQ" for irq::machine_word
+  "irq \<le> Kernel_Config.maxIRQ \<Longrightarrow> (ucast irq::irq) \<le> Kernel_Config.maxIRQ" for irq::machine_word
   by (simp add: Kernel_Config.maxIRQ_def word_le_nat_alt unat_ucast)
 
 lemma maxIRQ_eq_ucast_irq_32_signed_uint:
-  "(maxIRQ = (ucast b :: 32 signed word)) = (uint b = maxIRQ)" for b::irq
+  "(Kernel_Config.maxIRQ = (ucast b :: 32 signed word)) = (uint b = Kernel_Config.maxIRQ)" for b::irq
   unfolding Kernel_Config.maxIRQ_def
   apply uint_arith
   apply (simp add: uint_up_ucast is_up)
   done
 
 lemma sint_maxIRQ_32[simp]:
-  "sint (maxIRQ :: 32 signed word) = maxIRQ"
+  "sint (Kernel_Config.maxIRQ :: 32 signed word) = Kernel_Config.maxIRQ"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma scast_maxIRQ_32_machine[simp]:
-  "scast (maxIRQ::32 signed word) = (maxIRQ::machine_word)"
+  "scast (Kernel_Config.maxIRQ::32 signed word) = (Kernel_Config.maxIRQ::machine_word)"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma scast_maxIRQ_32_irq[simp]:
-  "scast (maxIRQ :: 32 signed word) = (maxIRQ::irq)"
+  "scast (Kernel_Config.maxIRQ :: 32 signed word) = (Kernel_Config.maxIRQ::irq)"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma maxIRQ_ucast_toEnum_eq_machine:
-  "x \<le> maxIRQ \<Longrightarrow> toEnum (unat x) = x" for x::machine_word
+  "x \<le> Kernel_Config.maxIRQ \<Longrightarrow> toEnum (unat x) = x" for x::machine_word
   by (simp add: word_le_nat_alt Kernel_Config.maxIRQ_def)
 
 lemma maxIRQ_ucast_toEnum_eq_irq:
-  "x \<le> maxIRQ \<Longrightarrow> toEnum (unat x) = (ucast x :: irq)" for x::machine_word
+  "x \<le> Kernel_Config.maxIRQ \<Longrightarrow> toEnum (unat x) = (ucast x :: irq)" for x::machine_word
   by (simp add: word_le_nat_alt Kernel_Config.maxIRQ_def)
 
 lemma maxIRQ_1_plus_eq_Suc_machine[simp]:

--- a/spec/machine/AARCH64/Platform.thy
+++ b/spec/machine/AARCH64/Platform.thy
@@ -29,6 +29,10 @@ context Arch begin global_naming AARCH64
 value_type irq_len = Kernel_Config.irqBits (* IRQ_CNODE_SLOT_BITS *)
 type_synonym irq = "irq_len word"
 
+(* maxIRQ is defined via Kernel_Config on this architecture *)
+definition maxIRQ :: "'a::numeral" where
+  "maxIRQ \<equiv> Kernel_Config.maxIRQ"
+
 (* Software-generated interrupts *)
 definition numSGIs_bits :: nat where
   "numSGIs_bits = 4"
@@ -196,5 +200,9 @@ value_type pt_array_len = "(2::nat) ^ LENGTH(pt_index_len)"
 value_type vs_array_len = "(2::nat) ^ vs_index_bits"
 
 end
+
+(* we want to use the Platform constant in the global context instead of the arch-specific one from
+   Kernel_Config *)
+arch_requalify_consts (aliasing) maxIRQ
 
 end

--- a/spec/machine/ARM/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/ARM/Arch_Kernel_Config_Lemmas.thy
@@ -23,7 +23,7 @@ lemma physBase_aligned:
 (* maxIRQ conditions *)
 
 lemma maxIRQ_less_2p_irqBits:
-  "(maxIRQ::nat) < 2^irqBits"
+  "(Kernel_Config.maxIRQ::nat) < 2^irqBits"
   by (simp add: Kernel_Config.maxIRQ_def Kernel_Config.irqBits_def)
 
 (* follows from value_type definition of irq_len *)
@@ -33,7 +33,7 @@ lemma LENGTH_irq_len_irqBits[simp]: (* [simp] will fire only for simp del: len_o
   by simp
 
 lemma maxIRQ_less_2p_irq_len:
-  "(maxIRQ::nat) < 2^LENGTH(irq_len)"
+  "(Kernel_Config.maxIRQ::nat) < 2^LENGTH(irq_len)"
   using maxIRQ_less_2p_irqBits
   by (simp del: len_of_numeral_defs)
 
@@ -41,33 +41,33 @@ lemma maxIRQ_less_2p_irq_len:
    mentioning numbers: *)
 
 lemma of_nat_maxIRQ[simp]:
-  "of_nat maxIRQ = (maxIRQ::'a::len word)"
+  "of_nat Kernel_Config.maxIRQ = (Kernel_Config.maxIRQ::'a::len word)"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma of_int_maxIRQ[simp]:
-  "of_int maxIRQ = (maxIRQ::'a::len word)"
+  "of_int Kernel_Config.maxIRQ = (Kernel_Config.maxIRQ::'a::len word)"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 (* Safe for [simp] because we don't use maxIRQ at lower than irq_len *)
 lemma unat_maxIRQ[simp]:
-  "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow> unat (maxIRQ::'a word) = maxIRQ"
+  "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow> unat (Kernel_Config.maxIRQ::'a word) = Kernel_Config.maxIRQ"
   by (metis maxIRQ_less_2p_irq_len Word.of_nat_unat of_nat_inverse of_nat_maxIRQ unat_ucast_up_simp)
 
 (* Safe for [simp] because we don't use maxIRQ at lower than irq_len *)
 lemma uint_maxIRQ[simp]:
-  "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow> uint (maxIRQ::'a word) = maxIRQ"
+  "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow> uint (Kernel_Config.maxIRQ::'a word) = Kernel_Config.maxIRQ"
   by (metis Kernel_Config.maxIRQ_def of_nat_numeral uint_nat unat_maxIRQ)
 
 (* Safe for [simp] because we don't use maxIRQ at lower than irq_len *)
 lemma ucast_maxIRQ[simp]:
   "\<lbrakk> LENGTH(irq_len) \<le> LENGTH('a::len); LENGTH(irq_len) \<le> LENGTH('b::len) \<rbrakk> \<Longrightarrow>
-   UCAST ('a \<rightarrow> 'b) maxIRQ = maxIRQ"
+   UCAST ('a \<rightarrow> 'b) Kernel_Config.maxIRQ = Kernel_Config.maxIRQ"
   by (metis of_nat_maxIRQ ucast_nat_def unat_maxIRQ)
 
 (* Safe for [simp] because we don't cast down from irq type *)
 lemma maxIRQ_less_upcast[simp]:
   "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow>
-   (maxIRQ < (ucast irq :: 'a word)) = (maxIRQ < irq)" for irq::irq
+   (Kernel_Config.maxIRQ < (ucast irq :: 'a word)) = (Kernel_Config.maxIRQ < irq)" for irq::irq
   by (simp add: word_less_nat_alt unat_ucast_up_simp)
 
 (* Safe for [simp] because we don't cast down from irq type *)
@@ -80,43 +80,43 @@ lemma maxIRQ_le_upcast[simp]:
    instances is limited and the concrete proofs are much simpler: *)
 
 lemma le_maxIRQ_machine_less_irqBits_val[simplified]:
-  "w \<le> maxIRQ \<Longrightarrow> unat w < 2^LENGTH(irq_len)" for w::machine_word
+  "w \<le> Kernel_Config.maxIRQ \<Longrightarrow> unat w < 2^LENGTH(irq_len)" for w::machine_word
   using maxIRQ_less_2p_irq_len
   by (simp add: word_le_nat_alt)
 
 lemma irq_machine_le_maxIRQ_irq:
-  "irq \<le> Kernel_Config.maxIRQ \<Longrightarrow> (ucast irq::irq) \<le> maxIRQ" for irq::machine_word
+  "irq \<le> Kernel_Config.maxIRQ \<Longrightarrow> (ucast irq::irq) \<le> Kernel_Config.maxIRQ" for irq::machine_word
   by (simp add: Kernel_Config.maxIRQ_def word_le_nat_alt unat_ucast)
 
 lemma maxIRQ_eq_ucast_irq_32_signed_uint:
-  "(maxIRQ = (ucast b :: int_word)) = (uint b = maxIRQ)" for b::irq
+  "(Kernel_Config.maxIRQ = (ucast b :: int_word)) = (uint b = Kernel_Config.maxIRQ)" for b::irq
   unfolding Kernel_Config.maxIRQ_def
   apply uint_arith
   apply (simp add: uint_up_ucast is_up)
   done
 
 lemma sint_maxIRQ_32[simp]:
-  "sint (maxIRQ :: int_word) = maxIRQ"
+  "sint (Kernel_Config.maxIRQ :: int_word) = Kernel_Config.maxIRQ"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma scast_maxIRQ_32_machine[simp]:
-  "scast (maxIRQ :: int_word) = (maxIRQ::machine_word)"
+  "scast (Kernel_Config.maxIRQ :: int_word) = (Kernel_Config.maxIRQ::machine_word)"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma scast_maxIRQ_32_irq[simp]:
-  "scast (maxIRQ :: int_word) = (maxIRQ::irq)"
+  "scast (Kernel_Config.maxIRQ :: int_word) = (Kernel_Config.maxIRQ::irq)"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma maxIRQ_ucast_toEnum_eq_machine:
-  "x \<le> maxIRQ \<Longrightarrow> toEnum (unat x) = x" for x::machine_word
+  "x \<le> Kernel_Config.maxIRQ \<Longrightarrow> toEnum (unat x) = x" for x::machine_word
   by (simp add: word_le_nat_alt Kernel_Config.maxIRQ_def)
 
 lemma maxIRQ_ucast_toEnum_eq_irq:
-  "x \<le> maxIRQ \<Longrightarrow> toEnum (unat x) = (ucast x :: irq)" for x::machine_word
+  "x \<le> Kernel_Config.maxIRQ \<Longrightarrow> toEnum (unat x) = (ucast x :: irq)" for x::machine_word
   by (simp add: word_le_nat_alt Kernel_Config.maxIRQ_def)
 
 lemma maxIRQ_1_plus_eq_Suc_machine[simp]:
-  "unat (1 + maxIRQ :: machine_word) = Suc Kernel_Config.maxIRQ"
+  "unat (1 + Kernel_Config.maxIRQ :: machine_word) = Suc Kernel_Config.maxIRQ"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 

--- a/spec/machine/ARM/Platform.thy
+++ b/spec/machine/ARM/Platform.thy
@@ -36,6 +36,10 @@ context Arch begin global_naming ARM
 value_type irq_len = Kernel_Config.irqBits (* IRQ_CNODE_SLOT_BITS *)
 type_synonym irq = "irq_len word"
 
+(* maxIRQ is defined via Kernel_Config on this architecture *)
+definition maxIRQ :: "'a::numeral" where
+  "maxIRQ \<equiv> Kernel_Config.maxIRQ"
+
 (* List of supported Arm platforms that support GICv3 or GICv2 *)
 definition isGICPlatform :: bool where
   "isGICPlatform \<equiv> \<not>(config_PLAT_OMAP3 \<or> config_PLAT_AM335X \<or> config_PLAT_BCM2837)"
@@ -140,5 +144,9 @@ definition minIRQ :: "irq" where
   "minIRQ \<equiv> 0"
 
 end
+
+(* we want to use the Platform constant in the global context instead of the arch-specific one from
+   Kernel_Config *)
+arch_requalify_consts (aliasing) maxIRQ
 
 end

--- a/spec/machine/ARM_HYP/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/ARM_HYP/Arch_Kernel_Config_Lemmas.thy
@@ -22,11 +22,11 @@ lemma physBase_aligned:
 (* maxIRQ conditions *)
 
 lemma irqVTimerEvent_le_maxIRQ[simp, intro!]:
-  "irqVTimerEvent \<le> maxIRQ"
+  "irqVTimerEvent \<le> Kernel_Config.maxIRQ"
   by (simp add: irqVTimerEvent_def Kernel_Config.maxIRQ_def)
 
 lemma maxIRQ_less_2p_irqBits:
-  "(maxIRQ::nat) < 2^irqBits"
+  "(Kernel_Config.maxIRQ::nat) < 2^irqBits"
   by (simp add: Kernel_Config.maxIRQ_def Kernel_Config.irqBits_def)
 
 (* follows from value_type definition of irq_len *)
@@ -36,7 +36,7 @@ lemma LENGTH_irq_len_irqBits[simp]: (* [simp] will fire only for simp del: len_o
   by simp
 
 lemma maxIRQ_less_2p_irq_len:
-  "(maxIRQ::nat) < 2^LENGTH(irq_len)"
+  "(Kernel_Config.maxIRQ::nat) < 2^LENGTH(irq_len)"
   using maxIRQ_less_2p_irqBits
   by (simp del: len_of_numeral_defs)
 
@@ -48,33 +48,33 @@ lemma unat_2p_irqBits_machine[simp]:
    mentioning numbers: *)
 
 lemma of_nat_maxIRQ[simp]:
-  "of_nat maxIRQ = (maxIRQ::'a::len word)"
+  "of_nat Kernel_Config.maxIRQ = (Kernel_Config.maxIRQ::'a::len word)"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma of_int_maxIRQ[simp]:
-  "of_int maxIRQ = (maxIRQ::'a::len word)"
+  "of_int Kernel_Config.maxIRQ = (Kernel_Config.maxIRQ::'a::len word)"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 (* Safe for [simp] because we don't use maxIRQ at lower than irq_len *)
 lemma unat_maxIRQ[simp]:
-  "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow> unat (maxIRQ::'a word) = maxIRQ"
+  "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow> unat (Kernel_Config.maxIRQ::'a word) = Kernel_Config.maxIRQ"
   by (metis maxIRQ_less_2p_irq_len Word.of_nat_unat of_nat_inverse of_nat_maxIRQ unat_ucast_up_simp)
 
 (* Safe for [simp] because we don't use maxIRQ at lower than irq_len *)
 lemma uint_maxIRQ[simp]:
-  "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow> uint (maxIRQ::'a word) = maxIRQ"
+  "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow> uint (Kernel_Config.maxIRQ::'a word) = Kernel_Config.maxIRQ"
   by (metis Kernel_Config.maxIRQ_def of_nat_numeral uint_nat unat_maxIRQ)
 
 (* Safe for [simp] because we don't use maxIRQ at lower than irq_len *)
 lemma ucast_maxIRQ[simp]:
   "\<lbrakk> LENGTH(irq_len) \<le> LENGTH('a::len); LENGTH(irq_len) \<le> LENGTH('b::len) \<rbrakk> \<Longrightarrow>
-   UCAST ('a \<rightarrow> 'b) maxIRQ = maxIRQ"
+   UCAST ('a \<rightarrow> 'b) Kernel_Config.maxIRQ = Kernel_Config.maxIRQ"
   by (metis of_nat_maxIRQ ucast_nat_def unat_maxIRQ)
 
 (* Safe for [simp] because we don't cast down from irq type *)
 lemma maxIRQ_less_upcast[simp]:
   "LENGTH(irq_len) \<le> LENGTH('a::len) \<Longrightarrow>
-   (maxIRQ < (ucast irq :: 'a word)) = (maxIRQ < irq)" for irq::irq
+   (Kernel_Config.maxIRQ < (ucast irq :: 'a word)) = (Kernel_Config.maxIRQ < irq)" for irq::irq
   by (simp add: word_less_nat_alt unat_ucast_up_simp)
 
 (* Safe for [simp] because we don't cast down from irq type *)
@@ -87,47 +87,47 @@ lemma maxIRQ_le_upcast[simp]:
    instances is limited and the concrete proofs are much simpler: *)
 
 lemma le_maxIRQ_machine_less_irqBits_val[simplified]:
-  "w \<le> maxIRQ \<Longrightarrow> unat w < 2^LENGTH(irq_len)" for w::machine_word
+  "w \<le> Kernel_Config.maxIRQ \<Longrightarrow> unat w < 2^LENGTH(irq_len)" for w::machine_word
   using maxIRQ_less_2p_irq_len
   by (simp add: word_le_nat_alt)
 
 lemma irq_machine_le_maxIRQ_irq:
-  "irq \<le> Kernel_Config.maxIRQ \<Longrightarrow> (ucast irq::irq) \<le> maxIRQ" for irq::machine_word
+  "irq \<le> Kernel_Config.maxIRQ \<Longrightarrow> (ucast irq::irq) \<le> Kernel_Config.maxIRQ" for irq::machine_word
   by (simp add: Kernel_Config.maxIRQ_def word_le_nat_alt unat_ucast)
 
 lemma maxIRQ_eq_ucast_irq_32_signed_uint:
-  "(maxIRQ = (ucast b :: 32 signed word)) = (uint b = maxIRQ)" for b::irq
+  "(Kernel_Config.maxIRQ = (ucast b :: 32 signed word)) = (uint b = Kernel_Config.maxIRQ)" for b::irq
   unfolding Kernel_Config.maxIRQ_def
   apply uint_arith
   apply (simp add: uint_up_ucast is_up)
   done
 
 lemma sint_maxIRQ_32[simp]:
-  "sint (maxIRQ :: 32 signed word) = maxIRQ"
+  "sint (Kernel_Config.maxIRQ :: 32 signed word) = Kernel_Config.maxIRQ"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma scast_maxIRQ_32_machine[simp]:
-  "scast (maxIRQ::32 signed word) = (maxIRQ::machine_word)"
+  "scast (Kernel_Config.maxIRQ::32 signed word) = (Kernel_Config.maxIRQ::machine_word)"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma scast_maxIRQ_32_irq[simp]:
-  "scast (maxIRQ :: 32 signed word) = (maxIRQ::irq)"
+  "scast (Kernel_Config.maxIRQ :: 32 signed word) = (Kernel_Config.maxIRQ::irq)"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma maxIRQ_ucast_toEnum_eq_machine:
-  "x \<le> maxIRQ \<Longrightarrow> toEnum (unat x) = x" for x::machine_word
+  "x \<le> Kernel_Config.maxIRQ \<Longrightarrow> toEnum (unat x) = x" for x::machine_word
   by (simp add: word_le_nat_alt Kernel_Config.maxIRQ_def)
 
 lemma maxIRQ_ucast_toEnum_eq_irq:
-  "x \<le> maxIRQ \<Longrightarrow> toEnum (unat x) = (ucast x :: irq)" for x::machine_word
+  "x \<le> Kernel_Config.maxIRQ \<Longrightarrow> toEnum (unat x) = (ucast x :: irq)" for x::machine_word
   by (simp add: word_le_nat_alt Kernel_Config.maxIRQ_def)
 
 lemma maxIRQ_1_plus_eq_Suc_machine[simp]:
-  "unat (1 + maxIRQ :: machine_word) = Suc Kernel_Config.maxIRQ"
+  "unat (1 + Kernel_Config.maxIRQ :: machine_word) = Suc Kernel_Config.maxIRQ"
   by (simp add: Kernel_Config.maxIRQ_def)
 
 lemma maxIRQ_le_mask_irq_len:
-  "x \<le> maxIRQ \<longrightarrow> x \<le> mask irq_len" for x :: machine_word
+  "x \<le> Kernel_Config.maxIRQ \<longrightarrow> x \<le> mask irq_len" for x :: machine_word
   using le_maxIRQ_machine_less_irqBits_val
   by (fastforce simp add: word_le_nat_alt word_less_nat_alt irq_len_val mask_def)
 

--- a/spec/machine/ARM_HYP/Platform.thy
+++ b/spec/machine/ARM_HYP/Platform.thy
@@ -36,6 +36,10 @@ context Arch begin global_naming ARM_HYP
 value_type irq_len = Kernel_Config.irqBits (* IRQ_CNODE_SLOT_BITS *)
 type_synonym irq = "irq_len word"
 
+(* maxIRQ is defined via Kernel_Config on this architecture *)
+definition maxIRQ :: "'a::numeral" where
+  "maxIRQ \<equiv> Kernel_Config.maxIRQ"
+
 (* List of supported Arm platforms that support GICv3 or GICv2 *)
 definition isGICPlatform :: bool where
   "isGICPlatform \<equiv> \<not>(config_PLAT_OMAP3 \<or> config_PLAT_AM335X \<or> config_PLAT_BCM2837)"
@@ -139,5 +143,9 @@ definition irqVTimerEvent :: "irq" where
   "irqVTimerEvent  \<equiv> 27"
 
 end
+
+(* we want to use the Platform constant in the global context instead of the arch-specific one from
+   Kernel_Config *)
+arch_requalify_consts (aliasing) maxIRQ
 
 end

--- a/spec/machine/RISCV64/Platform.thy
+++ b/spec/machine/RISCV64/Platform.thy
@@ -172,7 +172,7 @@ definition minIRQ :: "irq"
   where
   "minIRQ \<equiv> 0"
 
-definition maxIRQ :: "irq"
+definition maxIRQ :: "'a::numeral"
   where
   "maxIRQ \<equiv> 54"
 
@@ -186,4 +186,9 @@ definition pageColourBits :: nat
   "pageColourBits \<equiv> undefined" \<comment> \<open>not implemented on this platform\<close>
 
 end
+
+(* we want to use the Platform constant in the global context instead of the arch-specific one from
+   Kernel_Config *)
+arch_requalify_consts (aliasing) maxIRQ
+
 end

--- a/spec/machine/X64/Platform.thy
+++ b/spec/machine/X64/Platform.thy
@@ -87,6 +87,8 @@ primrec cr3pcid_update :: "(word64 \<Rightarrow> word64) \<Rightarrow> cr3 \<Rig
 where
   "cr3pcid_update f (X64CR3 v0 v1) = (X64CR3 v0 (f v1))"
 
-
 end
+
+arch_requalify_consts maxIRQ
+
 end


### PR DESCRIPTION
On Arm architectures, maxIRQ defaulted to Kernel_Config.maxIRQ, while on other architectures, it defaulted to Platform.L4VARCH.maxIRQ. This caused divergence when attempting to make interfaces that work on all architectures when arch-splitting Interrupt_R.

By forcing a Platform.L4VARCH.maxIRQ definition to exist on all platforms as an numeral, and pointing it to Kernel_Config.maxIRQ on architectures that have it, we can now point to the same constant on all architectures in interfaces.

For the design spec, we keep the abbreviation confining maxIRQ to type irq.

For CRefine, add maxIRQ_def to [simp] in ArchMove_R for Kernel_Config architectures, in order to keep the proof as close to what it used to be, which expected to only see Kernel_Config.maxIRQ.

Refine update is the minimal necessary to proceed to Interrupt_R arch-split, where we can have a go at proper interfacing.

This also means that Arch_Kernel_Config_Lemmas now needs to say which maxIRQ it's talking about. Apart from being verbose, this now causes another friction point: we might want to have those lemmas on the arch-common maxIRQ, and they only exist on Kernel_Config-enabled arches. So if we add such lemmas for Platform.L4VARCH.maxIRQ, we immediately get a "what do I call this thing" head-scratcher.

Merge-wise, this can go in after Tcb_R arch-split. It's necessary to arch-split Interrupt_R.