### PR TITLE
Aarch64 asid map 

### DIFF
--- a/lib/Monads/reader_option/Reader_Option_Monad.thy
+++ b/lib/Monads/reader_option/Reader_Option_Monad.thy
@@ -39,6 +39,8 @@ definition map_set :: "('a \<Rightarrow> 'b set option) \<Rightarrow> 'a \<Right
 definition opt_pred :: "('a \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> 'a option) \<Rightarrow> ('b \<Rightarrow> bool)" (infixl "|<" 55) where
   "P |< proj \<equiv> (\<lambda>x. case_option False P (proj x))"
 
+definition opt_filter :: "('a \<Rightarrow> bool) \<Rightarrow> 'a \<Rightarrow> 'a option" where
+  "opt_filter P x \<equiv> if P x then Some x else None"
 
 subsection \<open>Lemmas for @{const opt_map}\<close>
 
@@ -190,6 +192,101 @@ lemma opt_pred_proj_upd_eq[simp]:
   "(P |< proj (p \<mapsto> v)) p = P v"
   by (simp add: in_opt_pred)
 
+subsection \<open>Lemmas for @{const opt_filter}\<close>
+
+lemma opt_filter_True[simp]:
+  "opt_filter \<top> = Some"
+  by (simp add: opt_filter_def[abs_def])
+
+lemma opt_filter_False[simp]:
+  "opt_filter \<bottom> = (\<lambda>_. None)"
+  by (simp add: opt_filter_def[abs_def])
+
+lemma opt_filter_map_eq:
+  "opt_filter P |> f = (\<lambda>x. if P x then f x else None)"
+  by (auto simp: opt_filter_def[abs_def] opt_map_def)
+
+lemma neg_opt_filter_map_eq:
+  "opt_filter (not P) |> f = (\<lambda>x. if P x then None else f x)"
+  by (auto simp: opt_filter_def[abs_def] opt_map_def)
+
+lemma opt_filter_map_apply:
+  "(opt_filter P |> f) x = (if P x then f x else None)"
+  by (auto simp: opt_filter_def opt_map_def)
+
+lemma opt_filter_Some_map_eq:
+  "opt_filter P ||> f = (\<lambda>x. if P x then Some (f x) else None)"
+  by (auto simp: opt_filter_def[abs_def] opt_map_def)
+
+lemma in_opt_filter_eq:
+  "opt_filter P x = Some y \<longleftrightarrow> P x \<and> y = x"
+  by (auto simp: opt_filter_def)
+
+lemma in_opt_filter_None_eq:
+  "opt_filter P x = None \<longleftrightarrow> \<not> P x"
+  by (simp add: opt_filter_def)
+
+lemma in_opt_map_filter_Some:
+  "(f |> opt_filter P) x = Some y \<longleftrightarrow> f x = Some y \<and> P y"
+  by (simp add: in_opt_map_eq in_opt_filter_eq)
+
+lemma in_opt_filter_map_Some:
+  "(opt_filter P |> f) x = Some y \<longleftrightarrow> P x \<and> f x = Some y"
+  by (simp add: in_opt_map_eq in_opt_filter_eq)
+
+lemma opt_filter_conj:
+  "opt_filter P |> opt_filter Q = opt_filter (P and Q)"
+  by (auto simp: opt_filter_def[abs_def] opt_map_def)
+
+lemma opt_filter_idem[simp]:
+  "opt_filter P |> opt_filter P = opt_filter P"
+  by (simp add: opt_filter_conj)
+
+lemma opt_filter_comm:
+  "opt_filter P |> opt_filter Q = opt_filter Q |> opt_filter P"
+  by (simp add: opt_filter_conj inf_commute)
+
+lemma opt_pred_opt_filter[simp]:
+  "(P |< opt_filter Q) = (P and Q)"
+  by (auto simp: in_opt_pred in_opt_filter_eq)
+
+lemma opt_pred_opt_filter_map[simp]:
+  "(P |< (f |> opt_filter Q)) = (P and Q) |< f"
+  by (simp add: opt_pred_unfold_map)
+
+lemma opt_pred_is_opt_filter:
+  "(P |< f) x \<longleftrightarrow> (\<exists>y. (f |> opt_filter P) x = Some y)"
+  by (auto simp: in_opt_pred in_opt_filter_eq in_opt_map_eq)
+
+lemma opt_pred_top_Some:
+  "(\<top> |< f) = (\<lambda>x. \<exists>y. f x = Some y)"
+  by (auto simp: in_opt_pred)
+
+lemma opt_filter_mono:
+  "\<lbrakk> \<And>x. P x \<Longrightarrow> Q x; opt_filter P x = Some y \<rbrakk> \<Longrightarrow> opt_filter Q x = Some y"
+  by (simp add: in_opt_filter_eq)
+
+lemma opt_map_filter_id:
+  "\<lbrakk> \<And>x y. f x = Some y \<Longrightarrow> P y \<rbrakk> \<Longrightarrow> f |> opt_filter P = f"
+  by (auto simp: opt_map_def in_opt_filter_eq split: option.splits)
+
+lemma opt_map_Some_map_eq:
+  "g ||> f |> h = g |> (h \<circ> f)"
+  by (auto simp add: opt_map_def split: option.splits)
+
+lemma opt_filter_upd_None_id:
+  "\<not>P x \<Longrightarrow> (opt_filter P) (x := None) = opt_filter P"
+  by (auto simp: opt_filter_def)
+
+lemma opt_filter_apply_None:
+  "\<not>P x \<Longrightarrow> opt_filter P x = None"
+  by (auto simp: opt_filter_def)
+
+lemma opt_filter_apply_Some:
+  "P x \<Longrightarrow> opt_filter P x = Some x"
+  by (auto simp: opt_filter_def)
+
+lemmas opt_filter_apply = opt_filter_apply_None opt_filter_apply_Some
 
 section \<open>The Reader Option Monad\<close>
 

--- a/proof/access-control/AARCH64/ArchAccess.thy
+++ b/proof/access-control/AARCH64/ArchAccess.thy
@@ -180,7 +180,7 @@ subsection \<open>How arch objects can change\<close>
 definition asid_pool_integrity ::
   "'a set \<Rightarrow> 'a PAS \<Rightarrow> (asid_low_index \<rightharpoonup> asid_pool_entry) \<Rightarrow> (asid_low_index \<rightharpoonup> asid_pool_entry) \<Rightarrow> bool" where
   "asid_pool_integrity subjects aag pool pool' \<equiv>
-     \<forall>x. option_map ap_vspace (pool' x) \<noteq> option_map ap_vspace (pool x)
+     \<forall>x. pool' x \<noteq> pool x
          \<longrightarrow> pool' x = None \<and> aag_subjects_have_auth_to subjects aag Control (ap_vspace (the (pool x)))"
 
 inductive arch_integrity_obj_atomic ::

--- a/proof/access-control/AARCH64/ArchArch_AC.thy
+++ b/proof/access-control/AARCH64/ArchArch_AC.thy
@@ -1121,14 +1121,6 @@ lemma perform_pg_inv_get_addr_pas_refined [wp]:
   unfolding perform_pg_inv_get_addr_def
   by wp auto
 
-lemma store_pte_vmid_for_asid[wp]:
-  " store_pte pt_t p pte
-   \<lbrace>\<lambda>s. P (vmid_for_asid s asid)\<rbrace>"
-  apply (simp add: store_pte_def set_pt_def)
-  apply (wp get_object_wp set_object_wp)
-  by (auto simp: obj_at_def opt_map_def vmid_for_asid_def obind_def entry_for_pool_def
-          split: if_splits option.splits)
-
 lemma unmap_page_pas_refined:
   "\<lbrace>pas_refined aag and invs and K (vptr \<in> user_region)\<rbrace>
    unmap_page pgsz asid vptr pptr
@@ -1348,14 +1340,6 @@ lemma unmap_page_respects:
                           ucast_ucast_b ucast_up_ucast_id is_up_def source_size_def target_size_def)
   apply simp
   done
-
-lemma set_cap_vmid_for_asid[wp]:
-  "set_cap cap cslot
-   \<lbrace>\<lambda>s. P (vmid_for_asid s asid)\<rbrace>"
-  apply (simp add: set_cap_def)
-  apply (wpsimp wp: get_object_wp set_object_wp)
-  by (auto simp: obj_at_def opt_map_def vmid_for_asid_def obind_def entry_for_pool_def
-          split: if_splits option.splits)
 
 crunch isb, dsb
   for vcpu_state[wp]: "\<lambda>s. P (vcpu_state s)"
@@ -1624,7 +1608,7 @@ lemma store_pte_state_vrefs_unreachable:
 lemma store_asid_pool_entry_state_vrefs:
   "\<lbrace>\<lambda>s. P (\<lambda>x. if x = pool_ptr
                then vs_refs_aux asid_pool_level (ASIDPool (\<lambda>a. if a = asid_low_bits_of asid
-                                                               then Some (ASIDPoolVSpace None pt_base)
+                                                               then Some (ASIDPoolVSpace pt_base)
                                                                else the (asid_pools_of s pool_ptr) a))
                else if x = pt_base
                then vs_refs_aux max_pt_level (the (vspace_objs_of s x))
@@ -1634,7 +1618,7 @@ lemma store_asid_pool_entry_state_vrefs:
         (\<forall>pool. ako_at (ASIDPool pool) pool_ptr s \<longrightarrow> pool (asid_low_bits_of asid) = None) \<and>
         (\<forall>level. \<not>\<exists>\<rhd> (level, pt_base) s) \<and>
         (\<exists>pt. pts_of s pt_base = Some (empty_pt VSRootPT_T))\<rbrace>
-   store_asid_pool_entry pool_ptr asid (Some (ASIDPoolVSpace None pt_base))
+   store_asid_pool_entry pool_ptr asid (Some (ASIDPoolVSpace pt_base))
    \<lbrace>\<lambda>_ s. P (state_vrefs s)\<rbrace>"
   unfolding store_asid_pool_entry_def set_asid_pool_def
   apply (wpsimp wp: set_object_wp get_cap_wp)
@@ -1719,7 +1703,7 @@ lemma store_asid_pool_entry_pas_refined:
         (\<forall>level. \<not>\<exists>\<rhd> (level, pt_base) s) \<and>
         (\<forall>pool. ako_at (ASIDPool pool) pool_ptr s \<longrightarrow> pool (asid_low_bits_of asid) = None) \<and>
         (\<exists>pt. pts_of s pt_base = Some (empty_pt VSRootPT_T))\<rbrace>
-   store_asid_pool_entry pool_ptr asid (Some (ASIDPoolVSpace None pt_base))
+   store_asid_pool_entry pool_ptr asid (Some (ASIDPoolVSpace pt_base))
    \<lbrace>\<lambda>_ s. pas_refined aag s\<rbrace>"
   apply (clarsimp simp: pas_refined_def state_objs_to_policy_def)
   apply (rule hoare_pre)

--- a/proof/access-control/AARCH64/ArchSyscall_AC.thy
+++ b/proof/access-control/AARCH64/ArchSyscall_AC.thy
@@ -122,6 +122,7 @@ lemma arch_activate_idle_thread_pas_refined[Syscall_AC_assms, wp]:
 
 lemma update_asid_pool_entry_valid_cur_vcpu[wp]:
   "update_asid_pool_entry f asid \<lbrace>valid_cur_vcpu\<rbrace>"
+  unfolding update_asid_pool_entry_def
   by (wpsimp wp: valid_cur_vcpu_lift_weak in_cur_domain_lift_weak)
 
 lemma valid_cur_vcpu_vmid_upd[simp]:

--- a/proof/access-control/AARCH64/ExampleSystem.thy
+++ b/proof/access-control/AARCH64/ExampleSystem.thy
@@ -380,6 +380,7 @@ where
     arch_state = \<lparr>
         arm_asid_table = Map.empty,
         arm_kernel_vspace = init_vspace_uses,
+        arm_asid_map = Map.empty,
         arm_vmid_table = Map.empty,
         arm_next_vmid = 0,
         arm_us_global_vspace = arm_global_pt_ptr,
@@ -917,6 +918,7 @@ where
     arch_state = \<lparr>
         arm_asid_table = Map.empty,
         arm_kernel_vspace = init_vspace_uses,
+        arm_asid_map = Map.empty,
         arm_vmid_table = Map.empty,
         arm_next_vmid = 0,
         arm_us_global_vspace = arm_global_pt_ptr,

--- a/proof/crefine/AARCH64/Fastpath_C.thy
+++ b/proof/crefine/AARCH64/Fastpath_C.thy
@@ -1786,8 +1786,8 @@ lemma capVSBasePtr_CL_capUntypedPtr_helper:
                dest!: isValidVTableRootD')
 
 lemma casid_map_relation_Some_get_tag:
-  "casid_map_relation (Some asid_entry) asid_entry'
-   \<Longrightarrow> asid_map_get_tag asid_entry' = signed asid_map_asid_map_vspace"
+  "casid_map_relation (Some asid_pool_entry) asid_pool_entry'
+   \<Longrightarrow> asid_map_get_tag asid_pool_entry' = signed asid_map_asid_map_vspace"
   by (clarsimp simp: casid_map_relation_def asid_map_lift_def Let_def
                split: option.splits if_splits asid_map_CL.splits)
 

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -749,37 +749,10 @@ lemma valid_asid_table_inj:
   unfolding valid_asid_table_def
   by clarsimp (drule inj_onD; fastforce)
 
-lemma set_asid_pool_None_vmid[wp]:
-  "\<lbrace>\<lambda>s. valid_asid_table s \<and>
-        asid_pools_of s p = Some ap \<and>
-        (\<exists>asid_high. asid_table s asid_high = Some p \<and>
-                     P ((vmid_for_asid s) (asid_of asid_high asid_low := None)))\<rbrace>
-   set_asid_pool p (ap(asid_low := None))
-   \<lbrace>\<lambda>_ s. P (vmid_for_asid s)\<rbrace>"
-  apply (wp_pre, wps, wp)
-  apply (clarsimp simp del: fun_upd_apply)
-  apply (erule rsubst[where P=P])
-  apply (rule ext)
-  apply (clarsimp simp: vmid_for_asid_def obind_def simp del: fun_upd_apply split: option.splits)
-  apply (clarsimp simp: opt_map_left_None)
-  apply (rule opt_map_apply_left_eq)
-  apply (clarsimp simp: entry_for_pool_def obind_def split: option.splits)
-  apply (drule (2) valid_asid_table_inj, simp)
-  apply (erule notE)
-  apply (simp add: asid_bits_of_defs)
-  apply (word_eqI_solve simp: asid_high_bits_def asid_low_bits_def)
-  done
-
 lemma set_asid_pool_None_vmid_inv:
-  "\<lbrace>\<lambda>s. vmid_inv s \<and> valid_asid_table s \<and>
-        asid_pools_of s p = Some ap \<and>
-        (\<exists>asid_high. asid_table s asid_high = Some p \<and>
-                     vmid_for_asid s (asid_of asid_high asid_low) = None) \<rbrace>
-   set_asid_pool p (ap(asid_low := None))
-   \<lbrace>\<lambda>_. vmid_inv\<rbrace>"
+  "set_asid_pool p (ap(asid_low := None)) \<lbrace>vmid_inv\<rbrace>"
   unfolding vmid_inv_def
-  by (rule hoare_lift_Pf2[where f="\<lambda>s. arm_vmid_table (arch_state s)"]; wp)
-     (fastforce simp del: fun_upd_apply)
+  by wp
 
 lemma set_asid_pool_vcpus_of[wp]:
   "set_asid_pool p ap \<lbrace>\<lambda>s. P (vcpus_of s)\<rbrace>"
@@ -794,21 +767,56 @@ lemma set_asid_pool_dom[wp]:
      (auto simp: dom_def opt_map_def obj_at_def is_ArchObj_def
            split: option.splits elim!: rsubst[where P=P])
 
-lemma set_asid_pool_valid_asid_table[wp]:
-  "set_asid_pool p ap \<lbrace>valid_asid_table\<rbrace>"
+lemma asid_high_bits_of_0[simp]:
+  "asid_high_bits_of 0 = 0"
+  by (simp add: asid_high_bits_of_def)
+
+lemma asid_low_bits_of_0[simp]:
+  "asid_low_bits_of 0 = 0"
+  by (simp add: asid_low_bits_of_def)
+
+lemma asid_entry_pools_None:
+  "\<lbrakk> asid_entry table pools asid = None; pools p = Some ap \<rbrakk> \<Longrightarrow>
+   asid_entry table (pools(p \<mapsto> ap(asid_low := None))) asid = None"
+  unfolding asid_entry_def
+  by (auto split: Option.bind_splits)
+
+lemma asid_entry_0_pools_Some:
+  "\<lbrakk> asid_entry table pools 0 = None; inj_on table (dom table);
+     table (asid_high_bits_of asid) = Some p; pools p = Some ap; asid \<noteq> 0 \<rbrakk> \<Longrightarrow>
+   asid_entry table (pools(p \<mapsto> ap(asid_low_bits_of asid \<mapsto> entry))) 0 = None"
+  unfolding asid_entry_def
+  by (auto split: Option.bind_splits simp: asid_high_low_inj inj_on_domD)
+
+lemma set_asid_pool_None_valid_asid_table[wp]:
+  "\<lbrace>valid_asid_table and (\<lambda>s. asid_pools_of s p = Some ap)\<rbrace>
+   set_asid_pool p (ap(asid_low := None))
+   \<lbrace>\<lambda>_. valid_asid_table\<rbrace>"
   unfolding valid_asid_table_def
-  using set_asid_pool_asid_pools_of[wp del]
-  by (wp_pre, wps, wp, clarsimp)
+  supply set_asid_pool_asid_pools_of[wp del] fun_upd_apply[simp del]
+  apply (wp_pre, wps)
+   apply (wp set_asid_pool_asid_pools_of)
+  apply (clarsimp simp: asid_entry_pools_None)
+  done
+
+lemma set_asid_pool_Some_valid_asid_table[wp]:
+  "\<lbrace>valid_asid_table and
+    (\<lambda>s. asid_table s (asid_high_bits_of asid) = Some p \<and> asid_pools_of s p = Some ap \<and> asid \<noteq> 0)\<rbrace>
+   set_asid_pool p (ap(asid_low_bits_of asid \<mapsto> entry))
+   \<lbrace>\<lambda>_. valid_asid_table\<rbrace>"
+  unfolding valid_asid_table_def
+  supply set_asid_pool_asid_pools_of[wp del] fun_upd_apply[simp del]
+  apply (wp_pre, wps)
+   apply (wp set_asid_pool_asid_pools_of)
+  apply (clarsimp simp: asid_entry_0_pools_Some)
+  done
 
 lemma set_asid_pool_valid_global_tables[wp]:
   "set_asid_pool p ap \<lbrace>valid_global_tables\<rbrace>"
   by (wp_pre, wps, wp, clarsimp)
 
 lemma set_asid_pool_None_valid_arch:
-  "\<lbrace>\<lambda>s. valid_arch_state s \<and>
-        asid_pools_of s p = Some ap \<and>
-        (\<exists>asid_high. asid_table s asid_high = Some p \<and>
-                     vmid_for_asid s (asid_of asid_high asid_low) = None) \<rbrace>
+  "\<lbrace>valid_arch_state and (\<lambda>s. asid_pools_of s p = Some ap)\<rbrace>
    set_asid_pool p (ap (asid_low := None))
    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
   unfolding valid_arch_state_def
@@ -1990,14 +1998,35 @@ crunch set_asid_pool
   for valid_asid_pool_caps[wp]: valid_asid_pool_caps
   (ignore: set_object)
 
+lemma set_asid_pool_None_vspace_for_asid:
+  "\<lbrace>\<lambda>s. valid_asid_table s \<and>
+        (\<exists>asid_high. asid_table s asid_high = Some p \<and> asid_pools_of s p = Some ap \<and>
+                     P ((\<lambda>asid. vspace_for_asid asid s)(asid_of asid_high asid_low := None))) \<rbrace>
+   set_asid_pool p (ap (asid_low := None))
+   \<lbrace>\<lambda>_ s. P (\<lambda>asid. vspace_for_asid asid s)\<rbrace>"
+  unfolding set_asid_pool_def
+  apply (wp set_object_wp)
+  apply clarsimp
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: vspace_for_asid_def obind_def entry_for_asid_def pool_for_asid_def
+                        entry_for_pool_def
+                  split: option.splits)
+  apply (prop_tac "asid_high_bits_of asid = asid_high")
+   apply (simp add: valid_asid_table_inj)
+  apply clarsimp
+  done
+
 lemma set_asid_pool_None_valid_asid_map[wp]:
-  "\<lbrace> valid_asid_map and (\<lambda>s. asid_pools_of s p = Some ap) \<rbrace>
+  "\<lbrace>valid_asid_map and valid_asid_table and
+    (\<lambda>s. \<exists>asid_high. asid_table s asid_high = Some p \<and> asid_pools_of s p = Some ap \<and>
+                     asid_map s (asid_of asid_high asid_low) = None) \<rbrace>
    set_asid_pool p (ap (asid_low := None))
    \<lbrace>\<lambda>_. valid_asid_map\<rbrace>"
-  unfolding valid_asid_map_def entry_for_asid_def
-  apply (clarsimp simp: obind_None_eq pool_for_asid_def)
-  apply (wp hoare_vcg_disj_lift hoare_vcg_ex_lift get_object_wp)
-  apply (fastforce simp: entry_for_pool_def obind_None_eq in_omonad split: if_split_asm)
+  unfolding valid_asid_map_def
+  supply fun_upd_apply[simp del]
+  apply (wpsimp wp: set_asid_pool_None_vspace_for_asid hoare_Ball_helper)
+  apply (fastforce simp: fun_upd_apply)
   done
 
 crunch set_asid_pool
@@ -2006,9 +2035,8 @@ crunch set_asid_pool
 
 lemma set_asid_pool_invs_unmap:
   "\<lbrace>invs and
-    (\<lambda>s. asid_pools_of s p = Some ap) and
-    (\<lambda>s. \<exists>asid_high. asid_table s asid_high = Some p \<and>
-                     vmid_for_asid s (asid_of asid_high asid_low) = None)\<rbrace>
+    (\<lambda>s. \<exists>asid_high. asid_table s asid_high = Some p \<and> asid_pools_of s p = Some ap \<and>
+                     asid_map s (asid_of asid_high asid_low) = None)\<rbrace>
    set_asid_pool p (ap (asid_low := None))
    \<lbrace>\<lambda>_. invs\<rbrace>"
   apply (simp add: invs_def valid_state_def valid_pspace_def
@@ -2023,7 +2051,6 @@ lemma set_asid_pool_invs_unmap:
 
 lemmas set_asid_pool_cte_wp_at1[wp]
     = hoare_cte_wp_caps_of_state_lift [OF set_asid_pool_caps_of_state]
-
 
 lemma mdb_cte_at_set_asid_pool[wp]:
   "\<lbrace>\<lambda>s. mdb_cte_at (swp (cte_wp_at ((\<noteq>) cap.NullCap)) s) (cdt s)\<rbrace>

--- a/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
@@ -397,8 +397,9 @@ lemma valid_arch_caps:
 
 lemma valid_asid_map':
   "valid_asid_map s \<Longrightarrow> valid_asid_map s'"
-  by (clarsimp simp: valid_asid_map_def entry_for_asid_def obind_None_eq pool_for_asid_def s'_def
-                     entry_for_pool_def ko)
+  using ko empty
+  by (force simp: valid_asid_map_def vspace_for_asid_def entry_for_asid_def obind_None_eq
+                  pool_for_asid_def s'_def entry_for_pool_def)
 
 lemma vspace_for_asid[simp]:
   "vspace_for_asid asid s' = vspace_for_asid asid s"
@@ -420,11 +421,12 @@ end
 
 context Arch begin arch_global_naming
 
-lemma vmid_for_asid_empty_update:
-  "\<lbrakk> asid_table s asid_high = None; asid_pools_of s ap = Some Map.empty \<rbrakk> \<Longrightarrow>
-   vmid_for_asid_2 asid ((asid_table s)(asid_high \<mapsto> ap)) (asid_pools_of s) = vmid_for_asid s asid"
-  by (clarsimp simp: vmid_for_asid_2_def obind_def entry_for_pool_def opt_map_def
-               split: option.splits)
+lemma asid_entry_table_Some:
+  "\<lbrakk>\<forall>asid. table asid \<noteq> Some ap;
+    asid_table s asid = None; pools ap = Some Map.empty; asid_entry table pools 0 = None\<rbrakk> \<Longrightarrow>
+   asid_entry (table(asid \<mapsto> ap)) pools 0 = None"
+  unfolding asid_entry_def
+  by (clarsimp split: Option.bind_splits)
 
 lemma valid_arch_state_strg:
   "valid_arch_state s \<and> ap \<notin> ran (asid_table s) \<and> asid_table s asid = None \<and>
@@ -433,10 +435,9 @@ lemma valid_arch_state_strg:
   apply (clarsimp simp: valid_arch_state_def)
   apply (clarsimp simp: valid_asid_table_def ran_def valid_global_arch_objs_def)
   apply (prop_tac "vmid_inv (asid_table_update asid ap s)")
-   apply (fastforce simp: vmid_inv_def vmid_for_asid_empty_update ran_def)
-  apply (fastforce intro!: inj_on_fun_updI simp: asid_pools_at_eq)
+   apply (fastforce simp: vmid_inv_def ran_def)
+  apply (fastforce intro!: inj_on_fun_updI simp: asid_pools_at_eq asid_entry_table_Some)
   done
-
 
 lemma valid_vs_lookup_at_upd_strg:
   "valid_vs_lookup s \<and>
@@ -584,8 +585,8 @@ lemma valid_asid_map_asid_upd_strg:
    asid_pools_of s ap = Some Map.empty \<and>
    asid_table s asid = None \<longrightarrow>
    valid_asid_map (asid_table_update asid ap s)"
-  by (simp add: valid_asid_map_def entry_for_asid_def obind_None_eq entry_for_pool_def
-                pool_for_asid_def)
+  by (force simp: valid_asid_map_def vspace_for_asid_def entry_for_asid_def obind_None_eq
+                  entry_for_pool_def pool_for_asid_def)
 
 lemma valid_vspace_objs_asid_upd_strg:
   "valid_vspace_objs s \<and>

--- a/proof/invariant-abstract/AARCH64/ArchBits_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBits_AI.thy
@@ -21,6 +21,10 @@ sublocale p_asid_table_vmid_table_update:
   Arch_p_asid_table_update_eq "\<lambda>s. s\<lparr>arch_state := arm_vmid_table_update f (arch_state s)\<rparr>"
   by (unfold_locales) auto
 
+sublocale p_asid_table_asid_map_update:
+  Arch_p_asid_table_update_eq "\<lambda>s. s\<lparr>arch_state := arm_asid_map_update f (arch_state s)\<rparr>"
+  by (unfold_locales) auto
+
 sublocale p_asid_table_next_vmid_update:
   Arch_p_asid_table_update_eq "\<lambda>s. s\<lparr>arch_state := arm_next_vmid_update f (arch_state s)\<rparr>"
   by (unfold_locales) auto

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
@@ -73,6 +73,7 @@ lemma set_asid_pool_valid_queues[wp]:
 crunch set_asid_pool, set_vm_root, vcpu_flush
   for cur_domain[wp]: "\<lambda>s. P (cur_domain s)"
   and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
+  and scheduler_action[wp]: "\<lambda>s. P (scheduler_action s)"
 
 lemma set_asid_pool_weak_valid_sched_action[wp]:
   "set_asid_pool ptr pool \<lbrace>weak_valid_sched_action\<rbrace>"

--- a/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
@@ -279,8 +279,10 @@ lemma valid_asid_table:
   "valid_asid_table (detype (untyped_range cap) s)"
   using valid_arch_state
   apply (clarsimp simp: valid_asid_table_def valid_arch_state_def)
-  apply (drule (1) subsetD)
-  apply (clarsimp simp: ran_def asid_table_Some_not_untyped_range)
+  apply (rule conjI, clarsimp)
+   apply (drule (1) subsetD)
+   apply (clarsimp simp: ran_def asid_table_Some_not_untyped_range)
+  apply (clarsimp simp: asid_entry_def split: Option.bind_splits)
   done
 
 lemma entry_for_pool_detype_Some[simp]:
@@ -288,19 +290,12 @@ lemma entry_for_pool_detype_Some[simp]:
    (pool_ptr \<notin> S \<and> entry_for_pool pool_ptr asid pools = Some p)"
   by (clarsimp simp: entry_for_pool_def in_omonad)
 
-lemma vmid_for_asid_2_detype_Some[simp]:
-  "(vmid_for_asid_2 asid table (\<lambda>p. if p \<in> S then None else pools p) = Some p) =
-   ((\<exists>pool_ptr. table (asid_high_bits_of asid) = Some pool_ptr \<and> pool_ptr \<notin> S)
-    \<and> vmid_for_asid_2 asid table pools = Some p)"
-  by (fastforce simp: vmid_for_asid_def in_omonad)
-
 lemma vmid_inv_detype:
   "vmid_inv (detype (untyped_range cap) s)"
   apply (prop_tac "vmid_inv s")
    using valid_arch_state
    apply (simp add: valid_arch_state_def)
-  apply (fastforce simp: vmid_inv_def is_inv_def asid_pools_of_detype vmid_for_asid_def
-                         in_omonad asid_table_Some_not_untyped_range)
+  apply (fastforce simp: vmid_inv_def is_inv_def)
   done
 
 lemma vcpus_of_detype[simp]:
@@ -504,7 +499,7 @@ proof -
     using invs by (simp add: invs_def valid_state_def)
   thus ?thesis
     by (clarsimp simp: valid_asid_map_def entry_for_asid_def obind_None_eq pool_for_asid_def
-                       entry_for_pool_def)
+                       entry_for_pool_def vspace_for_asid_def asid_table_Some_not_untyped_range)
 qed
 
 lemma equal_kernel_mappings_detype[detype_invs_proofs]:

--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -591,9 +591,25 @@ definition global_refs :: "'z::state_ext state \<Rightarrow> obj_ref set" where
      {idle_thread s, arm_us_global_vspace (arch_state s)} \<union>
      range (interrupt_irq_node s)"
 
+definition asid_entry ::
+  "(asid_high_index \<rightharpoonup> obj_ref) \<Rightarrow> (obj_ref \<rightharpoonup> (asid_low_index \<rightharpoonup> asid_pool_entry)) \<Rightarrow> asid
+   \<rightharpoonup> asid_pool_entry"
+  where
+  "asid_entry table pools asid \<equiv> do {
+     pool_ptr \<leftarrow> table (asid_high_bits_of asid);
+     pool \<leftarrow> pools pool_ptr;
+     pool (asid_low_bits_of asid)
+   }"
+
+lemma asid_entry_eq_entry_for_asid:
+  "asid_entry (asid_table s) (asid_pools_of s) asid = entry_for_asid asid s"
+  by (simp add: asid_entry_def entry_for_asid_def pool_for_asid_def entry_for_pool_def obind_def
+           split: Option.bind_split)
+
 definition valid_asid_table_2 :: "(asid_high_index \<rightharpoonup> obj_ref) \<Rightarrow> (obj_ref \<rightharpoonup> asid_pool) \<Rightarrow> bool"
   where
-  "valid_asid_table_2 table pools \<equiv> ran table \<subseteq> dom pools \<and> inj_on table (dom table)"
+  "valid_asid_table_2 table pools \<equiv>
+     ran table \<subseteq> dom pools \<and> inj_on table (dom table) \<and> asid_entry table pools 0 = None"
 
 locale_abbrev valid_asid_table :: "'z::state_ext state \<Rightarrow> bool" where
   "valid_asid_table \<equiv> \<lambda>s. valid_asid_table_2 (asid_table s) (asid_pools_of s)"
@@ -649,28 +665,12 @@ locale_abbrev valid_uses :: "'z::state_ext state \<Rightarrow> bool" where
 
 lemmas valid_uses_def = valid_uses_2_def
 
-definition vmid_for_asid_2 ::
-  "asid \<Rightarrow> (asid_high_index \<rightharpoonup> obj_ref) \<Rightarrow> (obj_ref \<rightharpoonup> asid_pool, vmid) lookup" where
-  "vmid_for_asid_2 asid table \<equiv> do {
-     ap_ptr \<leftarrow> K $ table (asid_high_bits_of asid);
-     entry_for_pool ap_ptr asid |> ap_vmid
-   }"
-
-locale_abbrev vmid_for_asid :: "'z::state_ext state \<Rightarrow> asid \<rightharpoonup> vmid" where
-  "vmid_for_asid \<equiv> \<lambda>s asid. vmid_for_asid_2 asid (asid_table s) (asid_pools_of s)"
-
-lemmas vmid_for_asid_def = vmid_for_asid_2_def
-
-(* For name preservation with older proofs *)
-abbreviation (input) asid_map :: "'z::state_ext state \<Rightarrow> asid \<rightharpoonup> vmid" where
-  "asid_map \<equiv> vmid_for_asid"
-
 locale_abbrev
   "vmid_table s \<equiv> arm_vmid_table (arch_state s)"
 
-(* vmIDs stored in ASID pools form the inverse of the vmid_table *)
+(* vmIDs stored in the asid_map form the inverse of the vmid_table *)
 definition vmid_inv :: "'z::state_ext state \<Rightarrow> bool" where
-  "vmid_inv s \<equiv> is_inv (vmid_table s) (vmid_for_asid s)"
+  "vmid_inv s \<equiv> is_inv (vmid_table s) (asid_map s)"
 
 (* The vmID table never stores ASID 0 *)
 definition valid_vmid_table_2 :: "(vmid \<rightharpoonup> asid) \<Rightarrow> bool" where
@@ -763,11 +763,12 @@ lemmas hyp_refs_of_simps[simp] = hyp_refs_of_def[split_simps kernel_object.split
 definition state_hyp_refs_of :: "'z::state_ext state \<Rightarrow> obj_ref \<Rightarrow> (obj_ref \<times> reftype) set" where
   "state_hyp_refs_of \<equiv> \<lambda>s p. case_option {} (hyp_refs_of) (kheap s p)"
 
-
-(* Mostly covered by ASIDPool case of valid_vspace_obj and vmid_inv, but we still need to make sure
-   that ASID 0 is never mapped. *)
+(* Compared to ARM we do not duplicate the vspace pointer in the asid_map, but instead use the
+   existing vspace_for_asid function. The invariant records that we only allocate a VMID for an
+   ASID if there also exists a VSpace for that ASID. Since vspace_for_asid already implies that
+   the ASID is not 0, we do not need that conjunct here. *)
 definition valid_asid_map :: "'z::state_ext state \<Rightarrow> bool" where
-  "valid_asid_map \<equiv> \<lambda>s. entry_for_asid 0 s = None"
+  "valid_asid_map \<equiv> \<lambda>s. \<forall>asid \<in> dom (asid_map s). vspace_for_asid asid s \<noteq> None"
 
 definition valid_global_objs :: "'z::state_ext state \<Rightarrow> bool" where
   "valid_global_objs \<equiv> \<top>"
@@ -3084,11 +3085,18 @@ lemma hyp_refs_of_rev:
                  vcpu_tcb_refs_def refs_of_ao_def
            split: kernel_object.splits arch_kernel_obj.splits option.split)
 
+lemma valid_asid_map_0_None:
+  "valid_asid_map s \<Longrightarrow> asid_map s 0 = None"
+  unfolding valid_asid_map_def
+  by (fastforce dest: vspace_for_asid_0)
+
 lemma valid_asid_map_lift_strong:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_map s)\<rbrace>"
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_table s)\<rbrace>"
   assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
   shows "f \<lbrace>valid_asid_map\<rbrace>"
-  by (wpsimp simp: valid_asid_map_def wp: entry_for_asid_lift assms)
+  unfolding valid_asid_map_def
+  by (wpsimp wp: assms hoare_vcg_op_lift vspace_for_asid_lift | wps assms)+
 
 end
 
@@ -3188,10 +3196,6 @@ lemma vspace_for_asid_update[iff]:
 lemma vspace_at_asid_update[iff]:
   "vspace_at_asid asid pt (f s) =  vspace_at_asid asid pt s"
   by (simp add: vspace_at_asid_def)
-
-lemma vmid_for_asid_update[iff]:
-  "vmid_for_asid (f s) asid = vmid_for_asid s asid"
-  by (simp add: asid_table)
 
 lemma vs_lookup_update [iff]:
   "vs_lookup_table bot_level asid vptr (f s) = vs_lookup_table bot_level asid vptr s"

--- a/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
@@ -370,8 +370,8 @@ lemma invs_A:
   apply (rule conjI)
    apply (clarsimp simp: valid_arch_state_def)
    apply (rule conjI)
-    apply (clarsimp simp: valid_asid_table_def state_defs)
-   apply (simp add: valid_arch_state_def vmid_inv_def vmid_for_asid_2_def valid_vmid_table_def
+    apply (clarsimp simp: valid_asid_table_def state_defs asid_entry_def)
+   apply (simp add: valid_arch_state_def vmid_inv_def valid_vmid_table_def
                     valid_global_tables_2_def valid_numlistregs_def cur_vcpu_2_def is_inv_def
                     state_defs obj_at_def a_type_def word_bits_def obind_def empty_pt_def)
   apply (rule conjI, clarsimp simp: valid_cur_fpu_def is_tcb_cur_fpu_def obj_at_def state_defs)

--- a/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
@@ -334,7 +334,8 @@ lemma pts_of':
 
 lemma valid_asid_table:
   "valid_asid_table s \<Longrightarrow> valid_asid_table s'"
-  unfolding valid_asid_table_def by (auto simp: asid_pools)
+  unfolding valid_asid_table_def
+  by (auto simp: asid_pools asid_entry_def split: Option.bind_splits)
 
 lemma valid_global_arch_objs:
   "valid_global_arch_objs s \<Longrightarrow> valid_global_arch_objs s'"
@@ -415,22 +416,9 @@ lemma vcpu_hyp_live_of':
   apply (erule (1) pspace_no_overlapC[OF orth _ _ cover vp])
   done
 
-lemma dom_vmid_for_asid[simplified]:
-  "dom (vmid_for_asid s') = dom (vmid_for_asid s)"
-  apply (clarsimp simp: dom_def s'_def ps_def obj_at_def vmid_for_asid_def in_omonad
-                  split: if_split_asm)
-  apply (rule set_eqI)
-  apply (rule iffI; clarsimp simp: entry_for_pool_def in_omonad split: if_split_asm)
-   apply (fastforce simp: default_object_def default_arch_object_def default_vcpu_def tyunt
-                    split: apiobject_type.splits aobject_type.splits)
-  apply (fastforce elim: pspace_no_overlapC[OF orth _ _ cover vp])
-  done
-
 lemma vmid_inv':
   "vmid_inv s \<Longrightarrow> vmid_inv s'"
-  by (clarsimp simp: vmid_inv_def is_inv_def dom_vmid_for_asid)
-     (fastforce simp: s'_def ps_def vmid_for_asid_def entry_for_pool_def in_omonad
-                elim!: pspace_no_overlapC[OF orth _ _ cover vp])
+  by (clarsimp simp: vmid_inv_def is_inv_def)
 
 lemma valid_global_tables':
   "valid_global_tables s \<Longrightarrow> valid_global_tables s'"
@@ -735,13 +723,6 @@ lemma valid_kernel_mappings:
   "valid_kernel_mappings s \<Longrightarrow> valid_kernel_mappings s'"
   by (simp add: valid_kernel_mappings_def s'_def ball_ran_eq ps_def)
 
-lemma valid_asid_map:
-  "valid_asid_map s \<Longrightarrow> valid_asid_map s'"
-  apply (clarsimp simp: valid_asid_map_def entry_for_asid_def obind_None_eq pool_for_asid_def
-                        entry_for_pool_def)
-  apply (fastforce dest!: asid_pools_of')
-  done
-
 lemma vspace_for_asid:
   "vspace_for_asid asid s' = Some pt \<Longrightarrow> vspace_for_asid asid s = Some pt"
   apply (clarsimp simp: s'_def ps_def vspace_for_asid_def entry_for_asid_def pool_for_asid_def
@@ -749,6 +730,16 @@ lemma vspace_for_asid:
                   split: if_split_asm)
   apply (fastforce simp: default_object_def default_arch_object_def tyunt
                    split: apiobject_type.splits aobject_type.splits)
+  done
+
+lemma valid_asid_map:
+  "valid_asid_map s \<Longrightarrow> valid_asid_map s'"
+  apply (clarsimp simp: valid_asid_map_def)
+  apply (drule bspec, fastforce)
+  apply (fastforce simp: s'_def ps_def vspace_for_asid_def entry_for_asid_def pool_for_asid_def
+                         in_omonad entry_for_pool_def
+                   dest: orthr
+                   split: if_split_asm)
   done
 
 lemma equal_kernel_mappings:

--- a/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
@@ -42,6 +42,10 @@ lemma set_arm_current_fpu_owner_valid_pspace[wp]:
   apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift' hoare_disjI1)
   by fastforce
 
+lemma valid_asid_map_arch_arm_current_fpu_owner_update[simp]:
+  "valid_asid_map (s\<lparr>arch_state := arch_state s\<lparr>arm_current_fpu_owner := x\<rparr>\<rparr>) = valid_asid_map s"
+  by (simp add: valid_asid_map_def)
+
 crunch set_arm_current_fpu_owner
   for valid_mdb[wp]: valid_mdb
   and valid_ioc[wp]: valid_ioc

--- a/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
@@ -132,6 +132,9 @@ crunch vcpu_disable, vcpu_restore, vcpu_save, set_vm_root
   for arch_tcb_at_cur_thread[wp]: "\<lambda>s. arch_tcb_at P (cur_thread s) s"
   (wp: crunch_wps ignore: set_object)
 
+crunch update_asid_map
+  for arm_current_vcpu[wp]: "\<lambda>s. P (arm_current_vcpu (arch_state s))"
+
 crunch vcpu_update, do_machine_op, invalidate_asid, invalidate_vmid_entry
   for active_cur_vcpu_of[wp]: "\<lambda>s. P (active_cur_vcpu_of s)"
   (simp: active_cur_vcpu_of_def)

--- a/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
@@ -13,11 +13,11 @@ theory ArchVSpace_AI
 imports VSpacePre_AI
 begin
 
-context Arch_p_asid_table_update_eq begin (* FIXME AARCh64: move to ArchInvariants_AI *)
+context Arch_p_arch_update_eq begin (* FIXME AARCH64: move to ArchInvariants_AI *)
 
 lemma valid_asid_map_upd[simp]:
   "valid_asid_map (f s) = valid_asid_map s"
-  by (simp add: valid_asid_map_def)
+  by (simp add: valid_asid_map_def arch)
 
 end
 
@@ -153,20 +153,20 @@ lemma vs_lookup_target_clear_asid_table:
   apply blast
   done
 
-lemma vmid_for_asid_unmap_pool:
-  "\<forall>asid_low. vmid_for_asid_2 (asid_of asid_high asid_low) table pools = None \<Longrightarrow>
-   vmid_for_asid_2 asid (table(asid_high := None)) pools = vmid_for_asid_2 asid table pools"
-  unfolding vmid_for_asid_2_def
-  by (clarsimp simp: obind_def entry_for_pool_def split: option.splits)
+lemma asid_entry_table_None:
+  "asid_entry table pools asid = None \<Longrightarrow>
+   asid_entry (table(asid_high := None)) pools asid = None"
+  unfolding asid_entry_def
+  by (auto split: Option.bind_splits)
 
 lemma valid_arch_state_unmap_strg:
-  "valid_arch_state s \<and> (\<forall>asid_low. vmid_for_asid s (asid_of asid_high asid_low) = None) \<longrightarrow>
+  "valid_arch_state s \<longrightarrow>
    valid_arch_state(s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := (asid_table s)(asid_high := None)\<rparr>\<rparr>)"
   apply (clarsimp simp: valid_arch_state_def valid_asid_table_def valid_global_arch_objs_def)
   apply (rule conjI)
    apply (clarsimp simp add: ran_def)
    apply blast
-  apply (clarsimp simp: inj_on_def  vmid_inv_def is_inv_def vmid_for_asid_unmap_pool)
+  apply (clarsimp simp: inj_on_def  vmid_inv_def is_inv_def asid_entry_table_None)
   done
 
 lemma valid_vspace_objs_unmap_strg:
@@ -191,9 +191,12 @@ lemma asid_high_bits_shl:
   by word_eqI_solve
 
 lemma valid_asid_map_unmap:
-  "valid_asid_map s \<and> is_aligned base asid_low_bits \<longrightarrow>
-   valid_asid_map(s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := (asid_table s)(asid_high_bits_of base := None)\<rparr>\<rparr>)"
-  by (clarsimp simp: valid_asid_map_def entry_for_asid_def obind_None_eq pool_for_asid_def)
+  "valid_asid_map s \<and> (\<forall>asid_low. asid_map s (asid_of base asid_low) = None) \<longrightarrow>
+   valid_asid_map(s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := (asid_table s)(base := None)\<rparr>\<rparr>)"
+  apply (clarsimp simp: valid_asid_map_def vspace_for_asid_def entry_for_asid_def pool_for_asid_def
+                        in_omonad)
+  apply (metis Some_helper asid_of_high_low_eq)
+  done
 
 lemma asid_low_bits_word_bits:
   "asid_low_bits < word_bits"
@@ -543,7 +546,8 @@ lemma find_vspace_for_asid_inv[wp]:
   "\<lbrace>P and Q\<rbrace> find_vspace_for_asid asid \<lbrace>\<lambda>_. P\<rbrace>, \<lbrace>\<lambda>_. Q\<rbrace>"
   unfolding find_vspace_for_asid_def by wpsimp
 
-crunch get_vmid, invalidate_asid_entry, invalidate_tlb_by_asid, invalidate_tlb_by_asid_va
+crunch get_vmid, invalidate_asid_entry, invalidate_tlb_by_asid, invalidate_tlb_by_asid_va,
+       update_asid_pool_entry
   for typ_at[wp]: "\<lambda>s. P (typ_at T p s)"
   and pts[wp]: "\<lambda>s. P (pts_of s)"
   and vcpus[wp]: "\<lambda>s. P (vcpus_of s)"
@@ -557,6 +561,7 @@ crunch get_vmid, invalidate_asid_entry, invalidate_tlb_by_asid, invalidate_tlb_b
 
 lemmas find_free_vmid_typ_ats[wp] = abs_typ_at_lifts [OF find_free_vmid_typ_at]
 lemmas invalidate_asid_typ_ats[wp] = abs_typ_at_lifts [OF invalidate_asid_typ_at]
+lemmas update_asid_map_typ_ats[wp] = abs_typ_at_lifts [OF update_asid_map_typ_at]
 lemmas update_asid_pool_entry_typ_ats[wp] = abs_typ_at_lifts [OF update_asid_pool_entry_typ_at]
 lemmas invalidate_vmid_entry_typ_ats[wp] = abs_typ_at_lifts [OF invalidate_vmid_entry_typ_at]
 lemmas invalidate_asid_entry_typ_ats[wp] = abs_typ_at_lifts [OF invalidate_asid_entry_typ_at]
@@ -592,7 +597,7 @@ lemma vs_lookup_table_vspace_eq:
   by (auto simp: obind_def split: option.splits)
 
 lemma update_asid_pool_entry_valid_vs_lookup_table[wp]:
-  "update_asid_pool_entry (\<lambda>entry. Some (ASIDPoolVSpace vmid (ap_vspace entry))) asid
+  "update_asid_pool_entry (\<lambda>entry. Some (ASIDPoolVSpace (ap_vspace entry))) asid
    \<lbrace>\<lambda>s. P (vs_lookup_table level asid' vref s)\<rbrace>"
   unfolding update_asid_pool_entry_def set_asid_pool_def
   apply (wpsimp wp: set_object_wp)
@@ -603,7 +608,7 @@ lemma update_asid_pool_entry_valid_vs_lookup_table[wp]:
   done
 
 lemma update_asid_pool_entry_valid_vspace_objs[wp]:
-  "update_asid_pool_entry (\<lambda>entry. Some (ASIDPoolVSpace vmid (ap_vspace entry))) asid
+  "update_asid_pool_entry (\<lambda>entry. Some (ASIDPoolVSpace (ap_vspace entry))) asid
    \<lbrace>valid_vspace_objs\<rbrace>"
   unfolding valid_vspace_objs_def
   by (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift update_asid_pool_entry_vspace_objs_of)
@@ -630,7 +635,7 @@ lemma vspace_for_asid_lift:
   done
 
 lemma update_asid_pool_entry_vspace_for_asid[wp]:
-  "update_asid_pool_entry (\<lambda>entry. Some (ASIDPoolVSpace vmid (ap_vspace entry))) asid'
+  "update_asid_pool_entry (\<lambda>entry. Some (ASIDPoolVSpace (ap_vspace entry))) asid'
    \<lbrace>\<lambda>s. P (vspace_for_asid asid s)\<rbrace>"
   unfolding update_asid_pool_entry_def
   supply fun_upd_apply[simp del]
@@ -642,13 +647,13 @@ lemma update_asid_pool_entry_vspace_for_asid[wp]:
 
 lemma invalidate_asid_vspace_objs[wp]:
   "invalidate_asid asid \<lbrace>valid_vspace_objs\<rbrace>"
-  unfolding invalidate_asid_def
+  unfolding invalidate_asid_def update_asid_map_def
   by wpsimp
 
 lemma store_vmid_valid_vspace_objs[wp]:
   "store_vmid asid vmid \<lbrace>valid_vspace_objs\<rbrace>"
-  unfolding store_vmid_def
-  by wpsimp
+  unfolding store_vmid_def update_asid_map_def
+  by (wpsimp simp: valid_vspace_objs_def)
 
 lemma valid_global_arch_objs_upd_eq_lift:
   "(\<And>s. arm_us_global_vspace (f s) = arm_us_global_vspace s) \<Longrightarrow>
@@ -675,39 +680,16 @@ crunch get_vmid, invalidate_asid_entry, invalidate_tlb_by_asid, invalidate_tlb_b
   and valid_global_arch_objs[wp]: valid_global_arch_objs
   (ignore: set_asid_pool simp: valid_global_arch_objs_upd_eq_lift)
 
-crunch do_machine_op
-  for vmid_for_asid[wp]: "\<lambda>s. P (vmid_for_asid s)" (* FIXME: move to ArchAcc crunches *)
-
-lemma vmid_for_asid_upd_eq:
-  "\<lbrakk> pool_for_asid asid s = Some pool_ptr; asid_pools_of s pool_ptr = Some ap;
-     ap (asid_low_bits_of asid) = Some entry; valid_asid_table s \<rbrakk>
-   \<Longrightarrow> (\<lambda>asid'. vmid_for_asid_2
-                  asid'
-                  (asid_table s)
-                  ((asid_pools_of s)(pool_ptr \<mapsto> ap(asid_low_bits_of asid \<mapsto>
-                                                    ASIDPoolVSpace vmid vsp))))
-       = (vmid_for_asid s) (asid := vmid)"
-  apply (rule ext)
-  apply (clarsimp simp: vmid_for_asid_2_def entry_for_pool_def pool_for_asid_def obind_def
-                  split: option.splits)
-  apply (rule conjI; clarsimp)
-  apply (rule conjI; clarsimp simp: opt_map_def split: option.splits)
-  apply (drule (1) valid_asid_table_inj, simp add: opt_map_def)
-  apply (drule (1) asid_high_low_inj[OF _ sym, THEN sym])
-  apply simp
-  done
-
 lemma find_free_vmid_vmid_inv[wp]:
-  "\<lbrace>valid_asid_table and vmid_inv\<rbrace> find_free_vmid \<lbrace>\<lambda>_. vmid_inv\<rbrace>"
+  "find_free_vmid \<lbrace>vmid_inv\<rbrace>"
   unfolding find_free_vmid_def invalidate_vmid_entry_def invalidate_asid_def
-            update_asid_pool_entry_def vmid_inv_def
+            update_asid_map_def vmid_inv_def
   supply fun_upd_apply[simp del]
-  apply (wpsimp|wps)+
+  apply wpsimp
   apply (frule is_inv_inj)
   apply (drule findNoneD)
-  apply (rename_tac pool_ptr ap entry)
   apply (drule_tac x="arm_next_vmid (arch_state s)" in bspec, simp add: minBound_word)
-  apply (fastforce simp: vmid_for_asid_upd_eq is_inv_def ran_upd[folded fun_upd_apply] dom_upd
+  apply (fastforce simp: is_inv_def ran_upd[folded fun_upd_apply] dom_upd
                          fun_upd_apply
                    split: if_split_asm
                    dest: inj_on_domD)
@@ -717,6 +699,14 @@ lemma invalidate_vmid_entry_valid_vmid_table[wp]:
   "invalidate_vmid_entry vmid \<lbrace>valid_vmid_table\<rbrace>"
   unfolding invalidate_vmid_entry_def
   by (wpsimp simp: valid_vmid_table_def)
+
+lemma valid_cur_fpu_asid_map_udpate[simp]:
+  "valid_cur_fpu (s \<lparr> arch_state := arm_asid_map_update f (arch_state s) \<rparr>) = valid_cur_fpu s"
+  by (simp add: valid_cur_fpu_def is_tcb_cur_fpu_def)
+
+lemma valid_global_refs_asid_map_udpate[simp]:
+  "valid_global_refs (s \<lparr> arch_state := arm_asid_map_update f (arch_state s) \<rparr>) = valid_global_refs s"
+  by (simp add: valid_global_refs_def global_refs_def)
 
 crunch find_free_vmid
   for valid_global_tables[wp]: "valid_global_tables"
@@ -729,15 +719,10 @@ lemma find_free_vmid_valid_arch [wp]:
   "find_free_vmid \<lbrace>valid_arch_state\<rbrace>"
   unfolding valid_arch_state_def by wpsimp
 
-lemma entry_for_asid_Some_vmidD:
-  "entry_for_asid asid s = Some entry \<Longrightarrow> ap_vmid entry = vmid_for_asid s asid"
-  unfolding entry_for_asid_def vmid_for_asid_def entry_for_pool_def pool_for_asid_def
-  by (auto simp: obind_def opt_map_def if_option split: option.splits)
-
 lemma load_vmid_wp[wp]:
   "\<lbrace>\<lambda>s. P (asid_map s asid) s\<rbrace> load_vmid asid \<lbrace>P\<rbrace>"
   unfolding load_vmid_def
-  by wpsimp (fastforce dest: entry_for_asid_Some_vmidD)
+  by wpsimp
 
 lemma valid_global_refs_vmid_table_upd[simp]:
   "valid_global_refs (s\<lparr>arch_state := arch_state s\<lparr>arm_vmid_table := x\<rparr>\<rparr>) = valid_global_refs s"
@@ -762,7 +747,7 @@ lemma vs_lookup_target_vspace_eq:
      (fastforce intro!: obind_eqI simp: obind_assoc)
 
 lemma update_asid_pool_entry_valid_vs_lookup_target[wp]:
-  "update_asid_pool_entry (\<lambda>entry. Some (ASIDPoolVSpace vmid (ap_vspace entry))) asid
+  "update_asid_pool_entry (\<lambda>entry. Some (ASIDPoolVSpace (ap_vspace entry))) asid
    \<lbrace>\<lambda>s. P (vs_lookup_target level asid' vref s)\<rbrace>"
   unfolding update_asid_pool_entry_def set_asid_pool_def
   apply (wpsimp wp: set_object_wp)
@@ -783,7 +768,7 @@ lemma vs_lookup_pages_target_lift:
   done
 
 lemma update_asid_pool_entry_vs_lookup_pages_vmid[wp]:
-  "update_asid_pool_entry (\<lambda>entry. Some (ASIDPoolVSpace vmid (ap_vspace entry))) asid
+  "update_asid_pool_entry (\<lambda>entry. Some (ASIDPoolVSpace (ap_vspace entry))) asid
    \<lbrace>\<lambda>s. P (vs_lookup_pages s)\<rbrace>"
   by (wpsimp wp: vs_lookup_pages_target_lift[OF update_asid_pool_entry_valid_vs_lookup_target])
 
@@ -849,18 +834,25 @@ crunch update_asid_pool_entry, set_asid_pool
   for pool_for_asid[wp]: "\<lambda>s. P (pool_for_asid as s)"
   (simp: pool_for_asid_def)
 
-lemma update_asid_pool_entry_valid_asid_map[wp]:
-  "update_asid_pool_entry f asid \<lbrace>valid_asid_map\<rbrace>"
-  unfolding valid_asid_map_def entry_for_asid_def
-  apply (clarsimp simp: obind_None_eq)
-  apply (wpsimp wp: hoare_vcg_disj_lift hoare_vcg_ex_lift)
-  apply (clarsimp simp: pool_for_asid_def entry_for_pool_def obind_None_eq split: if_split_asm)
-  done
+lemma valid_cur_fpu_arch_vmid_asid_map_update:
+  "valid_cur_fpu (s\<lparr>arch_state := arch_state s\<lparr>arm_vmid_table := x, arm_asid_map := y\<rparr>\<rparr>) =
+   valid_cur_fpu s"
+  by (simp add: valid_cur_fpu_def is_tcb_cur_fpu_def)
+
+lemma valid_arch_caps_arch_vmid_asid_map_update:
+  "valid_arch_caps (s\<lparr>arch_state := arch_state s\<lparr>arm_vmid_table := x, arm_asid_map := y\<rparr>\<rparr>) =
+   valid_arch_caps s"
+  by (simp add: valid_arch_caps_def valid_vs_lookup_def)
+
+lemma vspace_for_asid_arch_vmid_asid_map_update:
+  "vspace_for_asid asid (s\<lparr>arch_state := arch_state s\<lparr>arm_vmid_table := x, arm_asid_map := y\<rparr>\<rparr>) =
+   vspace_for_asid asid s"
+  by (simp add: vspace_for_asid_def obind_def entry_for_asid_def cong: option.case_cong)
 
 lemma invalidate_asid_entry_invs[wp]:
   "invalidate_asid_entry asid \<lbrace>invs\<rbrace>"
   unfolding invalidate_asid_entry_def invalidate_asid_def invalidate_vmid_entry_def invs_def
-            valid_state_def valid_pspace_def valid_arch_state_def vmid_inv_def
+            valid_state_def valid_pspace_def valid_arch_state_def vmid_inv_def update_asid_map_def
   supply fun_upd_apply[simp del]
   apply (wpsimp wp: load_vmid_wp valid_irq_handlers_lift valid_irq_node_typ valid_irq_states_triv
                       valid_arch_caps_lift pspace_in_kernel_window_atyp_lift_strong
@@ -869,13 +861,41 @@ lemma invalidate_asid_entry_invs[wp]:
          | wps)+
   apply (clarsimp simp: valid_irq_node_def valid_global_refs_def global_refs_def valid_arch_state_def
                         valid_global_objs_def valid_global_arch_objs_def valid_machine_state_def
-                        valid_vspace_objs_def vmid_for_asid_upd_eq comp_upd_simp is_inv_None_upd
-                        valid_vmid_table_None_upd)
+                        valid_vspace_objs_def comp_upd_simp is_inv_None_upd
+                        valid_vmid_table_None_upd valid_cur_fpu_arch_vmid_asid_map_update
+                        valid_arch_caps_arch_vmid_asid_map_update)
+  apply (simp add: valid_asid_map_def fun_upd_apply vspace_for_asid_arch_vmid_asid_map_update)
+  done
+
+lemma vspace_for_asid_arch_vmid_asid_map_update2:
+  "vspace_for_asid asid (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_map := x, arm_vmid_table := y\<rparr>\<rparr>) =
+   vspace_for_asid asid s"
+  by (simp add: vspace_for_asid_def obind_def entry_for_asid_def cong: option.case_cong)
+
+lemma store_vmid_valid_asid_map[wp]:
+  "\<lbrace>valid_asid_map and (\<lambda>s. vspace_for_asid asid s \<noteq> None)\<rbrace>
+   store_vmid asid vmid
+   \<lbrace>\<lambda>_. valid_asid_map\<rbrace>"
+  unfolding store_vmid_def update_asid_map_def
+  apply (wpsimp simp: valid_asid_map_def)
+  apply (fastforce simp: vspace_for_asid_arch_vmid_asid_map_update2 split: if_splits)
+  done
+
+lemma valid_asid_map_arch_vmid_table_next_vmid_update:
+  "valid_asid_map (s\<lparr>arch_state := arch_state s\<lparr>arm_vmid_table := x, arm_next_vmid := y\<rparr>\<rparr>) =
+   valid_asid_map s"
+  by (simp add: valid_asid_map_def vspace_for_asid_def obind_def entry_for_asid_def
+           cong: option.case_cong)
+
+lemma find_free_vmid_valid_asid_map[wp]:
+  "find_free_vmid \<lbrace>valid_asid_map\<rbrace>"
+  unfolding find_free_vmid_def invalidate_vmid_entry_def invalidate_asid_def update_asid_map_def
+  apply (wpsimp simp: valid_asid_map_arch_vmid_table_next_vmid_update)
+  apply (fastforce simp: valid_asid_map_def split: if_splits)
   done
 
 crunch find_free_vmid, store_vmid
-  for valid_asid_map[wp]: valid_asid_map
-  and valid_cur_fpu[wp]: valid_cur_fpu
+  for valid_cur_fpu[wp]: valid_cur_fpu
 
 lemma find_free_vmid_invs[wp]:
   "find_free_vmid \<lbrace>invs\<rbrace>"
@@ -885,18 +905,25 @@ lemma find_free_vmid_invs[wp]:
              simp: valid_kernel_mappings_def equal_kernel_mappings_def
                    valid_global_vspace_mappings_def)
 
+lemma valid_global_arch_objs_arch_vmid_asid_map_update[simp]:
+  "valid_global_arch_objs (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_map := y, arm_vmid_table := x\<rparr>\<rparr>) =
+   valid_global_arch_objs s"
+  by (simp add: valid_global_arch_objs_def)
+
 lemma store_hw_asid_valid_arch[wp]:
   "\<lbrace>valid_arch_state and (\<lambda>s. asid_map s asid = None \<and> arm_vmid_table (arch_state s) vmid = None \<and> asid \<noteq> 0)\<rbrace>
    store_vmid asid vmid
    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  unfolding store_vmid_def valid_arch_state_def vmid_inv_def
+  unfolding store_vmid_def update_asid_map_def valid_arch_state_def vmid_inv_def
   supply fun_upd_apply[simp del]
   apply (wpsimp simp: valid_global_arch_objs_upd_eq_lift | wps)+
-  apply (fastforce simp: vmid_for_asid_upd_eq elim: is_inv_Some_upd intro: valid_vmid_table_Some_upd)
+  apply (fastforce elim: is_inv_Some_upd intro: valid_vmid_table_Some_upd)
   done
 
 lemma store_vmid_invs[wp]:
-  "\<lbrace>invs and (\<lambda>s. asid_map s asid = None \<and> arm_vmid_table (arch_state s) vmid = None \<and> asid \<noteq> 0)\<rbrace>
+  "\<lbrace>invs and
+    (\<lambda>s. vspace_for_asid asid s \<noteq> None \<and>
+         asid_map s asid = None \<and> arm_vmid_table (arch_state s) vmid = None \<and> asid \<noteq> 0)\<rbrace>
    store_vmid asid vmid
    \<lbrace>\<lambda>_. invs\<rbrace>"
   unfolding invs_def valid_state_def valid_pspace_def
@@ -915,22 +942,17 @@ lemma find_free_vmid_None[wp]:
   unfolding find_free_vmid_def
   by wpsimp (clarsimp dest!: findSomeD)
 
-lemma invalidate_vmid_entry_vmid_for_asid_None[wp]:
-  "invalidate_vmid_entry vmid \<lbrace>\<lambda>s. vmid_for_asid s asid = None\<rbrace>"
+lemma invalidate_vmid_entry_asid_map_None[wp]:
+  "invalidate_vmid_entry vmid \<lbrace>\<lambda>s. asid_map s asid = None\<rbrace>"
   unfolding invalidate_vmid_entry_def
   by wpsimp
 
 lemma invalidate_asid_vmid_for_asid_None[wp]:
-  "\<lbrace>\<lambda>s. asid' \<noteq> asid \<longrightarrow> vmid_for_asid s asid = None \<rbrace>
+  "\<lbrace>\<lambda>s. asid' \<noteq> asid \<longrightarrow> asid_map s asid = None \<rbrace>
    invalidate_asid asid'
-   \<lbrace>\<lambda>_ s. vmid_for_asid s asid = None\<rbrace>"
-  unfolding invalidate_asid_def update_asid_pool_entry_def
-  supply fun_upd_apply[simp del]
-  apply (wpsimp|wps)+
-  apply (auto simp: pool_for_asid_def vmid_for_asid_def entry_for_pool_def fun_upd_apply obind_def
-                    in_opt_map_None_eq
-              split: option.split)
-  done
+   \<lbrace>\<lambda>_ s. asid_map s asid = None\<rbrace>"
+  unfolding invalidate_asid_def update_asid_map_def
+  by wpsimp
 
 lemma find_free_vmid_None_asid_map[wp]:
   "find_free_vmid \<lbrace>\<lambda>s. asid_map s asid = None\<rbrace>"
@@ -942,8 +964,12 @@ lemma get_hw_asid_valid_arch[wp]:
   unfolding get_vmid_def
   by wpsimp
 
+lemma vspace_for_asid_0_None[simp]:
+  "vspace_for_asid 0 s = None"
+  by (simp add: vspace_for_asid_def entry_for_asid_def)
+
 lemma get_hw_asid_invs[wp]:
-  "\<lbrace>invs and K (asid \<noteq> 0)\<rbrace> get_vmid asid \<lbrace>\<lambda>_. invs\<rbrace>"
+  "\<lbrace>invs and (\<lambda>s. vspace_for_asid asid s \<noteq> None)\<rbrace> get_vmid asid \<lbrace>\<lambda>_. invs\<rbrace>"
   unfolding get_vmid_def
   by (wpsimp wp: store_vmid_invs load_vmid_wp simp: opt_map_def)
 
@@ -960,7 +986,7 @@ crunch invalidate_tlb_by_asid, invalidate_tlb_by_asid_va
   (ignore: do_machine_op)
 
 lemma arm_context_switch_invs [wp]:
-  "\<lbrace>invs and K (asid \<noteq> 0)\<rbrace> arm_context_switch pt asid \<lbrace>\<lambda>_. invs\<rbrace>"
+  "\<lbrace>invs and (\<lambda>s. vspace_for_asid asid s \<noteq> None)\<rbrace> arm_context_switch pt asid \<lbrace>\<lambda>_. invs\<rbrace>"
   unfolding arm_context_switch_def by wpsimp
 
 crunch set_vm_root
@@ -971,10 +997,6 @@ lemma set_global_user_vspace_invs[wp]:
   "set_global_user_vspace \<lbrace>invs\<rbrace>"
   unfolding set_global_user_vspace_def
   by wpsimp
-
-lemma vspace_for_asid_0_None[simp]:
-  "vspace_for_asid 0 s = None"
-  by (simp add: vspace_for_asid_def entry_for_asid_def)
 
 lemma set_vm_root_invs[wp]:
   "set_vm_root t \<lbrace>invs\<rbrace>"
@@ -2376,53 +2398,47 @@ lemma set_asid_pool_valid_arch_caps_map:
   apply (clarsimp simp: asid_pool_map.vs_lookup_target split: if_split_asm)
   by (fastforce simp: vref_for_level_asid_pool user_region_def)
 
-lemma vmid_for_asid_map_None:
-  "\<lbrakk> asid_pools_of s ap = Some pool; pool_for_asid asid s = Some ap;
-     pool (asid_low_bits_of asid) = None; ap_vmid ape = None \<rbrakk> \<Longrightarrow>
-   (\<lambda>asid'. vmid_for_asid_2 asid' (asid_table s)
-                                  ((asid_pools_of s)(ap \<mapsto> pool(asid_low_bits_of asid \<mapsto> ape)))) =
-   vmid_for_asid s"
-  unfolding vmid_for_asid_def
-  apply (rule ext)
-  apply (clarsimp simp: vmid_for_asid_2_def entry_for_pool_def pool_for_asid_def obind_def
-                        opt_map_def
-                  split: option.splits)
-  done
-
 lemma set_asid_pool_vmid_inv:
-  "\<lbrace>\<lambda>s. vmid_inv s \<and> asid_pools_of s ap = Some pool \<and> pool_for_asid asid s = Some ap \<and>
-        pool (asid_low_bits_of asid) = None \<and> ap_vmid ape = None \<rbrace>
-   set_asid_pool ap (pool(asid_low_bits_of asid \<mapsto> ape))
-   \<lbrace>\<lambda>_. vmid_inv\<rbrace>"
+  "set_asid_pool ap (pool(asid_low_bits_of asid \<mapsto> ape)) \<lbrace>vmid_inv\<rbrace>"
   unfolding vmid_inv_def
-  apply (wp_pre, wps, wp)
-  apply (simp add: vmid_for_asid_map_None del: fun_upd_apply)
-  done
+  by wpsimp
 
 lemma set_asid_pool_valid_arch_state:
   "\<lbrace>valid_arch_state and
     (\<lambda>s. asid_pools_of s ap = Some pool \<and> pool_for_asid asid s = Some ap \<and>
-         (\<exists>ptr cap. caps_of_state s ptr = Some cap \<and> obj_refs cap = {ap_vspace ape} \<and>
-                    vs_cap_ref cap = Some (asid, 0)))
-    and (\<lambda>s. \<exists>pt. pts_of s (ap_vspace ape) = Some pt \<and> pt = empty_pt VSRootPT_T)
-    and K (pool (asid_low_bits_of asid) = None \<and> 0 < asid  \<and> ap_vmid ape = None)\<rbrace>
-  set_asid_pool ap (pool(asid_low_bits_of asid \<mapsto> ape))
-  \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
+         pool (asid_low_bits_of asid) = None \<and> asid \<noteq> 0)\<rbrace>
+   set_asid_pool ap (pool(asid_low_bits_of asid \<mapsto> ape))
+   \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
   unfolding valid_arch_state_def
-  by (wpsimp wp: set_asid_pool_vmid_inv | wps)+
+  by (wpsimp wp: set_asid_pool_vmid_inv simp: pool_for_asid_def | wps)+
 
-lemma set_asid_pool_invs_valid_asid_map[wp]:
+lemma set_asid_pool_Some_vspace_for_asid:
+  "\<lbrace>\<lambda>s. valid_asid_table s \<and>
+        asid_pools_of s ap = Some pool \<and> pool_for_asid asid s = Some ap \<and>
+        pool (asid_low_bits_of asid) = None \<and> asid \<noteq> 0 \<and>
+        P ((\<lambda>asid. vspace_for_asid asid s)(asid \<mapsto> ap_vspace ape)) \<rbrace>
+   set_asid_pool ap (pool(asid_low_bits_of asid \<mapsto> ape))
+   \<lbrace>\<lambda>_ s. P (\<lambda>asid. vspace_for_asid asid s)\<rbrace>"
+  unfolding set_asid_pool_def
+  apply (wp set_object_wp)
+  apply clarsimp
+  apply (erule rsubst[where P=P])
+  apply (rule ext)
+  apply (clarsimp simp: vspace_for_asid_def obind_def entry_for_asid_def
+                        pool_for_asid_def entry_for_pool_def word_neq_0_conv
+                        asid_high_low_inj valid_asid_table_inj
+                  split: option.splits)
+  done
+
+lemma set_asid_pool_Some_valid_asid_map:
   "\<lbrace>valid_asid_map and valid_asid_table and
-    (\<lambda>s. asid_pools_of s ap = Some pool \<and> pool_for_asid asid s = Some ap \<and> asid \<noteq> 0)\<rbrace>
-  set_asid_pool ap (pool(asid_low_bits_of asid \<mapsto> ape))
-  \<lbrace>\<lambda>_. valid_asid_map\<rbrace>"
-  unfolding valid_asid_map_def entry_for_asid_def
-  apply (clarsimp simp: obind_None_eq)
-  apply (wp hoare_vcg_disj_lift hoare_vcg_ex_lift)
-  apply (fastforce simp: asid_high_low_inj pool_for_asid_def valid_asid_table_def entry_for_pool_def
-                         obind_None_eq
-                   dest: inj_on_domD
-                   split: if_split_asm)
+    (\<lambda>s. asid_pools_of s ap = Some pool \<and> pool_for_asid asid s = Some ap) and
+    K (pool (asid_low_bits_of asid) = None \<and> asid \<noteq> 0) \<rbrace>
+   set_asid_pool ap (pool(asid_low_bits_of asid \<mapsto> ape))
+   \<lbrace>\<lambda>_. valid_asid_map\<rbrace>"
+  unfolding valid_asid_map_def
+  apply (wpsimp wp: hoare_Ball_helper set_asid_pool_Some_vspace_for_asid)
+  apply (fastforce simp: pool_for_asid_def)
   done
 
 lemma set_asid_pool_invs_map:
@@ -2431,14 +2447,14 @@ lemma set_asid_pool_invs_map:
          (\<exists>ptr cap. caps_of_state s ptr = Some cap \<and> obj_refs cap = {ap_vspace ape} \<and>
                     vs_cap_ref cap = Some (asid, 0)))
     and (\<lambda>s. \<exists>pt. pts_of s (ap_vspace ape) = Some pt \<and> pt = empty_pt VSRootPT_T)
-    and K (pool (asid_low_bits_of asid) = None \<and> 0 < asid \<and> ap_vmid ape = None)\<rbrace>
+    and K (pool (asid_low_bits_of asid) = None \<and> 0 < asid)\<rbrace>
   set_asid_pool ap (pool(asid_low_bits_of asid \<mapsto> ape))
   \<lbrace>\<lambda>rv. invs\<rbrace>"
   apply (simp add: invs_def valid_state_def valid_pspace_def)
   apply (wpsimp wp: valid_irq_node_typ set_asid_pool_typ_at set_asid_pool_arch_objs_map
                     valid_irq_handlers_lift set_asid_pool_valid_arch_caps_map
-                    set_asid_pool_valid_arch_state)
-  apply (clarsimp simp: valid_arch_state_def)
+                    set_asid_pool_valid_arch_state set_asid_pool_Some_valid_asid_map)
+  apply (fastforce intro: valid_arch_state_asid_table simp: word_neq_0_conv)
   done
 
 lemma ako_asid_pools_of:

--- a/proof/refine/AARCH64/ADT_H.thy
+++ b/proof/refine/AARCH64/ADT_H.thy
@@ -449,7 +449,7 @@ lemma absHeap_correct:
   assumes pspace_relation: "pspace_relation (kheap s) (ksPSpace s')"
   assumes ghost_relation:  "ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')
                                            (gsPTTypes (ksArchState s'))"
-  assumes arch_state_relation: "(arch_state s, ksArchState s') \<in> arch_state_relation"
+  assumes arch_state_relation: "(arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s')"
   shows
     "absHeap (gsUserPages s') (gsCNodes s') (gsPTTypes (ksArchState s')) (ksPSpace s') (armKSCurFPUOwner (ksArchState s'))
      = kheap s"
@@ -1580,12 +1580,13 @@ lemma absInterruptStates_correct:
   done
 
 definition
-  "absArchState s' \<equiv>
+  "absArchState s' aobjs' \<equiv>
    case s' of
      ARMKernelState asid_tbl kvspace vmid_tab next_vmid global_us_vspace current_vcpu
                     num_list_regs gs_pt_types current_fpu_owner \<Rightarrow>
      \<lparr> arm_asid_table = asid_tbl \<circ> ucast,
        arm_kernel_vspace = kvspace,
+       arm_asid_map = armKSASIDMap' s' aobjs',
        arm_vmid_table = map_option ucast \<circ> vmid_tab,
        arm_next_vmid = next_vmid,
        arm_us_global_vspace = global_us_vspace,
@@ -1594,8 +1595,8 @@ definition
        arm_current_fpu_owner = current_fpu_owner \<rparr>"
 
 lemma absArchState_correct:
-  "(s,s') \<in> state_relation \<Longrightarrow> absArchState (ksArchState s') = arch_state s"
-  apply (prop_tac "(arch_state s, ksArchState s') \<in> arch_state_relation")
+  "(s,s') \<in> state_relation \<Longrightarrow> absArchState (ksArchState s') (aobjs_of' s') = arch_state s"
+  apply (prop_tac "(arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s')")
    apply (simp add: state_relation_def)
   apply (clarsimp simp: arch_state_relation_def absArchState_def
                   split: AARCH64_H.kernel_state.splits)
@@ -1660,7 +1661,7 @@ definition
     machine_state = observable_memory (ksMachineState s) (user_mem' s),
     interrupt_irq_node = absInterruptIRQNode (ksInterruptState s),
     interrupt_states = absInterruptStates (ksInterruptState s),
-    arch_state = absArchState (ksArchState s),
+    arch_state = absArchState (ksArchState s) (aobjs_of' s),
     exst = absExst s\<rparr>"
 
 

--- a/proof/refine/AARCH64/ArchArchAcc_R.thy
+++ b/proof/refine/AARCH64/ArchArchAcc_R.thy
@@ -19,6 +19,10 @@ lemma asid_pool_at_ko:
   "asid_pool_at p s \<Longrightarrow> \<exists>pool. ko_at (ArchObj (AARCH64_A.ASIDPool pool)) p s"
   by (clarsimp simp: asid_pools_at_eq obj_at_def elim!: opt_mapE)
 
+lemma ko_at_asid_pools_of':
+  "ko_at' (ASIDPool pool) p s \<Longrightarrow> asid_pools_of' s p = Some pool"
+  by (clarsimp simp: obj_at'_def ko_wp_at'_def in_omonad)
+
 lemma corres_gets_asid[corres]:
   "corres (\<lambda>a c. a = c o ucast) \<top> \<top> (gets asid_table) (gets (armKSASIDTable \<circ> ksArchState))"
   by (simp add: state_relation_def arch_state_relation_def)
@@ -163,12 +167,12 @@ lemma pspace_distinct_cross[ArchAcc_R_assms]:
   apply (erule (2) in_empty_interE)
   done
 
-lemma asid_pool_at_cross:
-  "\<lbrakk> asid_pool_at p s; pspace_relation (kheap s) (ksPSpace s');
+lemma asid_pool_of_ko_at'_cross:
+  "\<lbrakk> asid_pools_of s p = Some pool; pspace_relation (kheap s) (ksPSpace s');
      pspace_aligned s; pspace_distinct s \<rbrakk>
-   \<Longrightarrow> asid_pool_at' p s'"
+   \<Longrightarrow> \<exists>pool'. ko_at' (ASIDPool pool') p s' \<and> asid_pool_relation pool (ASIDPool pool')"
   apply (drule (2) pspace_distinct_cross)
-  apply (clarsimp simp: obj_at_def typ_at'_def ko_wp_at'_def)
+  apply (clarsimp simp: obj_at'_def ko_wp_at'_def in_omonad)
   apply (prop_tac "p \<in> pspace_dom (kheap s)")
    apply (clarsimp simp: pspace_dom_def)
    apply (rule bexI)
@@ -180,11 +184,18 @@ lemma asid_pool_at_cross:
   apply (clarsimp simp: other_aobj_relation_def objBits_simps
                   split: kernel_object.splits arch_kernel_object.splits)
   apply (frule (1) pspace_alignedD)
-  apply (rule conjI, simp add: bit_simps)
   apply (clarsimp simp: pspace_distinct'_def)
   apply (drule bspec, fastforce)
   apply (simp add: objBits_simps)
+  apply (metis asidpool.exhaust)
   done
+
+lemma asid_pool_at_cross:
+  "\<lbrakk> asid_pool_at p s; pspace_relation (kheap s) (ksPSpace s');
+     pspace_aligned s; pspace_distinct s \<rbrakk>
+   \<Longrightarrow> asid_pool_at' p s'"
+  by (fastforce simp: asid_pools_at_eq typ_at'_def ko_wp_at'_def obj_at'_def
+                dest!: asid_pool_of_ko_at'_cross)
 
 lemma corres_cross_over_asid_pool_at:
   "\<lbrakk> \<And>s. P s \<Longrightarrow> asid_pool_at p s \<and> pspace_distinct s \<and> pspace_aligned s;
@@ -228,6 +239,15 @@ lemma getObject_ASIDPool_corres[corres]:
   apply (clarsimp simp: other_aobj_relation_def)
   done
 
+lemma setObject_asidpool_wp:
+  "\<lbrace>\<lambda>s. asid_pool_at' p s \<and>
+        Q () (ksPSpace_update (\<lambda>ps. ps(p \<mapsto> KOArch (KOASIDPool v))) s)\<rbrace>
+   setObject p v
+   \<lbrace>Q\<rbrace>"
+  apply (wpsimp wp: setObject_default_wp simp: objBits_simps bit_simps)
+  apply (simp add: typ_at_to_obj_at_arches)
+  done
+
 lemma storePTE_cte_wp_at'[wp]:
   "storePTE ptr val \<lbrace>\<lambda>s. P (cte_wp_at' P' p s)\<rbrace>"
   apply (simp add: storePTE_def)
@@ -251,37 +271,6 @@ lemma storePTE_state_hyp_refs_of[wp]:
    \<lbrace>\<lambda>rv s. P (state_hyp_refs_of' s)\<rbrace>"
   by (wpsimp wp: hoare_drop_imps setObject_state_hyp_refs_of_eq
              simp: storePTE_def updateObject_default_def in_monad)
-
-lemma setObject_ASIDPool_corres[corres]:
-  "\<lbrakk> p = p'; a = map_option abs_asid_entry o inv ASIDPool a' o ucast \<rbrakk> \<Longrightarrow>
-  corres dc (asid_pool_at p and pspace_aligned and pspace_distinct) \<top>
-            (set_asid_pool p a) (setObject p' a')"
-  apply (simp add: set_asid_pool_def)
-  apply (rule corres_underlying_symb_exec_l[where P=P and Q="\<lambda>_. P" for P])
-    apply (rule corres_no_failI; clarsimp)
-    apply (clarsimp simp: gets_map_def bind_def simpler_gets_def assert_opt_def fail_def return_def
-                          obj_at_def in_omonad
-                    split: option.splits)
-   prefer 2
-   apply wpsimp
-  apply (rule corres_cross_over_asid_pool_at, fastforce)
-  apply (rule corres_guard_imp)
-    apply (rule setObject_other_arch_corres[where P="\<lambda>ko::asidpool. True"])
-           apply simp
-          apply (clarsimp simp: obj_at'_def)
-          apply (erule map_to_ctes_upd_other, simp, simp)
-         apply (simp add: a_type_def is_other_obj_relation_type_def)
-        apply (simp add: objBits_simps)+
-      apply (simp add: objBits_simps pageBits_def)+
-    apply (simp add: other_aobj_relation_def asid_pool_relation_def)
-   apply (simp add: typ_at'_def obj_at'_def ko_wp_at'_def)
-   apply clarsimp
-   apply (rename_tac arch_kernel_object)
-   apply (case_tac arch_kernel_object; simp)
-   apply (clarsimp simp: obj_at_def exs_valid_def assert_def a_type_def return_def fail_def)
-   apply (auto split: Structures_A.kernel_object.split_asm arch_kernel_obj.split_asm if_split_asm)[1]
-  apply (simp add: typ_at_to_obj_at_arches)
-  done
 
 lemma p_le_table_base:
   "is_aligned p pte_bits \<Longrightarrow> p + mask pte_bits \<le> table_base pt_t p + mask (table_size pt_t)"
@@ -438,6 +427,7 @@ lemma setObject_PT_corres:
      apply ((simp split: if_split_asm)+)[2]
     apply (simp add: other_obj_relation_def split: Structures_A.kernel_object.splits)
    apply (simp add: other_aobj_relation_def split: arch_kernel_obj.splits)
+  apply (simp add: typ_at_asid_pools_of'_None cong: arch_state_relation_vmids_cong)
   apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _ _" \<Rightarrow> -\<close>)
    apply (clarsimp simp add: ghost_relation_def)
    apply (erule_tac x="p && ~~ mask (pt_bits (pt_type pt))" in allE)+

--- a/proof/refine/AARCH64/ArchCSpace_R.thy
+++ b/proof/refine/AARCH64/ArchCSpace_R.thy
@@ -406,6 +406,7 @@ lemma corres_caps_decomposition:
              "\<And>P. \<lbrace>\<lambda>s. P (new_ds' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksDomSchedule s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_cd' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksCurDomain s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_dt' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksDomainTime s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (new_ao' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (aobjs_of' s)\<rbrace>"
   assumes updated_relations:
     "\<And>s s'. \<lbrakk> P s; P' s'; (s, s') \<in> state_relation \<rbrakk>
               \<Longrightarrow> cdt_relation ((\<noteq>) None \<circ> new_caps s) (new_mdb s) (new_ctes s')
@@ -416,7 +417,7 @@ lemma corres_caps_decomposition:
                   \<and> sched_act_relation (new_action s) (new_sa' s')
                   \<and> revokable_relation (new_rvk s) (null_filter (new_caps s)) (new_ctes s')
                   \<and> interrupt_state_relation (new_irqn s) (new_irqs s) (new_irqs' s')
-                  \<and> (new_as s, new_as' s') \<in> arch_state_relation
+                  \<and> (new_as s, new_as' s') \<in> arch_state_relation (new_ao' s')
                   \<and> new_ct s = new_ct' s'
                   \<and> new_id s = new_id' s'
                   \<and> new_ms s = new_ms' s'
@@ -470,6 +471,12 @@ proof -
     "\<And>P. \<lbrace>\<lambda>s. P (new_irqn s) (new_irqs s)\<rbrace> f
              \<lbrace>\<lambda>rv s. \<exists>irn. interrupt_irq_node s = irn \<and> P irn (interrupt_states s)\<rbrace>"
     by (wp hoare_vcg_ex_lift updates, simp)
+  have g_as_ao'[wp]:
+    "\<And>P. \<lbrace>\<lambda>s'. P (new_as' s') (new_ao' s')\<rbrace> g \<lbrace>\<lambda>_ s'. P (ksArchState s') (aobjs_of' s')\<rbrace>"
+    apply wp_pre
+     apply (wp updates | wps updates)+
+    apply simp
+    done
   note abs_irq_together = abs_irq_together'[simplified]
   show ?thesis
     unfolding state_relation_def swp_cte_at

--- a/proof/refine/AARCH64/ArchDetype_R.thy
+++ b/proof/refine/AARCH64/ArchDetype_R.thy
@@ -267,9 +267,43 @@ end (* detype_locale' *)
 
 context Arch begin arch_global_naming
 
+lemma vmid_for_asid'_detype:
+  assumes table:
+    "\<And>(asid::asid_high_index) p. armKSASIDTable (ksArchState s') (ucast asid) = Some p \<Longrightarrow> \<not>P p"
+  shows "armKSASIDMap' (ksArchState s') ((\<lambda>x. if P x then None else ksPSpace s' x) |> aobj_of') =
+         armKSASIDMap' (ksArchState s') (aobjs_of' s')"
+  unfolding vmid_for_asid_2'_def
+  apply (subst neg_opt_filter_map_eq[symmetric])
+  apply (rule ext)
+  apply simp
+  apply (rule obind_eqI, rule refl)
+  apply (rule obind_eqI)
+   apply simp
+   apply (drule table)
+   apply (simp flip: opt_map_assoc add: opt_filter_map_apply)
+  apply (rule refl)
+  done
+
+lemma freeMemory_invs:
+  "\<lbrace>invs and K (is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits)\<rbrace>
+   do_machine_op (freeMemory ptr bits)
+   \<lbrace>\<lambda>_. invs\<rbrace>"
+  apply (simp add: freeMemory_def)
+  apply (rule hoare_pre)
+   apply (rule_tac P'="is_aligned ptr bits \<and> word_size_bits \<le> bits \<and> bits \<le> word_bits"
+                in hoare_grab_asm)
+   apply (simp add: mapM_storeWord_clear_um[unfolded word_size_def] word_size_def
+                    intvl_range_conv[where 'a=machine_word_len, folded word_bits_def])
+   apply wp
+  apply (clarsimp simp: invs_def valid_state_def valid_irq_states_def clear_um_def cur_tcb_def
+                        valid_machine_state_def)
+  done
+
 (* FIXME arch-split: some of this can be generalised; 3 is same on all arches *)
+(* FIXME: is_aligned base magnitude; magnitude \<ge> 3: both already follow from valid_cap in
+          the abstract precondition *)
 lemma deleteObjects_corres:
-  "is_aligned base magnitude \<Longrightarrow> magnitude \<ge> 3 \<Longrightarrow>
+  "\<lbrakk> is_aligned base magnitude; magnitude \<ge> 3 \<rbrakk> \<Longrightarrow>
    corres dc
       (\<lambda>s. einvs s
            \<and> s \<turnstile> (cap.UntypedCap d base magnitude idx)
@@ -314,7 +348,7 @@ lemma deleteObjects_corres:
       apply (rule corres_return_bind)
       apply (rule corres_split[OF pTableNoPartialOverlap])
         apply simp
-        apply (rule_tac P="\<lambda>s. valid_objs s \<and> valid_list s \<and>
+        apply (rule_tac P="\<lambda>s. invs s \<and> valid_objs s \<and> valid_list s \<and>
                                (\<exists>cref. cte_wp_at ((=) (cap.UntypedCap d base magnitude idx)) cref s \<and>
                                        descendants_range (cap.UntypedCap d base magnitude idx) cref s ) \<and>
                                s \<turnstile> cap.UntypedCap d base magnitude idx \<and> pspace_aligned s \<and>
@@ -358,9 +392,14 @@ lemma deleteObjects_corres:
             apply (erule state_relation_ready_queues_relation)
            apply (simp add: add_mask_fold)
           (* arch_state_relation *)
-          apply (fastforce simp: arch_state_relation_def update_gs_def comp_def
-                           dest!: state_relationD
-                           split: Structures_A.apiobject_type.splits aobject_type.splits)
+          apply (clarsimp simp: arch_state_relation_def
+                           dest!: state_relationD)
+          apply (rename_tac oref slot)
+          apply (rule vmid_for_asid'_detype[symmetric])
+          apply (prop_tac "detype_locale_arch (cap.UntypedCap d base magnitude idx) (oref, slot) s")
+           apply (simp add: detype_locale_arch_def detype_locale_def)
+          apply (drule detype_locale_arch.asid_table_Some_not_untyped_range, simp)
+          apply (simp add: untyped_range_def add_mask_fold)
          apply (clarsimp simp: state_relation_def ghost_relation_of_heap
                                detype_def)
          apply (drule_tac t="gsUserPages s'" in sym)
@@ -370,10 +409,10 @@ lemma deleteObjects_corres:
                            opt_map_def
                      split: option.splits kernel_object.splits)[1]
         apply (simp add: valid_mdb_def)
-       apply (wp hoare_vcg_ex_lift hoare_vcg_ball_lift | wps |
+       apply (wp hoare_vcg_ex_lift hoare_vcg_ball_lift freeMemory_invs | wps |
               simp add: invs_def valid_state_def valid_pspace_def
                         descendants_range_def | wp (once) hoare_drop_imps)+
-   apply fastforce
+   apply (fastforce simp: valid_cap_def cap_aligned_def word_size_bits_def)
   apply (wpsimp wp: hoare_vcg_op_lift)
   done
 

--- a/proof/refine/AARCH64/ArchInit_R.thy
+++ b/proof/refine/AARCH64/ArchInit_R.thy
@@ -18,6 +18,7 @@ definition zeroed_arch_abstract_state :: arch_state where
   "zeroed_arch_abstract_state \<equiv> \<lparr>
     arm_asid_table    = Map.empty,
     arm_kernel_vspace = K ArmVSpaceUserRegion,
+    arm_asid_map = Map.empty,
     arm_vmid_table = Map.empty,
     arm_next_vmid = 0,
     arm_us_global_vspace = 0,
@@ -38,9 +39,9 @@ lemma ghost_relation_wrapper_arch_intermediate_state[Init_R_assms]:
   by simp
 
 lemma non_empty_refine_arch_state_relation[Init_R_assms]:
-  "(zeroed_arch_abstract_state, zeroed_arch_intermediate_state) \<in> arch_state_relation"
+  "(zeroed_arch_abstract_state, zeroed_arch_intermediate_state) \<in> arch_state_relation Map.empty"
   unfolding zeroed_arch_abstract_state_def zeroed_arch_intermediate_state_def arch_state_relation_def
-  by simp
+  by (simp add: vmid_for_asid_2'_def obind_def)
 
 end (* Arch *)
 

--- a/proof/refine/AARCH64/ArchKHeap_R.thy
+++ b/proof/refine/AARCH64/ArchKHeap_R.thy
@@ -166,6 +166,17 @@ lemma obj_relation_cut_same_type:
 lemmas obj_at_simps = gen_obj_at_simps is_other_obj_relation_type_def
                       objBits_simps pageBits_def
 
+lemma arch_state_relation_vmids_cong:
+  "aobjs |> asid_pool_of' ||> vmids_of_pool' = aobjs' |> asid_pool_of' ||> vmids_of_pool' \<Longrightarrow>
+  ((s, s') \<in> arch_state_relation aobjs) = ((s, s') \<in> arch_state_relation aobjs')"
+  by (simp add: arch_state_relation_def)
+
+lemma typ_at_asid_pools_of'_None:
+  "\<lbrakk> typ_at' T p s; T \<noteq> ArchT ASIDPoolT \<rbrakk> \<Longrightarrow> asid_pools_of' s p = None"
+  unfolding typ_at'_def ko_wp_at'_def
+  by (clarsimp simp: opt_map_def aobj_of'_def asid_pool_of'_def
+               split: kernel_object.split arch_kernel_object.split)
+
 lemma setObject_other_corres:
   fixes ob' :: "'a :: pspace_storable"
   assumes x: "updateObject ob' = updateObject_default ob'"
@@ -225,6 +236,9 @@ lemma setObject_other_corres:
    apply (insert t)
    apply ((erule disjE
           | clarsimp simp: is_other_obj_relation_type is_other_obj_relation_type_def a_type_def)+)[1]
+  \<comment> \<open>aobjs_of' unchanged\<close>
+  apply (simp add: other_obj_is_ArchObj_isArchT_eq isArch_koTypeOf_aobj_of'[THEN iffD1]
+                   typ_at_aobjs_of'_None)
   \<comment> \<open>ready_queues_relation\<close>
   apply (prop_tac "koTypeOf (injectKO ob') \<noteq> TCBT")
    subgoal
@@ -240,9 +254,13 @@ lemma setObject_other_arch_corres:
                \<Longrightarrow> map_to_ctes ((ksPSpace s) (ptr \<mapsto> injectKO ob')) = map_to_ctes (ksPSpace s)"
   assumes t: "is_other_obj_relation_type (a_type ob)"
   assumes b: "\<And>ko. P ko \<Longrightarrow> objBits ko = objBits ob'"
-  assumes e: "\<And>ko. P ko \<Longrightarrow> exst_same' (injectKO ko) (injectKO ob')"
   assumes P: "\<And>v::'a::pspace_storable. (1 :: machine_word) < 2 ^ objBits v"
   assumes a: "is_ArchObj ob"
+  assumes arch:
+    "\<And>s s'. \<lbrakk> (s, ksArchState s') \<in> arch_state_relation (aobjs_of' s');
+               typ_at' (koTypeOf (injectKO ob')) ptr s'; obj_at' P  ptr s' \<rbrakk> \<Longrightarrow>
+              (s, ksArchState s') \<in>
+                arch_state_relation ((aobjs_of' s')(ptr := aobj_of' (injectKO ob')))"
   shows      "other_aobj_relation ob (injectKO (ob' :: 'a :: pspace_storable)) \<Longrightarrow>
   corres dc (obj_at (\<lambda>ko. a_type ko = a_type ob) ptr and obj_at (same_caps ob) ptr)
             (obj_at' (P :: 'a \<Rightarrow> bool) ptr)
@@ -293,12 +311,43 @@ lemma setObject_other_arch_corres:
    apply (insert t)
    apply ((erule disjE
           | clarsimp simp: is_other_obj_relation_type is_other_obj_relation_type_def a_type_def)+)[1]
+  apply (simp add: arch)
   \<comment> \<open>ready_queues_relation\<close>
   apply (prop_tac "koTypeOf (injectKO ob') \<noteq> TCBT")
    subgoal
      by (clarsimp simp: other_aobj_relation_def; cases ob; cases "injectKO ob'";
          simp split: arch_kernel_obj.split_asm)
   by (fastforce dest: tcbs_of'_non_tcb_update)
+
+lemma setObject_not_asidpool_corres:
+  fixes ob' :: "'a :: pspace_storable"
+  assumes x: "updateObject ob' = updateObject_default ob'"
+  assumes z: "\<And>s. obj_at' P ptr s
+               \<Longrightarrow> map_to_ctes ((ksPSpace s) (ptr \<mapsto> injectKO ob')) = map_to_ctes (ksPSpace s)"
+  assumes t: "is_other_obj_relation_type (a_type ob)"
+  assumes b: "\<And>ko. P ko \<Longrightarrow> objBits ko = objBits ob'"
+  assumes P: "\<And>v::'a::pspace_storable. (1 :: machine_word) < 2 ^ objBits v"
+  assumes a: "is_ArchObj ob"
+  assumes n: "koTypeOf (injectKO ob') \<noteq> ArchT ASIDPoolT"
+  shows      "other_aobj_relation ob (injectKO (ob' :: 'a :: pspace_storable)) \<Longrightarrow>
+  corres dc (obj_at (\<lambda>ko. a_type ko = a_type ob) ptr and obj_at (same_caps ob) ptr)
+            (obj_at' (P :: 'a \<Rightarrow> bool) ptr)
+            (set_object ptr ob) (setObject ptr ob')"
+  apply (rule setObject_other_arch_corres; (rule assms; assumption | assumption)?)
+  apply (subgoal_tac "(aobjs_of' s')(ptr := aobj_of' (injectKO ob')) |> asid_pool_of' =
+                      asid_pools_of' s'")
+   apply (simp add: arch_state_relation_def)
+  apply (frule typ_at_asid_pools_of'_None, rule n)
+  apply (prop_tac "isArchT (koTypeOf (injectKO ob'))")
+   apply (clarsimp simp: other_aobj_relation_def
+                   split: Structures_A.kernel_object.splits arch_kernel_obj.splits
+                          kernel_object.splits arch_kernel_object.splits)
+  apply (clarsimp simp: obj_at'_def typ_at'_def ko_wp_at'_def)
+  apply (case_tac "injectKO ob'"; simp)
+  using n
+  apply (rename_tac ako, case_tac ako; simp)
+  done
+
 
 lemmas [KHeap_R_assms] =
   setObject_other_corres[where 'a=endpoint]

--- a/proof/refine/AARCH64/ArchRetype_R.thy
+++ b/proof/refine/AARCH64/ArchRetype_R.thy
@@ -1014,17 +1014,21 @@ lemma retype_state_relation[Retype_R_2_assms]:
   have nc_dis: "distinct (new_cap_addrs m ptr ko)"
     by (rule new_cap_addrs_distinct [OF cover'])
 
+  have ksPSpace_None:
+    "\<And>p. p \<in> set (new_cap_addrs m ptr ko) \<Longrightarrow> ksPSpace s' p = None"
+    apply (drule subsetD [OF new_cap_addrs_subset [OF cover']])
+    apply (insert pspace_no_overlap_disjoint'[OF vs'(1) pn'])
+    apply (drule orthD1)
+     apply (simp add:ptr_add_def field_simps)
+    apply clarsimp
+    done
+
   note nc_al = bspec [OF new_cap_addrs_aligned [OF al']]
   note nc_al' = nc_al[unfolded objBits_def]
   show "null_filter' (map_to_ctes ?ps') = null_filter' (ctes_of s')"
     apply (rule null_filter_ctes_retype [OF ko vs' pa'' pd''])
      apply (simp add: nc_al)
-    apply clarsimp
-    apply (drule subsetD [OF new_cap_addrs_subset [OF cover']])
-    apply (insert pspace_no_overlap_disjoint'[OF vs'(1) pn'])
-    apply (drule orthD1)
-      apply (simp add:ptr_add_def field_simps)
-    apply clarsimp
+    apply (clarsimp simp: ksPSpace_None)
     done
 
   show "valid_objs s" using vs
@@ -1206,11 +1210,32 @@ lemma retype_state_relation[Retype_R_2_assms]:
     using retype_ready_queues_relation[OF _ vs' pn' ko cover num_r]
     by (clarsimp simp: ready_queues_relation_def Let_def)
 
-  have asr: "(arch_state s, ksArchState s') \<in> arch_state_relation" using sr
-    by (blast dest: state_relationD)
+  have [dest!]:
+    "\<And>pool. (makeObjectKO dev d ty = Some (KOArch (KOASIDPool (asidpool.ASIDPool pool)))) \<Longrightarrow>
+             (pool = Map.empty)"
+    by (simp add: makeObjectKO_def makeObject_asidpool const_def
+             split: sum.splits kernel_object.splits arch_kernel_object.splits object_type.splits
+                    apiobject_type.splits if_splits)
 
-  thus "(arch_state s, ksArchState ?t') \<in> arch_state_relation"
-    using asr
+  from ko
+  have vmid_for_asid':
+    "\<And>table.
+       (\<lambda>asid::AARCH64_A.asid. vmid_for_asid_2' (ucast asid) table
+                                                (asid_pools_of' s' ||> vmids_of_pool')) =
+       (\<lambda>asid. vmid_for_asid_2' (ucast asid) table
+                                (?ps' |> aobj_of' |> asid_pool_of' ||> vmids_of_pool'))"
+    apply (simp add: foldr_upd_app_if[folded data_map_insert_def])
+    apply (rule ext, rename_tac asid)
+    apply (clarsimp simp: vmid_for_asid_2'_def obind_def split: option.split)
+    apply (fastforce simp: in_omonad in_opt_map_None_eq ksPSpace_None vmids_of_pool'_def
+                     split: if_splits)
+    done
+
+  moreover
+  have asr: "(arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s')" using sr
+    by (blast dest: state_relationD)
+  ultimately
+  show "(arch_state s, ksArchState ?t') \<in> arch_state_relation (?ps' |> aobj_of')"
     by (clarsimp simp: arch_state_relation_def update_gs_def comp_def
                  split: Structures_A.apiobject_type.splits aobject_type.splits)
 qed

--- a/proof/refine/AARCH64/ArchSchedule_R.thy
+++ b/proof/refine/AARCH64/ArchSchedule_R.thy
@@ -259,7 +259,8 @@ crunch arch_switch_to_thread, arch_switch_to_idle_thread
 
 lemma arch_switchToThread_corres:
   "corres dc (valid_arch_state and valid_objs and pspace_aligned and pspace_distinct
-              and valid_vspace_objs and pspace_in_kernel_window and valid_cur_fpu and tcb_at t)
+              and valid_vspace_objs and pspace_in_kernel_window and valid_cur_fpu
+              and valid_asid_map and tcb_at t)
              (no_0_obj')
              (arch_switch_to_thread t) (Arch.switchToThread t)"
   unfolding arch_switch_to_thread_def AARCH64_H.switchToThread_def

--- a/proof/refine/AARCH64/ArchStateRelation.thy
+++ b/proof/refine/AARCH64/ArchStateRelation.thy
@@ -46,8 +46,9 @@ primrec acap_relation :: "arch_cap \<Rightarrow> arch_capability \<Rightarrow> b
 | "acap_relation (arch_cap.SMCCap smc_badge) c  = (c =
         arch_capability.SMCCap smc_badge)"
 
+(* The vmID component is handled in abs_asid_map *)
 definition abs_asid_entry :: "asidpool_entry \<Rightarrow> asid_pool_entry" where
-  "abs_asid_entry ap = AARCH64_A.ASIDPoolVSpace (apVMID ap) (apVSpace ap)"
+  "abs_asid_entry ap = AARCH64_A.ASIDPoolVSpace (apVSpace ap)"
 
 definition asid_pool_relation :: "asid_pool \<Rightarrow> asidpool \<Rightarrow> bool" where
   "asid_pool_relation \<equiv> \<lambda>p p'. p = map_option abs_asid_entry \<circ> inv ASIDPool p' \<circ> ucast"
@@ -120,6 +121,56 @@ definition is_other_obj_relation_type :: "a_type \<Rightarrow> bool" where
     | AGarbage _ \<Rightarrow> False
     | _ \<Rightarrow> True"
 
+type_synonym asidpool_content = "asid \<rightharpoonup> asidpool_entry"
+
+definition asid_pool_of' :: "arch_kernel_object \<rightharpoonup> asidpool_content" where
+  "asid_pool_of' ako \<equiv> case ako of KOASIDPool ap \<Rightarrow> Some (inv ASIDPool ap) | _ \<Rightarrow> None"
+
+lemmas asid_pool_of'_simps[simp] = asid_pool_of'_def[split_simps arch_kernel_object.split]
+
+lemma inv_ASIDPool_eq:
+  "(inv ASIDPool ako = pool) = (ako = ASIDPool pool)"
+  by (cases ako, simp)
+
+lemma asid_pool_of'_Some[iff]:
+  "(asid_pool_of' a = Some pool) = (a = KOASIDPool (ASIDPool pool))"
+  by (clarsimp simp: asid_pool_of'_def inv_ASIDPool_eq split: arch_kernel_object.splits)
+
+locale_abbrev asid_pools_of' :: "kernel_state \<Rightarrow> obj_ref \<rightharpoonup> asidpool_content" where
+  "asid_pools_of' \<equiv> \<lambda>s. aobjs_of' s |> asid_pool_of'"
+
+definition vmids_of_pool' :: "asidpool_content \<Rightarrow> (asid \<rightharpoonup> vmid)" where
+  "vmids_of_pool' pool \<equiv> pool |> apVMID"
+
+locale_abbrev vmids_of' :: "kernel_state \<Rightarrow> obj_ref \<rightharpoonup> (asid \<rightharpoonup> vmid)" where
+  "vmids_of' \<equiv> \<lambda>s. asid_pools_of' s ||> vmids_of_pool'"
+
+definition vmid_for_asid_2' :: "asid \<Rightarrow> (asid \<rightharpoonup> obj_ref) \<Rightarrow> (obj_ref \<rightharpoonup> (asid \<rightharpoonup> vmid)) \<rightharpoonup> vmid"
+  where
+  "vmid_for_asid_2' asid asid_table' \<equiv> do {
+     pool_ptr \<leftarrow> K $ asid_table' (asidHighBitsOf asid);
+     vmids \<leftarrow> oapply pool_ptr;
+     K $ vmids (asid && mask asidLowBits)
+   }"
+
+locale_abbrev vmid_for_asid' :: "kernel_state \<Rightarrow> asid \<rightharpoonup> vmid" where
+  "vmid_for_asid' \<equiv>
+    \<lambda>s asid. vmid_for_asid_2' asid (armKSASIDTable (ksArchState s)) (vmids_of' s)"
+
+lemmas vmid_for_asid'_def = vmid_for_asid_2'_def
+
+(* The definition of arch_state_relation works on arch states and aobjs_of' directly *)
+locale_abbrev (input) armKSASIDMap' ::
+  "Arch.kernel_state \<Rightarrow> (obj_ref \<rightharpoonup> arch_kernel_object) \<Rightarrow> AARCH64_A.asid \<rightharpoonup> vmid"
+  where
+  "armKSASIDMap' s aobjs \<equiv> \<lambda>asid. vmid_for_asid_2' (ucast (asid::AARCH64_A.asid))
+                                                   (armKSASIDTable s)
+                                                   (aobjs |> asid_pool_of' ||> vmids_of_pool')"
+
+(* Short name for proof goals that work on the entire state *)
+locale_abbrev armKSASIDMap :: "kernel_state \<Rightarrow> AARCH64_A.asid \<rightharpoonup> vmid" where
+  "armKSASIDMap \<equiv> \<lambda>s. armKSASIDMap' (ksArchState s) (aobjs_of' s)"
+
 definition ghost_relation ::
   "kheap \<Rightarrow> (machine_word \<rightharpoonup> vmpage_size) \<Rightarrow> (machine_word \<rightharpoonup> nat) \<Rightarrow> (machine_word \<rightharpoonup> pt_type) \<Rightarrow> bool"
   where
@@ -139,8 +190,9 @@ definition ghost_relation_wrapper_2 ::
 (* inside Arch locale, we have no need for the wrapper *)
 lemmas ghost_relation_wrapper_def[simp] = ghost_relation_wrapper_2_def
 
-definition arch_state_relation :: "(arch_state \<times> AARCH64_H.kernel_state) set" where
-  "arch_state_relation \<equiv> {(s, s') .
+definition arch_state_relation ::
+  "(obj_ref \<rightharpoonup> arch_kernel_object) \<Rightarrow> (arch_state \<times> AARCH64_H.kernel_state) set" where
+  "arch_state_relation aobjs' \<equiv> {(s, s') .
          arm_asid_table s = armKSASIDTable s' \<circ> ucast
          \<and> arm_us_global_vspace s = armKSGlobalUserVSpace s'
          \<and> arm_next_vmid s = armKSNextVMID s'
@@ -148,7 +200,8 @@ definition arch_state_relation :: "(arch_state \<times> AARCH64_H.kernel_state) 
          \<and> arm_kernel_vspace s = armKSKernelVSpace s'
          \<and> arm_current_vcpu s = armHSCurVCPU s'
          \<and> arm_gicvcpu_numlistregs s = armKSGICVCPUNumListRegs s'
-         \<and> arm_current_fpu_owner s = armKSCurFPUOwner s'}"
+         \<and> arm_current_fpu_owner s = armKSCurFPUOwner s'
+         \<and> arm_asid_map s = armKSASIDMap' s' aobjs'}"
 
 locale_abbrev
   "pt_types_of s \<equiv> pts_of s ||> pt_type"

--- a/proof/refine/AARCH64/ArchVSpace_R.thy
+++ b/proof/refine/AARCH64/ArchVSpace_R.thy
@@ -224,12 +224,12 @@ lemma setObject_VCPU_corres:
                   (setObject vcpu vcpuObj')"
   apply (simp add: set_vcpu_def)
   apply (rule corres_guard_imp)
-    apply (rule setObject_other_arch_corres[where P="\<lambda>ko::vcpu. True"], simp)
+    apply (rule setObject_not_asidpool_corres[where P="\<lambda>ko::vcpu. True"], simp)
           apply (clarsimp simp: obj_at'_def)
           apply (erule map_to_ctes_upd_other, simp, simp)
          apply (simp add: a_type_def is_other_obj_relation_type_def)
-        apply (simp add: objBits_simps)+
-      apply (simp add: objBits_simps vcpuBits_def pageBits_def)+
+        apply (simp add: objBits_simps)
+       apply (simp add: objBits_simps vcpuBits_def pageBits_def)+
     apply (simp add: other_aobj_relation_def asid_pool_relation_def)
    apply (clarsimp simp: typ_at_to_obj_at'[symmetric] obj_at_def exs_valid_def
                          assert_def a_type_def return_def fail_def)
@@ -1359,35 +1359,53 @@ lemma mask_is_asid_low_bits_of[simp]:
   "(ucast asid :: machine_word) && mask asid_low_bits = ucast (asid_low_bits_of asid)"
   by (word_eqI_solve simp: asid_low_bits_of_def asid_low_bits_def)
 
-lemma getASIDPoolEntry_corres'[corres]:
-  "asid' = ucast asid \<Longrightarrow>
-   corres (\<lambda>r r'. r = map_option abs_asid_entry r')
-          (\<lambda>s. pspace_aligned s \<and> pspace_distinct s \<and>
-               (\<forall>p. pool_for_asid asid s = Some p \<longrightarrow> asid_pool_at p s) \<and> 0 < asid)
-          \<top>
-          (gets (entry_for_asid asid))
-          (getASIDPoolEntry asid')"
-  unfolding entry_for_asid_def getASIDPoolEntry_def
-  apply (clarsimp simp: gets_obind_bind_eq entry_for_pool_def obind_comp_dist
-                  cong: option.case_cong)
-  apply (corres corres: getPoolPtr_corres | corres_cases_both)+
-      apply (rule monadic_rewrite_corres_l)
-       apply (monadic_rewrite_l gets_oapply_liftM_rewrite)
-       apply (rule monadic_rewrite_refl)
-      apply (corres simp: liftM_def asid_pool_relation_def asid_pools_at_eq corres: corres_returnTT
-             | corres_cases)+
+lemma getObject_asidpool_no_fail[wp]:
+  "no_fail (asid_pool_at' p) (getObject p :: asidpool kernel)"
+  supply lookupAround2_same1[simp del]
+  apply (simp add: getObject_def split_def)
+  apply wp
+  apply (clarsimp simp add: obj_at'_def objBits_simps typ_at_to_obj_at_arches
+                      cong: conj_cong option.case_cong)
+  apply (rule ps_clear_lookupAround2; assumption?)
+    apply simp
+   apply (erule is_aligned_no_overflow)
+  apply clarsimp
   done
 
-lemma getASIDPoolEntry_get_the_corres[corres]:
-  "asid' = ucast asid \<Longrightarrow>
-   corres (\<lambda>r r'. map_option abs_asid_entry r' = Some r)
-          (\<lambda>s. pspace_aligned s \<and> pspace_distinct s \<and> entry_for_asid asid s \<noteq> None \<and> 0 < asid)
-          \<top>
-          (gets_the (entry_for_asid asid))
-          (getASIDPoolEntry asid')"
-  apply (simp add: gets_the_def cong: corres_weak_cong)
-  apply (rule corres_bind_return2)
-  apply (corres simp: entry_for_asid_def entry_for_pool_def in_omonad obj_at_def)
+lemma vspace_for_asid_cross:
+  "\<lbrakk> (s, s') \<in> state_relation; pspace_aligned s; pspace_distinct s;
+     vspace_for_asid asid s \<noteq> None \<rbrakk> \<Longrightarrow>
+   0 < asid \<and>
+   (\<exists>ap pool. armKSASIDTable (ksArchState s') (ucast (asid_high_bits_of (ucast asid))) = Some ap \<and>
+              ko_at' (ASIDPool pool) ap s' \<and>
+              pool (ucast asid && mask asid_low_bits) \<noteq> None)"
+  apply (clarsimp simp: vspace_for_asid_def ex_abs_def entry_for_asid_def
+                        pool_for_asid_def entry_for_pool_def if_option_eq
+                        ucast_down_ucast_id is_down)
+  apply (erule state_relationE)
+  apply (fastforce simp: arch_state_relation_def asid_pool_relation_def
+                   dest!: asid_pool_of_ko_at'_cross)
+  done
+
+lemma asid_leq_asidRange[simp]:
+  "ucast (asid :: AARCH64_A.asid) \<le> snd asidRange"
+  apply (simp add: asidRange_def word_less_nat_alt unat_ucast_upcast is_up)
+  apply (unfold asid_bits_def)
+  apply (rule unat_lt2p)
+  done
+
+lemma loadVMID_no_fail[wp]:
+  "no_fail (\<lambda>s. 0 < asid \<and>
+                (\<exists>ap pool. armKSASIDTable (ksArchState s)
+                             (ucast (asid_high_bits_of (ucast asid))) = Some ap \<and>
+                           ko_at' (ASIDPool pool) ap s \<and>
+                           pool (ucast asid && mask asid_low_bits) \<noteq> None))
+           (loadVMID (ucast asid))"
+  for asid::AARCH64_A.asid
+  unfolding loadVMID_def
+  apply (wpsimp simp: if_apply_def2 getASIDPoolEntry_def getPoolPtr_def typ_at'_def wp: getASID_wp)
+  apply (simp add: is_down ucast_down_ucast_id)
+  apply (rule conjI, normalise_obj_at'+)
   done
 
 lemma loadVMID_corres[corres]:
@@ -1396,39 +1414,106 @@ lemma loadVMID_corres[corres]:
           (pspace_aligned and pspace_distinct and (\<lambda>s. vspace_for_asid asid s \<noteq> None))
           \<top>
           (load_vmid asid) (loadVMID asid')"
-  unfolding load_vmid_def loadVMID_def
-  apply corres
-      apply (corres_cases, rule corres_inst[where P=\<top> and P'=\<top>], clarsimp)
-      apply (corres_cases, rule corres_returnTT, clarsimp simp: abs_asid_entry_def)
-     apply wpsimp+
-   apply (clarsimp simp: vspace_for_asid_def)
-  apply clarsimp
+  apply (rule corres_from_valid)
+   apply wpsimp
+   apply (fastforce dest!: vspace_for_asid_cross simp: ex_abs_def)
+  apply (simp add: load_vmid_def loadVMID_def exec_gets return_def)
+  apply (wpsimp simp: getASIDPoolEntry_def getPoolPtr_def wp: getASID_wp)
+  apply (fastforce simp: arch_state_relation_def vmid_for_asid'_def vmids_of_pool'_def
+                         obind_def opt_map_def
+                   dest!: ko_at_asid_pools_of'
+                   elim!: state_relationE)
   done
 
-lemma updateASIDPoolEntry_corres[corres]:
+lemma updateASIDPoolEntry_no_fail[wp]:
+  "no_fail (\<lambda>s. 0 < asid \<and>
+                (\<exists>ap pool. armKSASIDTable (ksArchState s)
+                             (ucast (asid_high_bits_of (ucast asid))) = Some ap \<and>
+                           ko_at' (ASIDPool pool) ap s \<and>
+                           pool (ucast asid && mask asid_low_bits) \<noteq> None))
+           (updateASIDPoolEntry f (ucast asid))"
+  for asid::AARCH64_A.asid
+  unfolding updateASIDPoolEntry_def getPoolPtr_def
+  apply (wpsimp wp: getASID_wp)
+  apply (simp add: is_down ucast_down_ucast_id objBits_simps typ_at'_def)
+  apply (rule conjI, normalise_obj_at'+)
+  done
+
+lemma vmids_of_pool'_udpate[simp]:
+  "vmids_of_pool' (pool(asid := entry)) =
+   (vmids_of_pool' pool)(asid := case_option None apVMID entry)"
+  by (fastforce simp: vmids_of_pool'_def opt_map_def)
+
+lemma vmid_for_asid_2'_udpate:
+  "\<lbrakk> aps p = Some pool'; asidTable (ucast (asid_high_bits_of asid)) = Some p;
+     inj_on (asidTable \<circ> UCAST(asid_high_len \<rightarrow> machine_word_len))
+            (dom (asidTable \<circ> UCAST(asid_high_len \<rightarrow> machine_word_len)));
+     asid_low' = ucast (asid_low_bits_of asid); vmid_opt' = vmid_opt \<rbrakk> \<Longrightarrow>
+   (\<lambda>asid::AARCH64_A.asid. vmid_for_asid_2' (ucast asid) asidTable (aps ||> vmids_of_pool'))(asid := vmid_opt) =
+   (\<lambda>asid. vmid_for_asid_2' (ucast asid) asidTable ((aps ||> vmids_of_pool')(p \<mapsto> (vmids_of_pool' pool')(asid_low' := vmid_opt'))))"
+  apply (rule ext, rename_tac asid_x)
+  apply clarsimp
+  apply (rule conjI; clarsimp)
+   (* asid_x = asid *)
+   apply (clarsimp simp: vmid_for_asid_2'_def obind_def ucast_up_ucast is_up)
+  (* asid_x \<noteq> asid *)
+  apply (clarsimp simp: vmid_for_asid_2'_def obind_def ucast_up_ucast is_up split: option.splits)
+  apply (clarsimp simp: vmids_of_pool'_def in_omonad o_def)
+  apply (drule (2) inj_on_domD[rotated])
+  apply (simp add: up_ucast_inj_eq asid_high_low_inj)
+  done
+
+lemma updateASIDPoolEntry_asid_map_corres[corres]:
   assumes eq: "asid' = ucast asid"
-  assumes abs: "\<And>e. map_option abs_asid_entry (f' e) = f (abs_asid_entry e)"
+  assumes vmid: "\<And>e. map_option apVMID (f' e) = Some vmid_opt"
+  assumes vspace: "\<And>e. map_option apVSpace (f' e) = Some (apVSpace e)"
   shows "corres dc
-                ((\<lambda>s. entry_for_asid asid s \<noteq> None \<and> 0 < asid)
-                 and pspace_aligned and pspace_distinct)
+                (pspace_aligned and pspace_distinct and (\<lambda>s. vspace_for_asid asid s \<noteq> None) and
+                 valid_asid_table)
                 \<top>
-                (update_asid_pool_entry f asid)
+                (update_asid_map asid vmid_opt)
                 (updateASIDPoolEntry f' asid')"
-  unfolding update_asid_pool_entry_def updateASIDPoolEntry_def
-  apply (simp add: gets_the_def bind_assoc eq)
-  apply (corres simp: liftM_def
-                term_simp: asid_pool_relation_def asid_low_bits_of_def
-                           mask_asid_low_bits_ucast_ucast ucast_ucast_mask2
-                           is_down ucast_and_mask)
-             apply (rule ext)
-             apply (clarsimp simp: asid_pool_relation_def asid_low_bits_of_def
-                                   mask_asid_low_bits_ucast_ucast ucast_ucast_mask2
-                                   is_down ucast_and_mask abs)
-             apply (erule notE)
-             apply word_eqI_solve
-           apply wpsimp+
-   apply (clarsimp simp: entry_for_asid_def entry_for_pool_def asid_pools_at_eq)
-  apply simp
+  apply (rule corres_from_valid)
+   apply (wpsimp simp: eq)
+   apply (fastforce dest!: vspace_for_asid_cross simp: ex_abs_def)
+  apply (simp add: update_asid_map_def exec_gets simpler_modify_def)
+  apply (simp add: updateASIDPoolEntry_def getPoolPtr_def)
+  apply (wpsimp wp: setObject_asidpool_wp getASID_wp)
+  apply (rename_tac s s' vspace p ko' entry')
+  apply (rule conjI)
+   apply (simp add: typ_at'_def obj_at'_def ko_wp_at'_def)
+  apply (clarsimp simp: state_relation_def obj_at'_def ko_wp_at'_def eq ucast_up_ucast is_up)
+  apply (simp add: map_to_ctes_upd_other)
+  apply (prop_tac "tcbs_of' s' p = None")
+   apply (clarsimp simp: opt_map_def projectKO_opt_tcb)
+  apply (simp add: projectKO_opt_tcb)
+  apply (rule conjI)
+   (* pspace_relation unchanged because it does not talk about vmid *)
+   apply (clarsimp simp: pspace_relation_def in_omonad)
+   apply (rule conjI, fastforce)
+   apply clarsimp
+   apply (rename_tac ko)
+   apply (rule conjI; clarsimp)
+    apply (drule bspec, fastforce)
+    apply (drule bspec, fastforce)
+    apply clarsimp
+    apply (case_tac ko; clarsimp simp: other_obj_relation_def tcb_relation_cut_def cte_relation_def
+                                 split: if_split_asm)
+    apply (rename_tac ako)
+    apply (case_tac ako; clarsimp simp: other_aobj_relation_def pte_relation_def split: if_split_asm)
+    apply (clarsimp simp: asid_pool_relation_def)
+    apply (rule ext)
+    apply (cut_tac e=entry' in vspace)
+    apply (clarsimp simp: abs_asid_entry_def)
+   apply (drule bspec, fastforce)
+   apply (fastforce)
+    (* arch_state_relation *)
+  apply (case_tac ko', rename_tac pool')
+  apply (clarsimp simp: arch_state_relation_def)
+  apply (rule vmid_for_asid_2'_udpate; (simp add: in_omonad)?)
+   apply (clarsimp simp: valid_asid_table_def)
+  apply (cut_tac e=entry' in vmid)
+  apply clarsimp
   done
 
 lemma gets_armKSVMIDTable_corres[corres]:
@@ -1440,21 +1525,21 @@ lemma gets_armKSVMIDTable_corres[corres]:
 lemma storeVMID_corres[corres]:
   "\<lbrakk> asid' = ucast asid; vmid' = vmid \<rbrakk> \<Longrightarrow>
    corres dc
-          (pspace_aligned and pspace_distinct and (\<lambda>s. vspace_for_asid asid s \<noteq> None))
+          (pspace_aligned and pspace_distinct and (\<lambda>s. vspace_for_asid asid s \<noteq> None) and
+           valid_asid_table)
           \<top>
           (store_vmid asid vmid) (storeVMID asid' vmid')"
   unfolding store_vmid_def storeVMID_def
   apply (corres simp: abs_asid_entry_def corres: corres_modify_tivial)
         apply (fastforce simp: state_relation_def arch_state_relation_def)
        apply wpsimp+
-   apply (clarsimp simp: vspace_for_asid_def)
-  apply simp
   done
 
 lemma invalidateASID_corres[corres]:
   "asid' = ucast asid \<Longrightarrow>
    corres dc
-          ((\<lambda>s. entry_for_asid asid s \<noteq> None \<and> 0 < asid) and pspace_aligned and pspace_distinct)
+          ((\<lambda>s. vspace_for_asid asid s \<noteq> None) and pspace_aligned and pspace_distinct and
+           valid_asid_table)
           \<top>
           (invalidate_asid asid) (invalidateASID asid')"
   unfolding invalidate_asid_def invalidateASID_def
@@ -1489,7 +1574,8 @@ lemma valid_vmid_tableD:
 
 lemma findFreeVMID_corres[corres]:
   "corres (=)
-          (vmid_inv and valid_vmid_table and pspace_aligned and pspace_distinct)
+          (vmid_inv and valid_vmid_table and valid_asid_table and valid_asid_map and
+           pspace_aligned and pspace_distinct)
           \<top>
           find_free_vmid findFreeVMID"
   unfolding find_free_vmid_def findFreeVMID_def
@@ -1509,16 +1595,15 @@ lemma findFreeVMID_corres[corres]:
    apply (clarsimp simp: vmid_inv_def)
    apply (frule (1) valid_vmid_tableD)
    apply (drule (1) is_inv_SomeD)
-   apply (clarsimp simp: entry_for_asid_def)
-   apply (clarsimp simp: vmid_for_asid_2_def in_omonad entry_for_pool_def pool_for_asid_def
-                         if_option_eq)
+   apply (fastforce simp: valid_asid_map_def)
   apply simp
   done
 
 lemma getVMID_corres[corres]:
   "asid' = ucast asid \<Longrightarrow>
    corres (=)
-          (vmid_inv and valid_vmid_table and pspace_aligned and pspace_distinct
+          (vmid_inv and valid_vmid_table and valid_asid_table and valid_asid_map and
+           pspace_aligned and pspace_distinct
            and (\<lambda>s. vspace_for_asid asid s \<noteq> None))
           \<top>
           (get_vmid asid) (getVMID asid')"
@@ -1528,8 +1613,8 @@ lemma getVMID_corres[corres]:
 lemma armContextSwitch_corres[corres]:
   "asid' = ucast asid \<Longrightarrow>
    corres dc
-          (vmid_inv and valid_vmid_table and pspace_aligned and pspace_distinct
-           and (\<lambda>s. vspace_for_asid asid s \<noteq> None))
+          (vmid_inv and valid_vmid_table and valid_asid_table and valid_asid_map and
+           pspace_aligned and pspace_distinct and (\<lambda>s. vspace_for_asid asid s \<noteq> None))
           \<top>
           (arm_context_switch pt asid) (armContextSwitch pt asid')"
   unfolding arm_context_switch_def armContextSwitch_def
@@ -1537,10 +1622,10 @@ lemma armContextSwitch_corres[corres]:
 
 lemma setVMRoot_corres [corres]:
   assumes "t' = t"
-  shows "corres dc (tcb_at t and valid_vspace_objs and valid_asid_table and
+  shows "corres dc (tcb_at t and valid_vspace_objs and valid_asid_table and valid_asid_map and
                     vmid_inv and valid_vmid_table and pspace_aligned and pspace_distinct and
                     valid_objs and valid_global_arch_objs and pspace_in_kernel_window and valid_uses)
-                   (no_0_obj')
+                   no_0_obj'
                    (set_vm_root t) (setVMRoot t')"
 proof -
   have global:
@@ -1560,7 +1645,7 @@ proof -
                         objBitsKO_def tcb_cnode_index_def to_bl_1 assms cteSizeBits_def)
       apply (rule_tac  R="\<lambda>thread_root. valid_vspace_objs and valid_asid_table and vmid_inv and
                                         valid_vmid_table and pspace_aligned and pspace_distinct and
-                                        valid_objs and valid_global_arch_objs and
+                                        valid_objs and valid_global_arch_objs and valid_asid_map and
                                         pspace_in_kernel_window and valid_uses and
                                         cte_wp_at ((=) thread_root) thread_root_slot and
                                         tcb_at (fst thread_root_slot) and
@@ -1585,7 +1670,7 @@ proof -
         apply (rule corres_guard_imp)
           apply (rule_tac P="valid_vspace_objs and valid_asid_table and pspace_aligned and
                              valid_vmid_table and vmid_inv and pspace_distinct and valid_objs and
-                             pspace_in_kernel_window and valid_uses and
+                             pspace_in_kernel_window and valid_uses and valid_asid_map and
                              valid_global_arch_objs and cte_wp_at ((=) cap) thread_root_slot"
                           in corres_assert_gen_asm2)
           prefer 3
@@ -1617,12 +1702,6 @@ proof -
   done
 qed
 
-lemma dMo_armvKSASIDTable_inv[wp]:
-  "doMachineOp f \<lbrace>\<lambda>s. P (armKSASIDTable (ksArchState s))\<rbrace>"
-  apply (simp add: doMachineOp_def split_def)
-  apply wp
-  by (clarsimp)
-
 crunch vcpuDisable, vcpuEnable, vcpuSave, vcpuRestore, deleteASID
   for no_0_obj'[wp]: no_0_obj'
   (simp: crunch_simps wp: crunch_wps getObject_inv getObject_inv_vcpu loadObject_default_inv)
@@ -1651,42 +1730,155 @@ lemma invalidate_vmid_entry_entry_for_asid[wp]:
   unfolding invalidate_vmid_entry_def
   by wpsimp
 
+lemma setObject_other_arch_corres':
+  fixes ob' :: "'a :: pspace_storable"
+  assumes x: "updateObject ob' = updateObject_default ob'"
+  assumes z: "\<And>s. obj_at' Q ptr s
+               \<Longrightarrow> map_to_ctes ((ksPSpace s) (ptr \<mapsto> injectKO ob')) = map_to_ctes (ksPSpace s)"
+  assumes t: "is_other_obj_relation_type (a_type ob)"
+  assumes b: "\<And>ko. Q ko \<Longrightarrow> objBits ko = objBits ob'"
+  assumes P: "\<And>v::'a::pspace_storable. (1 :: machine_word) < 2 ^ objBits v"
+  assumes a: "is_ArchObj ob"
+  assumes arch:
+    "\<And>s s'. \<lbrakk> (arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s');
+               typ_at' (koTypeOf (injectKO ob')) ptr s'; obj_at' Q  ptr s'; P s \<rbrakk> \<Longrightarrow>
+              (arch_state s, ksArchState s') \<in>
+                arch_state_relation ((aobjs_of' s')(ptr := aobj_of' (injectKO ob')))"
+  shows
+    "other_aobj_relation ob (injectKO (ob' :: 'a :: pspace_storable)) \<Longrightarrow>
+     corres dc (obj_at (\<lambda>ko. a_type ko = a_type ob) ptr and obj_at (same_caps ob) ptr and P)
+               (obj_at' (Q :: 'a \<Rightarrow> bool) ptr)
+               (set_object ptr ob) (setObject ptr ob')"
+  supply image_cong_simp[cong del] projectKOs[simp del]
+  apply (rule corres_no_failI)
+   apply (rule no_fail_pre)
+    apply wp
+    apply (rule x)
+   apply (clarsimp simp: b elim!: obj_at'_weakenE)
+  apply (unfold set_object_def setObject_def)
+  apply (clarsimp simp: in_monad split_def bind_def gets_def get_def Bex_def
+                        put_def return_def modify_def get_object_def x
+                        projectKOs obj_at_def
+                        updateObject_default_def in_magnitude_check [OF _ P])
+  apply (rename_tac ko)
+  apply (clarsimp simp add: state_relation_def z)
+  apply (clarsimp simp add: caps_of_state_after_update cte_wp_at_after_update
+                            swp_def fun_upd_def obj_at_def)
+  apply (subst conj_assoc[symmetric])
+  apply (extract_conjunct \<open>match conclusion in "ghost_relation _ _ _ _" \<Rightarrow> -\<close>)
+   apply (clarsimp simp add: ghost_relation_def)
+   apply (erule_tac x=ptr in allE)+
+   apply (clarsimp simp: obj_at_def a_type_def
+                   split: Structures_A.kernel_object.splits if_split_asm)
+   apply (simp split: arch_kernel_obj.splits if_splits)
+  apply (fold fun_upd_def)
+  apply (simp only: pspace_relation_def pspace_dom_update dom_fun_upd2 simp_thms)
+  apply (elim conjE)
+  apply (frule bspec, erule domI)
+  apply (prop_tac "is_ArchObj ko", clarsimp simp: a dest!: a_type_eq_is_ArchObj)
+  apply (prop_tac "typ_at' (koTypeOf (injectKO ob')) ptr b")
+   subgoal
+     by (clarsimp simp: typ_at'_def ko_wp_at'_def obj_at'_def projectKO_opts_defs
+                        is_other_obj_relation_type_def a_type_def other_aobj_relation_def
+                 split: Structures_A.kernel_object.split_asm if_split_asm
+                        arch_kernel_obj.split_asm kernel_object.split_asm
+                        arch_kernel_object.split_asm)
+  apply clarsimp
+  apply (rule conjI)
+   apply (rule ballI, drule(1) bspec)
+   apply (drule domD)
+   apply (clarsimp simp: is_other_obj_relation_type t a)
+   apply (drule(1) bspec)
+   apply clarsimp
+   apply (frule_tac ko'=ko and x'=ptr in obj_relation_cut_same_type)
+   apply ((fastforce simp add: is_other_obj_relation_type t)+)[3] (* loops when folded into above *)
+   apply (insert t)
+   apply ((erule disjE
+          | clarsimp simp: is_other_obj_relation_type is_other_obj_relation_type_def a_type_def)+)[1]
+  apply (simp add: arch)
+  \<comment> \<open>ready_queues_relation\<close>
+  apply (prop_tac "koTypeOf (injectKO ob') \<noteq> TCBT")
+   subgoal
+     by (clarsimp simp: other_aobj_relation_def; cases ob; cases "injectKO ob'";
+         simp split: arch_kernel_obj.split_asm)
+  by (fastforce dest: tcbs_of'_non_tcb_update)
+
+lemma setObject_ASIDPool_None_corres[corres]:
+  "\<lbrakk> p = p'; asid_pool_relation pool (asidpool.ASIDPool pool');
+     asid_low' = ucast (asid_low_bits_of asid) \<rbrakk> \<Longrightarrow>
+   corres dc ((\<lambda>s. asid_pools_of s p = Some pool \<and> asid_table s (asid_high_bits_of asid) = Some p \<and>
+                  asid_map s asid = None) and
+              pspace_aligned and pspace_distinct)
+             (\<lambda>s. ko_at' (ASIDPool pool') p' s)
+             (set_asid_pool p (pool(asid_low_bits_of asid := None)))
+             (setObject p' (ASIDPool (pool'(asid_low' := None))))"
+  apply (simp add: set_asid_pool_def)
+  apply (rule corres_underlying_symb_exec_l[where P=P and Q="\<lambda>_. P" for P])
+    apply (rule corres_no_failI; wpsimp)
+    apply (clarsimp simp: gets_map_def bind_def simpler_gets_def assert_opt_def fail_def return_def
+                          obj_at_def in_omonad
+                    split: option.splits)
+   prefer 2
+   apply wpsimp
+  apply (rule corres_guard_imp)
+    apply (rule setObject_other_arch_corres'[where
+                  Q="\<lambda>ko. ko = ASIDPool pool'" and
+                  P="\<lambda>s. asid_table s (asid_high_bits_of asid) = Some p \<and> asid_map s asid = None"])
+           apply simp
+          apply (clarsimp simp: obj_at'_def)
+          apply (erule map_to_ctes_upd_other, simp, simp)
+         apply (simp add: a_type_def is_other_obj_relation_type_def)
+        apply (simp add: objBits_simps)+
+       apply (simp add: objBits_simps pageBits_def)+
+     apply (drule ko_at_asid_pools_of')
+     apply (clarsimp simp: arch_state_relation_def)
+     apply (thin_tac "asid_map _ = _")
+     apply (clarsimp simp: vmid_for_asid_2'_def obind_def)
+     apply (rule ext)
+     apply (clarsimp split: option.splits)
+     (* needs a separate clarsimp step *)
+     apply (clarsimp simp: in_omonad)
+    apply (fastforce simp: other_aobj_relation_def asid_pool_relation_def up_ucast_inj_eq)
+   apply (simp add: obj_at_def in_omonad)
+  apply (simp add: typ_at'_def obj_at'_def ko_wp_at'_def)
+  done
+
 lemma invalidateASIDEntry_corres[corres]:
   "asid' = ucast asid \<Longrightarrow>
   corres dc
-         (pspace_aligned and pspace_distinct and (\<lambda>s. vspace_for_asid asid s \<noteq> None))
+         (pspace_aligned and pspace_distinct and valid_asid_table
+          and (\<lambda>s. vspace_for_asid asid s \<noteq> None))
          \<top>
          (invalidate_asid_entry asid) (invalidateASIDEntry asid')"
   unfolding invalidate_asid_entry_def invalidateASIDEntry_def
   by (corres simp: vspace_for_asid_def)
 
+lemma ASIDPool_inv_ASIDPool[simp]:
+  "ASIDPool (inv ASIDPool ko) = ko"
+  by (cases ko, simp)
+
 lemma deleteASID_corres [corres]:
   assumes "asid' = ucast asid" "pm' = pm"
-  shows "corres dc (invs and K (asid \<noteq> 0)) no_0_obj'
+  shows "corres dc
+                (invs and K (asid \<noteq> 0))
+                no_0_obj'
                 (delete_asid asid pm) (deleteASID asid' pm')"
   unfolding delete_asid_def deleteASID_def using assms
   apply simp
   apply (corres simp: liftM_def | corres_cases_both)+
          apply (simp add: mask_asid_low_bits_ucast_ucast asid_low_bits_of_def ucast_ucast_a is_down
                           asid_pool_relation_def abs_asid_entry_def split: option.splits)
-        apply corres
-                 apply (rule ext)
-                 apply (clarsimp simp: mask_asid_low_bits_ucast_ucast asid_low_bits_of_def
-                                       ucast_ucast_a is_down asid_pool_relation_def)
-                 apply (erule notE)
-                 apply word_eqI_solve
-                apply (corres corres: getCurThread_corres)
-               apply (wpsimp simp: cur_tcb_def[symmetric]
-                             wp: set_asid_pool_None_vmid_inv set_asid_pool_vspace_objs_unmap_single)
-              apply (wp getASID_wp)+
-           apply (rename_tac p pool pool' a b)
+        apply (corres wp: set_asid_pool_vspace_objs_unmap_single set_asid_pool_None_vmid_inv
+                          getASID_wp
+                      simp: cur_tcb_def[symmetric] ako_asid_pools_of)
+           apply (rename_tac p pool pool')
            apply (rule_tac Q'="\<lambda>_ s. invs s \<and>
-                                    (\<exists>high. asid_table s high = Some p \<and>
-                                            vmid_for_asid s (asid_of high (asid_low_bits_of asid)) =
-                                              None)" in hoare_strengthen_post)
-            apply (wp hoare_vcg_ex_lift invalidate_asid_entry_vmid_for_asid)
-           apply (fastforce simp: asid_pools_at_eq ako_asid_pools_of)
-          apply (wp hoare_drop_imp hoare_vcg_all_lift)
+                                     (asid_table s (asid_high_bits_of asid) = Some p \<and>
+                                      asid_map s asid = None)" in hoare_strengthen_post)
+            apply (wp hoare_vcg_ex_lift invalidate_asid_entry_asid_map)
+           apply fastforce
+          apply clarsimp
+          apply (wp hoare_drop_imp)
          apply (wp invalidate_tlb_by_asid_invs hoare_vcg_ex_lift)
         apply wp
        apply (clarsimp, wp)
@@ -1708,35 +1900,16 @@ lemma valid_arch_state_unmap_strg':
   apply (auto simp: ran_def split: if_split_asm option.splits)
   done
 
-crunch invalidateASIDEntry
-  for armKSASIDTable_inv[wp]: "\<lambda>s. P (armKSASIDTable (ksArchState s))"
-  (wp: getObject_inv crunch_wps simp: loadObject_default_def)
-
 lemma is_aligned_asid_low_bits_of_zero:
   "is_aligned asid asid_low_bits \<longleftrightarrow> asid_low_bits_of asid = 0"
   apply (simp add: is_aligned_mask word_eq_iff word_size asid_bits_defs asid_bits_of_defs nth_ucast)
   apply (intro iffI allI; drule_tac x=n in spec; fastforce)
   done
 
-lemma asid_high_bits_of_0[simp]:
-  "asid_high_bits_of 0 = 0"
-  by (simp add: asid_high_bits_of_def)
-
-lemma asid_low_bits_of_0[simp]:
-  "asid_low_bits_of 0 = 0"
-  by (simp add: asid_low_bits_of_def)
-
-lemma invalidate_asid_entry_asid_pool_doms[wp]:
-  "invalidate_asid_entry asid \<lbrace>\<lambda>s. P (asid_pools_of s ||> dom)\<rbrace>"
-  unfolding invalidate_asid_entry_def invalidate_asid_def invalidate_vmid_entry_def
-  apply wpsimp
-  apply (fastforce simp: opt_map_def split: option.splits elim!: rsubst[where P=P])
-  done
-
 lemma valid_asid_table_None_upd:
   "valid_asid_table_2 table pools \<Longrightarrow> valid_asid_table_2 (table(idx := None)) pools"
   unfolding valid_asid_table_2_def
-  by (auto simp: ran_def inj_on_def)
+  by (auto simp: ran_def inj_on_def asid_entry_def)
 
 lemma asid_low_le_mask_asidBits[simp]:
   "UCAST(asid_low_len \<rightarrow> asid_len) asid_low \<le> mask asid_low_bits"
@@ -1753,10 +1926,26 @@ lemma ucast_eq_from_zip_asid_low_bits:
                    asid_low_bits_def unat_of_nat_eq ucast_of_nat is_down ucast_of_nat_small)
   done
 
+lemma modify_armKSASIDTable_None_corres[corres]:
+  "asid_high' = ucast asid_high \<Longrightarrow>
+   corres dc
+          (\<lambda>s. table = asid_table s \<and> (\<forall>asid_low. asid_map s (asid_of asid_high asid_low) = None))
+          (\<lambda>s. table' = armKSASIDTable (ksArchState s))
+          (modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := table(asid_high := None)\<rparr>\<rparr>))
+          (modify (\<lambda>s. s\<lparr>ksArchState := armKSASIDTable_update (\<lambda>_. table'(asid_high' := None)) (ksArchState s)\<rparr>))"
+  apply (rule corres_modify)
+  apply (clarsimp simp: state_relation_def arch_state_relation_def simp del: fun_upd_apply)
+  apply (fastforce simp: vmid_for_asid_2'_def obind_def up_ucast_inj_eq)
+  done
+
+crunch invalidateASIDEntry, invalidateTLBByASID
+  for asidTable[wp]: "\<lambda>s. P (armKSASIDTable (ksArchState s))"
+  (wp: getASID_wp crunch_wps)
+
 lemma deleteASIDPool_corres:
   assumes "base' = ucast base" "ptr' = ptr"
   shows "corres dc (invs and K (is_aligned base asid_low_bits) and asid_pool_at ptr)
-                   (no_0_obj')
+                   no_0_obj'
                    (delete_asid_pool base ptr) (deleteASIDPool base' ptr)"
   using assms
   apply (simp add: delete_asid_pool_def deleteASIDPool_def)
@@ -1765,7 +1954,8 @@ lemma deleteASIDPool_corres:
              apply (rule_tac P="\<lambda>s. invs s \<and> pool_for_asid base s = Some ptr \<and>
                                     (asid_pools_of s ||> dom) ptr = Some (dom pool) \<and>
                                     is_aligned base asid_low_bits"
-                             and P'="no_0_obj'" in corres_mapM_x')
+                             and P'="no_0_obj'"
+                             in corres_mapM_x')
                 (* mapM_x body *)
                 apply corres
                    (* "when" condition *)
@@ -1781,20 +1971,17 @@ lemma deleteASIDPool_corres:
                                  dest!: set_zip_leftD)
                  apply (rule conjI, fastforce)
                  apply (clarsimp simp flip: word_neq_0_conv mask_2pm1)
-                 apply (prop_tac "valid_asid_map s", fastforce)
+                 apply (prop_tac "valid_asid_table s", fastforce)
                  apply (prop_tac "base = 0 \<and> low = 0")
                   apply (simp add: asid_low_bits_def)
                   apply (subst (asm) word_plus_and_or_coroll, word_eqI, force)
                   apply (fastforce simp: word_or_zero)
-                 apply (clarsimp simp: valid_asid_map_def entry_for_asid_def obind_None_eq
-                                       pool_for_asid_def entry_for_pool_def in_omonad)
+                 apply (clarsimp simp: valid_asid_table_def asid_entry_def obind_None_eq in_omonad)
                  apply blast
                 apply fastforce
                apply (wpsimp wp: invalidate_tlb_by_asid_invs)+
              apply (simp add: mask_def asid_low_bits_def)
-            apply (corres' \<open>fastforce simp: asid_high_bits_of_def asid_low_bits_def up_ucast_inj_eq
-                                            state_relation_def arch_state_relation_def\<close>
-                           corres: corres_modify_tivial)
+            apply (corres)
            (* mapM_x wp conditions *)
            apply (rename_tac table table' pool pool')
            apply (rule hoare_strengthen_post)
@@ -1802,16 +1989,20 @@ lemma deleteASIDPool_corres:
                                    pool_for_asid base s = Some ptr \<and>
                                    (asid_pools_of s ||> dom) ptr = Some (dom pool)" and
                             V="\<lambda>xs s. \<forall>asid_low \<in> set xs.
-                                         vmid_for_asid s (asid_of (asid_high_bits_of base)
-                                                                  (ucast asid_low)) = None"
+                                         asid_map s (asid_of (asid_high_bits_of base)
+                                                             (ucast asid_low)) = None"
                             in mapM_x_inv_wp3)
-            apply (wpsimp wp: invalidate_asid_entry_vmid_for_asid_add hoare_vcg_op_lift
+            apply (wpsimp wp: invalidate_asid_entry_asid_map_add hoare_vcg_op_lift
                               invalidate_tlb_by_asid_invs)
             apply (rule conjI; clarsimp)
              apply (drule arg_cong[where f=set], drule sym[where t="set xs" for xs])
              apply fastforce
-            apply (clarsimp simp: vmid_for_asid_def obind_None_eq)
+            apply (prop_tac "valid_asid_map s", fastforce)
+            apply (clarsimp simp: valid_asid_map_def)
             apply (rule ccontr)
+            apply clarsimp
+            apply (drule bspec, fastforce)
+            apply (clarsimp simp: vspace_for_asid_def entry_for_asid_def)
             apply (clarsimp simp: entry_for_pool_def in_omonad pool_for_asid_def)
             apply (fastforce dest: dom_eq_All)
            (* mapM_x invariant implies post condition;
@@ -1827,7 +2018,7 @@ lemma deleteASIDPool_corres:
            apply (fastforce simp: ucast_up_ucast_id is_up)
           apply (wpsimp wp: mapM_x_wp' getASID_wp)+
    apply (fastforce simp: is_aligned_asid_low_bits_of_zero pool_for_asid_def in_omonad)
-  apply (clarsimp simp: is_aligned_asid_low_bits_of_zero)
+  apply (fastforce simp: is_aligned_asid_low_bits_of_zero valid_asid_table'_def ran_def dom_def)
   done
 
 crunch setVMRoot
@@ -1957,10 +2148,12 @@ crunch unmapPage
   (wp: crunch_wps simp: crunch_simps)
 
 lemma vs_lookup_slot_vspace_for_asidD:
-  "\<lbrakk> vs_lookup_slot level asid vref s = Some (level, slot); level \<le> max_pt_level; valid_asid_map s \<rbrakk>
+  "\<lbrakk> vs_lookup_slot level asid vref s = Some (level, slot); level \<le> max_pt_level;
+     valid_asid_table s \<rbrakk>
    \<Longrightarrow> vspace_for_asid asid s \<noteq> None"
   by (fastforce simp: vs_lookup_slot_def vs_lookup_table_def vspace_for_asid_def in_omonad
-                      valid_asid_map_def entry_for_asid_def vspace_for_pool_def obind_None_eq
+                      valid_asid_table_def entry_for_asid_def vspace_for_pool_def obind_None_eq
+                      asid_entry_def entry_for_pool_def pool_for_asid_def
                 simp flip: word_neq_0_conv
                 split: if_split_asm)
 
@@ -2162,6 +2355,46 @@ definition
   | VCPUWriteRegister v _ _ \<Rightarrow> \<top>
   | VCPUAckVPPI v _ \<Rightarrow> \<top>"
 
+lemma setObject_ASIDPool_Some_vspace_corres[corres]:
+  "\<lbrakk>asid_low' = ucast (asid_low_bits_of asid); vs' = vs; asid_pool_relation pool (ASIDPool pool')\<rbrakk>
+   \<Longrightarrow> corres dc
+              (\<lambda>s. asid_pools_of s p = Some pool \<and> pool (asid_low_bits_of asid) = None)
+              (\<lambda>s. ko_at' (ASIDPool pool') p s)
+              (set_asid_pool p (pool(asid_low_bits_of asid \<mapsto> asid_pool_entry.ASIDPoolVSpace vs)))
+              (setObject p (ASIDPool (pool'(asid_low' \<mapsto> ASIDPoolVSpace None vs'))))"
+  apply (rule corres_assume_pre)
+  apply (prop_tac "pool' (ucast (asid_low_bits_of asid)) = None")
+   apply (fastforce simp: asid_pool_relation_def)
+  apply clarsimp
+  apply (thin_tac "_ \<in> state_relation")
+  apply (thin_tac "asid_pools_of _ _ = Some _")
+  apply (thin_tac "ko_at' _ _ _")
+  apply (simp add: set_asid_pool_def)
+  apply (rule corres_underlying_symb_exec_l[where P=P and Q="\<lambda>_. P" for P])
+    apply (rule corres_no_failI; wpsimp)
+    apply (clarsimp simp: gets_map_def bind_def simpler_gets_def assert_opt_def fail_def return_def
+                          obj_at_def in_omonad
+                    split: option.splits)
+   prefer 2
+   apply wpsimp
+  apply (rule corres_guard_imp)
+    apply (rule setObject_other_arch_corres[where P="\<lambda>ko. ko = ASIDPool pool'"])
+           apply simp
+          apply (clarsimp simp: obj_at'_def)
+          apply (erule map_to_ctes_upd_other, simp, simp)
+         apply (simp add: a_type_def is_other_obj_relation_type_def)
+        apply (simp add: objBits_simps)+
+       apply (simp add: objBits_simps pageBits_def)+
+     apply (drule ko_at_asid_pools_of')
+     apply (fastforce simp: arch_state_relation_def vmid_for_asid_2'_def obind_def in_omonad
+                            vmids_of_pool'_def opt_map_def
+                      split: option.split)
+    apply (fastforce simp: other_aobj_relation_def asid_pool_relation_def up_ucast_inj_eq
+                           abs_asid_entry_def)
+   apply (simp add: obj_at_def in_omonad)
+  apply (simp add: typ_at'_def obj_at'_def ko_wp_at'_def)
+  done
+
 lemma performASIDPoolInvocation_corres[corres]:
   "\<lbrakk> ap' = asid_pool_invocation_map ap \<rbrakk> \<Longrightarrow>
    corres dc
@@ -2171,17 +2404,18 @@ lemma performASIDPoolInvocation_corres[corres]:
           (performASIDPoolInvocation ap')"
   apply (clarsimp simp: perform_asid_pool_invocation_def performASIDPoolInvocation_def)
   apply (cases ap, simp add: asid_pool_invocation_map_def)
+  apply (rename_tac asid ap_ptr slot)
   apply (corres corres: getSlotCap_corres corres_assert_gen_asm_l updateCap_same_master
                 simp: liftM_def store_asid_pool_entry_def
+                wp: getASID_wp set_cap_typ_at get_cap_wp
+                    hoare_vcg_imp_lift'[where f="set_cap p cap" for p cap]
                 term_simp: cap.is_ArchObjectCap_def arch_cap.is_PageTableCap_def
                            update_map_data_def)
-          apply (fastforce simp: asid_pool_relation_def abs_asid_entry_def cap.is_ArchObjectCap_def
-                                 arch_cap.is_PageTableCap_def inv_def ucast_up_inj)
-         apply (wpsimp wp: set_cap_typ_at hoare_drop_imp get_cap_wp)+
    apply (clarsimp simp: valid_apinv_def cte_wp_at_caps_of_state cap_master_cap_simps is_cap_simps
-                         arch_cap.is_PageTableCap_def is_vsroot_cap_def update_map_data_def in_omonad)
+                         arch_cap.is_PageTableCap_def is_vsroot_cap_def update_map_data_def
+                         in_omonad)
    apply (drule (1) caps_of_state_valid_cap)
-   apply (simp add: valid_cap_def obj_at_def)
+   apply (simp add: valid_cap_def obj_at_def asid_low_bits_of_def)
   apply (clarsimp simp: valid_apinv'_def cte_wp_at_ctes_of)
   apply (fastforce intro!: pspace_aligned_cross pspace_distinct_cross)
   done

--- a/proof/refine/AARCH64/Arch_R.thy
+++ b/proof/refine/AARCH64/Arch_R.thy
@@ -112,6 +112,34 @@ lemma set_cap_device_and_range_aligned:
   apply (wp set_cap_device_and_range)
   done
 
+crunch cteInsert
+  for aobjs_of'[wp]: "\<lambda>s. P (aobjs_of' s)"
+  (wp: crunch_wps)
+
+lemma createObjects'_ap:
+  "\<lbrace>\<lambda>s. pspace_no_overlap' p sz s \<and> valid_pspace' s \<and> range_cover p sz pageBits (Suc 0)\<rbrace>
+   createObjects' p (Suc 0) (KOArch (KOASIDPool makeObject)) 0
+   \<lbrace>\<lambda>_ s. asid_pools_of' s p = Some (\<lambda>x. None)\<rbrace>"
+  apply (rule hoare_assume_pre)
+  apply (rule createObjects'_wp_subst)
+  apply (rule hoare_chain)
+    apply (rule hoare_vcg_conj_lift)
+     apply (rule createObjects_ko_at[where val="makeObject::asidpool"]; simp?)
+     apply (fastforce simp add: objBitsKO_def archObjSize_def)
+    apply (rule createObjects_ret; (simp add: word_bits_def)?)
+   apply simp
+  apply (clarsimp simp: makeObject_asidpool const_def ko_at_asid_pools_of')
+  done
+
+lemma vmid_for_asid'_new_ap:
+  "\<lbrakk> asid_pools_of' s' ap = Some Map.empty; armKSASIDTable (ksArchState s') asid_high = None \<rbrakk> \<Longrightarrow>
+   armKSASIDMap' (ksArchState s') (aobjs_of' s') =
+   (\<lambda>asid. vmid_for_asid_2' (ucast asid)
+                            ((armKSASIDTable (ksArchState s'))(asid_high \<mapsto> ap))
+                            (asid_pools_of' s' ||> vmids_of_pool'))"
+  by (auto simp: vmid_for_asid_2'_def obind_def in_omonad vmids_of_pool'_def
+           split: option.split)
+
 lemma performASIDControlInvocation_corres:
   "asid_ci_map i = i' \<Longrightarrow>
   corres dc
@@ -168,12 +196,15 @@ lemma performASIDControlInvocation_corres:
               apply (simp add: is_aligned_mask dc_def[symmetric])
               apply (rule corres_split[where P=\<top> and P'=\<top> and r'="\<lambda>t t'. t = t' o ucast"])
                  apply (clarsimp simp: state_relation_def arch_state_relation_def)
-                apply (rule corres_trivial)
-                apply (rule corres_modify)
-                apply (thin_tac "x \<in> state_relation" for x)
-                apply (clarsimp simp: state_relation_def arch_state_relation_def o_def)
-                apply (rule ext)
-                apply (clarsimp simp: up_ucast_inj_eq)
+                apply (thin_tac "(s, s') \<in> state_relation")
+                apply (rule_tac P="\<lambda>s. arm_asid_table (arch_state s) (asid_high_bits_of word2) = None"
+                            and P'="\<lambda>s'. asid_pools_of' s' word1 = Some Map.empty \<and>
+                                         asidTable = armKSASIDTable (ksArchState s')"
+                             in corres_modify)
+                apply (rename_tac t t')
+                apply (clarsimp simp: state_relation_def arch_state_relation_def o_def up_ucast_inj_eq)
+                apply (fold fun_upd_apply)[1]
+                apply (erule (1) vmid_for_asid'_new_ap)
                apply wp+
            apply (strengthen safe_parent_strg[where idx = "2^pageBits"])
            apply (strengthen invs_valid_objs invs_distinct
@@ -191,9 +222,10 @@ lemma performASIDControlInvocation_corres:
           apply (clarsimp simp:valid_cap'_def)
           apply (wp createObject_typ_at'
                     createObjects_orig_cte_wp_at'[where sz = pageBits])
-          apply (rule descendants_of'_helper)
-          apply (wp createObjects_null_filter'
-                    [where sz = pageBits and ty="Inl (KOArch (KOASIDPool undefined))"])
+          apply (wp (once) descendants_of'_helper)
+           apply (wp createObjects_null_filter'
+                     [where sz = pageBits and ty="Inl (KOArch (KOASIDPool undefined))"])
+          apply (wp createObjects'_ap)
          apply (clarsimp simp: conj_comms obj_bits_api_def arch_kobj_size_def
                                objBits_simps default_arch_object_def pred_conj_def)
          apply (clarsimp simp: conj_comms
@@ -282,7 +314,8 @@ lemma performASIDControlInvocation_corres:
     apply fastforce
    apply (clarsimp simp: is_simple_cap_arch_def)
    apply (rule conjI, clarsimp)
-   apply (rule conjI, clarsimp simp: clear_um_def)
+   apply (rule conjI, clarsimp simp: clear_um_def) (* asid_table *)
+   apply (rule conjI, clarsimp simp: clear_um_def) (* descendants_of *)
    apply (simp add:detype_clear_um_independent)
    apply (rule conjI)
     apply clarsimp
@@ -314,10 +347,11 @@ lemma performASIDControlInvocation_corres:
          simp_all add: is_simple_cap'_def isCap_simps descendants_range'_def2
                        null_filter_descendants_of'[OF null_filter_simp']
                        capAligned_def asid_low_bits_def)
-       apply (erule descendants_range_caps_no_overlapI')
-        apply (fastforce simp:cte_wp_at_ctes_of is_aligned_neg_mask_eq)
-       apply (simp add:empty_descendants_range_in')
-      apply (simp add:word_bits_def bit_simps)
+        apply (erule descendants_range_caps_no_overlapI')
+         apply (fastforce simp:cte_wp_at_ctes_of is_aligned_neg_mask_eq)
+        apply (simp add:empty_descendants_range_in')
+       apply (simp add:word_bits_def bit_simps)
+      apply (simp add: range_cover_def word_and_mask_shift_eq_0 pageBits_def)
      apply (rule is_aligned_weaken)
       apply (rule is_aligned_shiftl_self[unfolded shiftl_t2n,where p = 1,simplified])
      apply (simp add:pageBits_def)

--- a/proof/refine/AARCH64/Untyped_R.thy
+++ b/proof/refine/AARCH64/Untyped_R.thy
@@ -1393,6 +1393,7 @@ crunch set_cap, set_cdt
 crunch updateMDB, updateNewFreeIndex, setCTE
   for rdyq_projs[wp]:
     "\<lambda>s. P (ksReadyQueues s) (tcbSchedNexts_of s) (tcbSchedPrevs_of s) (\<lambda>d p. inQ d p |< tcbs_of' s)"
+  and aobjs_of'[wp]: "\<lambda>s. P (aobjs_of' s)"
 
 lemma insertNewCap_corres:
 notes if_cong[cong del] if_weak_cong[cong]

--- a/proof/refine/ARM/ADT_H.thy
+++ b/proof/refine/ARM/ADT_H.thy
@@ -1703,17 +1703,12 @@ definition
       arm_kernel_vspace = kvspace\<rparr>"
 
 lemma absArchState_correct:
-assumes rel:
-  "(s,s') \<in> state_relation"
-shows
-  "absArchState (ksArchState s') = arch_state s"
-apply (subgoal_tac "(arch_state s, ksArchState s') \<in> arch_state_relation")
- prefer 2
- using rel
- apply (simp add: state_relation_def)
-apply (clarsimp simp add: arch_state_relation_def)
-by (clarsimp simp add: absArchState_def
-             split: ARM_H.kernel_state.splits)
+  "(s,s') \<in> state_relation \<Longrightarrow> absArchState (ksArchState s') = arch_state s"
+  apply (prop_tac "(arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s')")
+   apply (simp add: state_relation_def)
+  apply (clarsimp simp add: arch_state_relation_def)
+  apply (clarsimp simp add: absArchState_def split: ARM_H.kernel_state.splits)
+  done
 
 definition absSchedulerAction where
   "absSchedulerAction action \<equiv>

--- a/proof/refine/ARM/ArchArchAcc_R.thy
+++ b/proof/refine/ARM/ArchArchAcc_R.thy
@@ -714,7 +714,7 @@ lemma setObject_PD_corres [@lift_corres_args, corres]:
    subgoal by (fastforce dest: tcbs_of'_non_tcb_update)
   apply (simp add: map_to_ctes_upd_other)
   apply (simp add: fun_upd_def)
-  apply (simp add: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
+  apply (clarsimp simp: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
   done
 
 lemma setObject_PT_corres [@lift_corres_args, corres]:
@@ -786,7 +786,7 @@ lemma setObject_PT_corres [@lift_corres_args, corres]:
    subgoal by (fastforce dest: tcbs_of'_non_tcb_update)
   apply (simp add: map_to_ctes_upd_other)
   apply (simp add: fun_upd_def)
-  apply (simp add: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
+  apply (clarsimp simp: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
   done
 
 

--- a/proof/refine/ARM/ArchCSpace_R.thy
+++ b/proof/refine/ARM/ArchCSpace_R.thy
@@ -427,6 +427,7 @@ lemma corres_caps_decomposition:
              "\<And>P. \<lbrace>\<lambda>s. P (new_ds' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksDomSchedule s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_cd' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksCurDomain s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_dt' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksDomainTime s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (new_ao' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (aobjs_of' s)\<rbrace>"
   assumes updated_relations:
     "\<And>s s'. \<lbrakk> P s; P' s'; (s, s') \<in> state_relation \<rbrakk>
               \<Longrightarrow> cdt_relation ((\<noteq>) None \<circ> new_caps s) (new_mdb s) (new_ctes s')
@@ -437,7 +438,7 @@ lemma corres_caps_decomposition:
                   \<and> sched_act_relation (new_action s) (new_sa' s')
                   \<and> revokable_relation (new_rvk s) (null_filter (new_caps s)) (new_ctes s')
                   \<and> interrupt_state_relation (new_irqn s) (new_irqs s) (new_irqs' s')
-                  \<and> (new_as s, new_as' s') \<in> arch_state_relation
+                  \<and> (new_as s, new_as' s') \<in> arch_state_relation (new_ao' s')
                   \<and> new_ct s = new_ct' s'
                   \<and> new_id s = new_id' s'
                   \<and> new_ms s = new_ms' s'
@@ -490,6 +491,12 @@ proof -
     "\<And>P. \<lbrace>\<lambda>s. P (new_irqn s) (new_irqs s)\<rbrace> f
              \<lbrace>\<lambda>rv s. \<exists>irn. interrupt_irq_node s = irn \<and> P irn (interrupt_states s)\<rbrace>"
     by (wp hoare_vcg_ex_lift updates, simp)
+  have g_as_ao'[wp]:
+    "\<And>P. \<lbrace>\<lambda>s'. P (new_as' s') (new_ao' s')\<rbrace> g \<lbrace>\<lambda>_ s'. P (ksArchState s') (aobjs_of' s')\<rbrace>"
+    apply wp_pre
+     apply (wp updates | wps updates)+
+    apply simp
+    done
   note abs_irq_together = abs_irq_together'[simplified]
   show ?thesis
     unfolding state_relation_def swp_cte_at

--- a/proof/refine/ARM/ArchInit_R.thy
+++ b/proof/refine/ARM/ArchInit_R.thy
@@ -33,7 +33,7 @@ lemma ghost_relation_wrapper_arch_intermediate_state[Init_R_assms]:
   by simp
 
 lemma non_empty_refine_arch_state_relation[Init_R_assms]:
-  "(zeroed_arch_abstract_state, zeroed_arch_intermediate_state) \<in> arch_state_relation"
+  "(zeroed_arch_abstract_state, zeroed_arch_intermediate_state) \<in> arch_state_relation Map.empty"
   unfolding zeroed_arch_abstract_state_def zeroed_arch_intermediate_state_def arch_state_relation_def
   by simp
 

--- a/proof/refine/ARM/ArchKHeap_R.thy
+++ b/proof/refine/ARM/ArchKHeap_R.thy
@@ -120,6 +120,11 @@ lemma obj_relation_cut_same_type:
 lemmas obj_at_simps = gen_obj_at_simps is_other_obj_relation_type_def
                       objBits_simps pageBits_def
 
+(* No aobjs dependency on this architecture *)
+lemma arch_state_relation_no_aobjs[elim!]:
+  "(s, s') \<in> arch_state_relation aobjs' \<Longrightarrow> (s, s') \<in> arch_state_relation aobjs"
+  by (simp add: arch_state_relation_def)
+
 lemma setObject_other_corres:
   fixes ob' :: "'a :: pspace_storable"
   assumes x: "updateObject ob' = updateObject_default ob'"

--- a/proof/refine/ARM/ArchRetype_R.thy
+++ b/proof/refine/ARM/ArchRetype_R.thy
@@ -1268,10 +1268,10 @@ lemma retype_state_relation[Retype_R_2_assms]:
     using retype_ready_queues_relation[OF _ vs' pn' ko cover num_r]
     by (clarsimp simp: ready_queues_relation_def Let_def)
 
-  have asr: "(arch_state s, ksArchState s') \<in> arch_state_relation" using sr
-    by (blast dest: state_relationD)
+  have asr: "\<And>aobjs. (arch_state s, ksArchState s') \<in> arch_state_relation aobjs" using sr
+    by (clarsimp dest!: state_relationD)
 
-  thus "(arch_state s, ksArchState ?t') \<in> arch_state_relation"
+  thus "\<And>aobjs. (arch_state s, ksArchState ?t') \<in> arch_state_relation aobjs"
     using asr
     by (clarsimp simp: arch_state_relation_def update_gs_def comp_def
                  split: Structures_A.apiobject_type.splits aobject_type.splits)

--- a/proof/refine/ARM/ArchStateRelation.thy
+++ b/proof/refine/ARM/ArchStateRelation.thy
@@ -152,8 +152,10 @@ definition ghost_relation_wrapper_2 ::
 (* inside Arch locale, we have no need for the wrapper *)
 lemmas ghost_relation_wrapper_def[simp] = ghost_relation_wrapper_2_def
 
-definition arch_state_relation :: "(arch_state \<times> ARM_H.kernel_state) set" where
-  "arch_state_relation \<equiv> {(s, s') .
+(* aobjs' argument unused on this architecture *)
+definition arch_state_relation ::
+  "(obj_ref \<rightharpoonup> arch_kernel_object) \<Rightarrow> (arch_state \<times> ARM_H.kernel_state) set" where
+  "arch_state_relation aobjs' \<equiv> {(s, s') .
          arm_asid_table s = armKSASIDTable s' o ucast
        \<and> arm_global_pd s = armKSGlobalPD s'
        \<and> arm_hwasid_table s = armKSHWASIDTable s'

--- a/proof/refine/ARM/Untyped_R.thy
+++ b/proof/refine/ARM/Untyped_R.thy
@@ -1398,6 +1398,9 @@ crunch updateMDB, updateNewFreeIndex, setCTE
   for rdyq_projs[wp]:
     "\<lambda>s. P (ksReadyQueues s) (tcbSchedNexts_of s) (tcbSchedPrevs_of s) (\<lambda>d p. inQ d p |< tcbs_of' s)"
 
+crunch updateNewFreeIndex
+  for aobjs_of'[wp]: "\<lambda>s. P (aobjs_of' s)"
+
 lemma insertNewCap_corres:
 notes if_cong[cong del] if_weak_cong[cong]
 shows

--- a/proof/refine/ARM_HYP/ADT_H.thy
+++ b/proof/refine/ARM_HYP/ADT_H.thy
@@ -1563,17 +1563,12 @@ definition
       arm_kernel_vspace = kvspace, arm_us_global_pd = globalpd\<rparr>"
 
 lemma absArchState_correct:
-assumes rel:
-  "(s,s') \<in> state_relation"
-shows
-  "absArchState (ksArchState s') = arch_state s"
-apply (subgoal_tac "(arch_state s, ksArchState s') \<in> arch_state_relation")
- prefer 2
- using rel
- apply (simp add: state_relation_def)
-apply (clarsimp simp add: arch_state_relation_def)
-by (clarsimp simp add: absArchState_def
-             split: ARM_HYP_H.kernel_state.splits)
+  "(s,s') \<in> state_relation \<Longrightarrow> absArchState (ksArchState s') = arch_state s"
+  apply (prop_tac "(arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s')")
+   apply (simp add: state_relation_def)
+  apply (clarsimp simp add: arch_state_relation_def)
+  apply (clarsimp simp add: absArchState_def split: ARM_HYP_H.kernel_state.splits)
+  done
 
 definition absSchedulerAction where
   "absSchedulerAction action \<equiv>

--- a/proof/refine/ARM_HYP/ArchArchAcc_R.thy
+++ b/proof/refine/ARM_HYP/ArchArchAcc_R.thy
@@ -886,7 +886,7 @@ lemma setObject_PD_corres [corres]:
    subgoal by (fastforce dest: tcbs_of'_non_tcb_update)
   apply (simp add: map_to_ctes_upd_other)
   apply (simp add: fun_upd_def)
-  apply (simp add: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
+  apply (clarsimp simp: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
   done
 
 lemma setObject_PT_corres [corres]:
@@ -959,7 +959,7 @@ lemma setObject_PT_corres [corres]:
    subgoal by (fastforce dest: tcbs_of'_non_tcb_update)
   apply (simp add: map_to_ctes_upd_other)
   apply (simp add: fun_upd_def)
-  apply (simp add: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
+  apply (clarsimp simp: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
   done
 
 lemma wordsFromPDEis2: "\<exists>a b . wordsFromPDE pde = [a , b]"

--- a/proof/refine/ARM_HYP/ArchCSpace_R.thy
+++ b/proof/refine/ARM_HYP/ArchCSpace_R.thy
@@ -438,6 +438,7 @@ lemma corres_caps_decomposition:
              "\<And>P. \<lbrace>\<lambda>s. P (new_ds' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksDomSchedule s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_cd' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksCurDomain s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_dt' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksDomainTime s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (new_ao' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (aobjs_of' s)\<rbrace>"
   assumes updated_relations:
     "\<And>s s'. \<lbrakk> P s; P' s'; (s, s') \<in> state_relation \<rbrakk>
               \<Longrightarrow> cdt_relation ((\<noteq>) None \<circ> new_caps s) (new_mdb s) (new_ctes s')
@@ -448,7 +449,7 @@ lemma corres_caps_decomposition:
                   \<and> sched_act_relation (new_action s) (new_sa' s')
                   \<and> revokable_relation (new_rvk s) (null_filter (new_caps s)) (new_ctes s')
                   \<and> interrupt_state_relation (new_irqn s) (new_irqs s) (new_irqs' s')
-                  \<and> (new_as s, new_as' s') \<in> arch_state_relation
+                  \<and> (new_as s, new_as' s') \<in> arch_state_relation (new_ao' s')
                   \<and> new_ct s = new_ct' s'
                   \<and> new_id s = new_id' s'
                   \<and> new_ms s = new_ms' s'
@@ -501,6 +502,12 @@ proof -
     "\<And>P. \<lbrace>\<lambda>s. P (new_irqn s) (new_irqs s)\<rbrace> f
              \<lbrace>\<lambda>rv s. \<exists>irn. interrupt_irq_node s = irn \<and> P irn (interrupt_states s)\<rbrace>"
     by (wp hoare_vcg_ex_lift updates, simp)
+  have g_as_ao'[wp]:
+    "\<And>P. \<lbrace>\<lambda>s'. P (new_as' s') (new_ao' s')\<rbrace> g \<lbrace>\<lambda>_ s'. P (ksArchState s') (aobjs_of' s')\<rbrace>"
+    apply wp_pre
+     apply (wp updates | wps updates)+
+    apply simp
+    done
   note abs_irq_together = abs_irq_together'[simplified]
   show ?thesis
     unfolding state_relation_def swp_cte_at

--- a/proof/refine/ARM_HYP/ArchInit_R.thy
+++ b/proof/refine/ARM_HYP/ArchInit_R.thy
@@ -35,7 +35,7 @@ lemma ghost_relation_wrapper_arch_intermediate_state[Init_R_assms]:
   by simp
 
 lemma non_empty_refine_arch_state_relation[Init_R_assms]:
-  "(zeroed_arch_abstract_state, zeroed_arch_intermediate_state) \<in> arch_state_relation"
+  "(zeroed_arch_abstract_state, zeroed_arch_intermediate_state) \<in> arch_state_relation Map.empty"
   unfolding zeroed_arch_abstract_state_def zeroed_arch_intermediate_state_def arch_state_relation_def
   by simp
 

--- a/proof/refine/ARM_HYP/ArchKHeap_R.thy
+++ b/proof/refine/ARM_HYP/ArchKHeap_R.thy
@@ -178,6 +178,11 @@ lemma obj_relation_cut_same_type:
 lemmas obj_at_simps = gen_obj_at_simps is_other_obj_relation_type_def
                       objBits_simps pageBits_def
 
+(* No aobjs dependency on this architecture *)
+lemma arch_state_relation_no_aobjs[elim!]:
+  "(s, s') \<in> arch_state_relation aobjs' \<Longrightarrow> (s, s') \<in> arch_state_relation aobjs"
+  by (simp add: arch_state_relation_def)
+
 lemma setObject_other_corres:
   fixes ob' :: "'a :: pspace_storable"
   assumes x: "updateObject ob' = updateObject_default ob'"

--- a/proof/refine/ARM_HYP/ArchRetype_R.thy
+++ b/proof/refine/ARM_HYP/ArchRetype_R.thy
@@ -1245,10 +1245,10 @@ lemma retype_state_relation[Retype_R_2_assms]:
     using retype_ready_queues_relation[OF _ vs' pn' ko cover num_r]
     by (clarsimp simp: ready_queues_relation_def Let_def)
 
-  have asr: "(arch_state s, ksArchState s') \<in> arch_state_relation" using sr
-    by (blast dest: state_relationD)
+  have asr: "\<And>aobjs. (arch_state s, ksArchState s') \<in> arch_state_relation aobjs" using sr
+    by (clarsimp dest!: state_relationD)
 
-  thus "(arch_state s, ksArchState ?t') \<in> arch_state_relation"
+  thus "\<And>aobjs. (arch_state s, ksArchState ?t') \<in> arch_state_relation aobjs"
     using asr
     by (clarsimp simp: arch_state_relation_def update_gs_def comp_def
                  split: Structures_A.apiobject_type.splits aobject_type.splits)

--- a/proof/refine/ARM_HYP/ArchStateRelation.thy
+++ b/proof/refine/ARM_HYP/ArchStateRelation.thy
@@ -175,8 +175,10 @@ definition ghost_relation_wrapper_2 ::
 (* inside Arch locale, we have no need for the wrapper *)
 lemmas ghost_relation_wrapper_def[simp] = ghost_relation_wrapper_2_def
 
-definition arch_state_relation :: "(arch_state \<times> ARM_HYP_H.kernel_state) set" where
-  "arch_state_relation \<equiv> {(s, s') .
+(* aobjs' argument unused on this architecture *)
+definition arch_state_relation ::
+  "(obj_ref \<rightharpoonup> arch_kernel_object) \<Rightarrow> (arch_state \<times> ARM_HYP_H.kernel_state) set" where
+  "arch_state_relation aobjs' \<equiv> {(s, s') .
          arm_asid_table s = armKSASIDTable s' o ucast
        \<and> arm_hwasid_table s = armKSHWASIDTable s'
        \<and> arm_next_asid s = armKSNextASID s'

--- a/proof/refine/ARM_HYP/Untyped_R.thy
+++ b/proof/refine/ARM_HYP/Untyped_R.thy
@@ -1421,6 +1421,9 @@ crunch updateMDB, updateNewFreeIndex, setCTE
   for rdyq_projs[wp]:
     "\<lambda>s. P (ksReadyQueues s) (tcbSchedNexts_of s) (tcbSchedPrevs_of s) (\<lambda>d p. inQ d p |< tcbs_of' s)"
 
+crunch updateNewFreeIndex
+  for aobjs_of'[wp]: "\<lambda>s. P (aobjs_of' s)"
+
 lemma insertNewCap_corres:
 notes if_cong[cong del] if_weak_cong[cong]
 shows

--- a/proof/refine/CSpace1_R.thy
+++ b/proof/refine/CSpace1_R.thy
@@ -1734,6 +1734,12 @@ lemma ctes_of_valid:
 
 context CSpace1_R begin
 
+lemma in_setCTE_aobjs_of':
+  "(rv, s') \<in> fst (setCTE p v s) \<Longrightarrow> aobjs_of' s' =  aobjs_of' s"
+  apply (clarsimp simp: setCTE_def)
+  apply (drule use_valid[OF _ setObject_cte_aobjs_of']; fastforce)
+  done
+
 lemma set_cap_not_quite_corres:
   assumes cr:
   "pspace_relation (kheap s) (ksPSpace s')"
@@ -1750,7 +1756,7 @@ lemma set_cap_not_quite_corres:
   "valid_objs s" "pspace_aligned s" "pspace_distinct s" "cte_at p s"
   "pspace_aligned' s'" "pspace_distinct' s'"
   "interrupt_state_relation (interrupt_irq_node s) (interrupt_states s) (ksInterruptState s')"
-  "(arch_state s, ksArchState s') \<in> arch_state_relation"
+  "(arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s')"
   assumes c: "cap_relation c c'"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
@@ -1762,7 +1768,7 @@ lemma set_cap_not_quite_corres:
              is_original_cap t = is_original_cap s \<and>
              interrupt_state_relation (interrupt_irq_node t) (interrupt_states t)
                               (ksInterruptState t') \<and>
-             (arch_state t, ksArchState t') \<in> arch_state_relation \<and>
+             (arch_state t, ksArchState t') \<in> arch_state_relation (aobjs_of' t') \<and>
              cur_thread t = ksCurThread t' \<and>
              idle_thread t = ksIdleThread t' \<and>
              machine_state t = ksMachineState t' \<and>
@@ -1780,6 +1786,7 @@ lemma set_cap_not_quite_corres:
     apply simp
     apply (rule c)
    apply (rule p)
+  apply (frule in_setCTE_aobjs_of')
   apply (erule exEI)
   apply clarsimp
   apply (frule setCTE_pspace_only)
@@ -2931,6 +2938,9 @@ lemma maxFreeIndex_eq[simp]:
 
 context CSpace1_R_2 begin
 
+crunch updateMDB
+  for aobjs_of'[wp]: "\<lambda>s. P (aobjs_of' s)"
+
 lemma updateMDB_the_lot:
   fixes s :: "det_state"
   assumes "(x, s'') \<in> fst (updateMDB p f s')"
@@ -2957,6 +2967,7 @@ lemma updateMDB_the_lot:
          ksDomainTime s''       = ksDomainTime s' \<and>
          tcbSchedNexts_of s''   = tcbSchedNexts_of s' \<and>
          tcbSchedPrevs_of s''   = tcbSchedPrevs_of s' \<and>
+         aobjs_of' s''        = aobjs_of' s' \<and>
          (\<forall>domain priority.
             (inQ domain priority |< tcbs_of' s'') = (inQ domain priority |< tcbs_of' s'))"
   using assms
@@ -2997,6 +3008,7 @@ lemma updateMDB_the_lot':
          ksDomainTime s''       = ksDomainTime s' \<and>
          tcbSchedNexts_of s''   = tcbSchedNexts_of s' \<and>
          tcbSchedPrevs_of s''   = tcbSchedPrevs_of s' \<and>
+         aobjs_of' s''        = aobjs_of' s' \<and>
          (\<forall>domain priority.
             (inQ domain priority |< tcbs_of' s'') = (inQ domain priority |< tcbs_of' s'))"
   by (rule updateMDB_the_lot; fastforce intro: assms)
@@ -3079,6 +3091,7 @@ lemma setCTE_UntypedCap_corres:
     apply (clarsimp simp: cdt_list_relation_def cte_wp_at_ctes_of split: if_split_asm)
    apply (rule conjI)
     prefer 2
+    apply (frule in_setCTE_aobjs_of')
     apply (frule setCTE_pspace_only)
     apply clarsimp
     apply (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def
@@ -5886,7 +5899,7 @@ lemma cteSwap_corres:
   apply (thin_tac "ksIdleThread t = p" for t p)+
   apply (thin_tac "pspace_relation s s'" for s s')+
   apply (thin_tac "interrupt_state_relation n s s'" for n s s')+
-  apply (thin_tac "(s,s') \<in> arch_state_relation" for s s')+
+  apply (thin_tac "(s,s') \<in> arch_state_relation aobjs" for s s' aobjs)+
   apply (rule conjI)
    apply (erule (2) ghost_relation_wrapper_set_cap_twice; rule refl)
   apply (thin_tac "ksArchState t = p" for t p)+

--- a/proof/refine/CSpace_R.thy
+++ b/proof/refine/CSpace_R.thy
@@ -826,7 +826,7 @@ lemma set_cap_not_quite_corres':
   "valid_objs s" "pspace_aligned s" "pspace_distinct s" "cte_at p s"
   "pspace_aligned' s'" "pspace_distinct' s'"
   "interrupt_state_relation (interrupt_irq_node s) (interrupt_states s) (ksInterruptState s')"
-  "(arch_state s, ksArchState s') \<in> arch_state_relation"
+  "(arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s')"
   assumes c: "cap_relation c c'"
   assumes p: "p' = cte_map p"
   shows "\<exists>t. ((),t) \<in> fst (set_cap c p s) \<and>
@@ -838,7 +838,7 @@ lemma set_cap_not_quite_corres':
              is_original_cap t = is_original_cap s \<and>
              interrupt_state_relation (interrupt_irq_node t) (interrupt_states t)
                                       (ksInterruptState t') \<and>
-             (arch_state t, ksArchState t') \<in> arch_state_relation \<and>
+             (arch_state t, ksArchState t') \<in> arch_state_relation (aobjs_of' t') \<and>
              cur_thread t = ksCurThread t' \<and>
              idle_thread t = ksIdleThread t' \<and>
              machine_state t = ksMachineState t' \<and>
@@ -5316,6 +5316,7 @@ lemma updateCap_same_master:
         prefer 2
         apply (rule conjI)
          prefer 2
+         apply (frule in_setCTE_aobjs_of')
          apply (frule setCTE_pspace_only)
          apply clarsimp
          apply (clarsimp simp: set_cap_def in_monad split_def get_object_def set_object_def

--- a/proof/refine/Init_R.thy
+++ b/proof/refine/Init_R.thy
@@ -29,8 +29,9 @@ begin
 locale Init_R =
   fixes zeroed_arch_abstract_state :: arch_state
   fixes zeroed_arch_intermediate_state :: Arch.kernel_state
+  fixes aobjs
   assumes non_empty_refine_arch_state_relation:
-    "(zeroed_arch_abstract_state, zeroed_arch_intermediate_state) \<in> arch_state_relation"
+    "(zeroed_arch_abstract_state, zeroed_arch_intermediate_state) \<in> arch_state_relation Map.empty"
   (* the None maps are a result of unfolding zeroed_main_abstract_state *)
   assumes ghost_relation_wrapper_arch_intermediate_state:
     "ghost_relation_wrapper_2 (\<lambda>_. None) (\<lambda>_. None) (\<lambda>_. None) zeroed_arch_intermediate_state"

--- a/proof/refine/KHeap_R.thy
+++ b/proof/refine/KHeap_R.thy
@@ -33,10 +33,10 @@ lemma typ_at_to_obj_at':
   by (simp add: typ_at'_def obj_at'_real_def project_koType[symmetric])
 
 lemma setObject_modify_variable_size:
-  fixes v :: "'a :: pspace_storable" shows
   "\<lbrakk>obj_at' (P :: 'a \<Rightarrow> bool) p s; updateObject v = updateObject_default v;
     (1 :: machine_word) < 2 ^ objBits v; obj_at' (\<lambda>obj. objBits v = objBits obj) p s\<rbrakk>
    \<Longrightarrow> setObject p v s = modify (ksPSpace_update (\<lambda>ps. ps (p \<mapsto> injectKO v))) s"
+  for v :: "'a :: pspace_storable"
   apply (clarsimp simp: setObject_def split_def exec_gets obj_at'_def lookupAround2_known1
                         assert_opt_def updateObject_default_def bind_assoc)
   apply (simp add: projectKO_def alignCheck_assert)
@@ -50,17 +50,50 @@ lemma setObject_modify_variable_size:
   apply (simp add: simpler_modify_def)
   done
 
+lemma setObject_default_wp:
+  "\<lbrakk> updateObject v = updateObject_default v; (1::nat) < 2 ^ objBits v \<rbrakk> \<Longrightarrow>
+   \<lbrace>\<lambda>s. obj_at' (\<lambda>obj::'a. objBits v = objBits obj) p s \<and>
+        Q () (ksPSpace_update (\<lambda>ps. ps(p \<mapsto> injectKO v)) s)\<rbrace>
+   setObject p v
+   \<lbrace>Q\<rbrace>"
+  for v :: "'a :: pspace_storable"
+  by (clarsimp simp: valid_def simpler_modify_def
+                     setObject_modify_variable_size[where P="\<lambda>ko. objBits v = objBits ko"])
+
 lemma setObject_modify:
-  fixes v :: "'a :: pspace_storable" shows
   "\<lbrakk>obj_at' (P :: 'a \<Rightarrow> bool) p s; updateObject v = updateObject_default v;
     (1 :: machine_word) < 2 ^ objBits v; \<And>ko. P ko \<Longrightarrow> objBits ko = objBits v \<rbrakk>
    \<Longrightarrow> setObject p v s = modify (ksPSpace_update (\<lambda>ps. ps (p \<mapsto> injectKO v))) s"
+  for v :: "'a :: pspace_storable"
   apply (rule setObject_modify_variable_size)
      apply fastforce
     apply fastforce
   apply fastforce
   unfolding obj_at'_def
   by fastforce
+
+definition isArchT :: "kernel_object_type \<Rightarrow> bool" where
+  "isArchT T \<equiv> case T of ArchT _ \<Rightarrow> True | _ \<Rightarrow> False"
+
+lemmas isArchT_simps[simp] = isArchT_def[split_simps kernel_object_type.split]
+
+lemma isArchT_eq:
+  "isArchT T = (\<exists>T'. T = ArchT T')"
+  by (cases T; simp)
+
+lemma isArch_koTypeOf_aobj_of':
+  "(\<not>isArchT (koTypeOf ko)) = (aobj_of' ko = None)"
+  by (cases ko; simp)
+
+lemma typ_at_aobjs_of'_None:
+  "\<lbrakk> typ_at' T p s; \<not>isArchT T \<rbrakk> \<Longrightarrow> aobjs_of' s p = None"
+  unfolding typ_at'_def ko_wp_at'_def
+  by (clarsimp simp: isArch_koTypeOf_aobj_of' opt_map_def)
+
+lemma other_obj_is_ArchObj_isArchT_eq:
+  "other_obj_relation ob ob' \<Longrightarrow> is_ArchObj ob = isArchT (koTypeOf ob')"
+  by (clarsimp simp: other_obj_relation_def
+               split: Structures_A.kernel_object.splits kernel_object.splits)
 
 lemma obj_at_getObject:
   assumes R:
@@ -232,7 +265,6 @@ lemma updateObject_ntfn_eta:
 lemmas updateObject_eta =
   updateObject_ep_eta updateObject_tcb_eta updateObject_ntfn_eta
 
-
 lemma setObject_ep_pre:
   assumes "\<lbrace>P and ep_at' p\<rbrace> setObject p (e::endpoint) \<lbrace>Q\<rbrace>"
   shows "\<lbrace>P\<rbrace> setObject p (e::endpoint) \<lbrace>Q\<rbrace>" using assms
@@ -307,6 +339,22 @@ lemma setObject_endpoint_tcbs_of'[wp]:
 
 lemma setObject_notification_tcbs_of'[wp]:
   "setObject c (notification :: notification) \<lbrace>\<lambda>s. P' (tcbs_of' s)\<rbrace>"
+  by setObject_easy_cases
+
+lemma setObject_endpoint_aobjs_of'[wp]:
+  "setObject c (ep :: endpoint) \<lbrace>\<lambda>s. P' (aobjs_of' s)\<rbrace>"
+  by setObject_easy_cases
+
+lemma setObject_notification_aobjs_of'[wp]:
+  "setObject c (ntfn :: notification) \<lbrace>\<lambda>s. P' (aobjs_of' s)\<rbrace>"
+  by setObject_easy_cases
+
+lemma setObject_cte_aobjs_of'[wp]:
+  "setObject c (cte :: cte) \<lbrace>\<lambda>s. P' (aobjs_of' s)\<rbrace>"
+  by setObject_easy_cases
+
+lemma setObject_tcb_aobjs_of'[wp]:
+  "setObject c (tcb :: tcb) \<lbrace>\<lambda>s. P' (aobjs_of' s)\<rbrace>"
   by setObject_easy_cases
 
 lemma setObject_cte_tcbSchedNexts_of[wp]:

--- a/proof/refine/RISCV64/ADT_H.thy
+++ b/proof/refine/RISCV64/ADT_H.thy
@@ -1456,7 +1456,7 @@ definition
 
 lemma absArchState_correct:
   "(s,s') \<in> state_relation \<Longrightarrow> absArchState (ksArchState s') = arch_state s"
-  apply (prop_tac "(arch_state s, ksArchState s') \<in> arch_state_relation")
+  apply (prop_tac "(arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s')")
    apply (simp add: state_relation_def)
   apply (clarsimp simp add: arch_state_relation_def)
   by (clarsimp simp add: absArchState_def

--- a/proof/refine/RISCV64/ArchArchAcc_R.thy
+++ b/proof/refine/RISCV64/ArchArchAcc_R.thy
@@ -439,7 +439,7 @@ lemma setObject_PT_corres:
    subgoal by (fastforce dest: tcbs_of'_non_tcb_update)
   apply (simp add: map_to_ctes_upd_other)
   apply (simp add: fun_upd_def)
-  apply (simp add: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
+  apply (clarsimp simp: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
   done
 
 lemma storePTE_corres[corres]:

--- a/proof/refine/RISCV64/ArchCSpace_R.thy
+++ b/proof/refine/RISCV64/ArchCSpace_R.thy
@@ -386,6 +386,7 @@ lemma corres_caps_decomposition:
              "\<And>P. \<lbrace>\<lambda>s. P (new_ds' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksDomSchedule s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_cd' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksCurDomain s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_dt' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksDomainTime s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (new_ao' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (aobjs_of' s)\<rbrace>"
   assumes updated_relations:
     "\<And>s s'. \<lbrakk> P s; P' s'; (s, s') \<in> state_relation \<rbrakk>
               \<Longrightarrow> cdt_relation ((\<noteq>) None \<circ> new_caps s) (new_mdb s) (new_ctes s')
@@ -396,7 +397,7 @@ lemma corres_caps_decomposition:
                   \<and> sched_act_relation (new_action s) (new_sa' s')
                   \<and> revokable_relation (new_rvk s) (null_filter (new_caps s)) (new_ctes s')
                   \<and> interrupt_state_relation (new_irqn s) (new_irqs s) (new_irqs' s')
-                  \<and> (new_as s, new_as' s') \<in> arch_state_relation
+                  \<and> (new_as s, new_as' s') \<in> arch_state_relation (new_ao' s')
                   \<and> new_ct s = new_ct' s'
                   \<and> new_id s = new_id' s'
                   \<and> new_ms s = new_ms' s'
@@ -449,6 +450,12 @@ proof -
     "\<And>P. \<lbrace>\<lambda>s. P (new_irqn s) (new_irqs s)\<rbrace> f
              \<lbrace>\<lambda>rv s. \<exists>irn. interrupt_irq_node s = irn \<and> P irn (interrupt_states s)\<rbrace>"
     by (wp hoare_vcg_ex_lift updates, simp)
+  have g_as_ao'[wp]:
+    "\<And>P. \<lbrace>\<lambda>s'. P (new_as' s') (new_ao' s')\<rbrace> g \<lbrace>\<lambda>_ s'. P (ksArchState s') (aobjs_of' s')\<rbrace>"
+    apply wp_pre
+     apply (wp updates | wps updates)+
+    apply simp
+    done
   note abs_irq_together = abs_irq_together'[simplified]
   show ?thesis
     unfolding state_relation_def swp_cte_at

--- a/proof/refine/RISCV64/ArchInit_R.thy
+++ b/proof/refine/RISCV64/ArchInit_R.thy
@@ -29,7 +29,7 @@ lemma ghost_relation_wrapper_arch_intermediate_state[Init_R_assms]:
   by simp
 
 lemma non_empty_refine_arch_state_relation[Init_R_assms]:
-  "(zeroed_arch_abstract_state, zeroed_arch_intermediate_state) \<in> arch_state_relation"
+  "(zeroed_arch_abstract_state, zeroed_arch_intermediate_state) \<in> arch_state_relation Map.empty"
   unfolding zeroed_arch_abstract_state_def zeroed_arch_intermediate_state_def arch_state_relation_def
   by simp
 

--- a/proof/refine/RISCV64/ArchKHeap_R.thy
+++ b/proof/refine/RISCV64/ArchKHeap_R.thy
@@ -108,6 +108,11 @@ lemma obj_relation_cut_same_type:
 lemmas obj_at_simps = gen_obj_at_simps is_other_obj_relation_type_def
                       objBits_simps pageBits_def
 
+(* No aobjs dependency on this architecture *)
+lemma arch_state_relation_no_aobjs[elim!]:
+  "(s, s') \<in> arch_state_relation aobjs' \<Longrightarrow> (s, s') \<in> arch_state_relation aobjs"
+  by (simp add: arch_state_relation_def)
+
 lemma setObject_other_corres:
   fixes ob' :: "'a :: pspace_storable"
   assumes x: "updateObject ob' = updateObject_default ob'"

--- a/proof/refine/RISCV64/ArchRetype_R.thy
+++ b/proof/refine/RISCV64/ArchRetype_R.thy
@@ -1104,10 +1104,10 @@ lemma retype_state_relation[Retype_R_2_assms]:
     using retype_ready_queues_relation[OF _ vs' pn' ko cover num_r]
     by (clarsimp simp: ready_queues_relation_def Let_def)
 
-  have asr: "(arch_state s, ksArchState s') \<in> arch_state_relation" using sr
-    by (blast dest: state_relationD)
+  have asr: "\<And>aobjs. (arch_state s, ksArchState s') \<in> arch_state_relation aobjs" using sr
+    by (clarsimp dest!: state_relationD)
 
-  thus "(arch_state s, ksArchState ?t') \<in> arch_state_relation"
+  thus "\<And>aobjs. (arch_state s, ksArchState ?t') \<in> arch_state_relation aobjs"
     using asr
     by (clarsimp simp: arch_state_relation_def update_gs_def comp_def
                  split: Structures_A.apiobject_type.splits aobject_type.splits)

--- a/proof/refine/RISCV64/ArchStateRelation.thy
+++ b/proof/refine/RISCV64/ArchStateRelation.thy
@@ -100,8 +100,10 @@ definition ghost_relation_wrapper_2 ::
 (* inside Arch locale, we have no need for the wrapper *)
 lemmas ghost_relation_wrapper_def[simp] = ghost_relation_wrapper_2_def
 
-definition arch_state_relation :: "(arch_state \<times> RISCV64_H.kernel_state) set" where
-  "arch_state_relation \<equiv> {(s, s') .
+(* aobjs' argument unused on this architecture *)
+definition arch_state_relation ::
+  "(obj_ref \<rightharpoonup> arch_kernel_object) \<Rightarrow> (arch_state \<times> RISCV64_H.kernel_state) set" where
+  "arch_state_relation aobjs' \<equiv> {(s, s') .
          riscv_asid_table s = riscvKSASIDTable s' o ucast
          \<and> riscv_global_pts s = (\<lambda>l. set (riscvKSGlobalPTs s' (size l)))
          \<and> riscv_kernel_vspace s = riscvKSKernelVSpace s'}"

--- a/proof/refine/RISCV64/Untyped_R.thy
+++ b/proof/refine/RISCV64/Untyped_R.thy
@@ -1380,6 +1380,9 @@ crunch updateMDB, updateNewFreeIndex, setCTE
   for rdyq_projs[wp]:
     "\<lambda>s. P (ksReadyQueues s) (tcbSchedNexts_of s) (tcbSchedPrevs_of s) (\<lambda>d p. inQ d p |< tcbs_of' s)"
 
+crunch updateNewFreeIndex
+  for aobjs_of'[wp]: "\<lambda>s. P (aobjs_of' s)"
+
 lemma insertNewCap_corres:
 notes if_cong[cong del] if_weak_cong[cong]
 shows

--- a/proof/refine/Retype_R.thy
+++ b/proof/refine/Retype_R.thy
@@ -594,7 +594,7 @@ lemma state_relation_null_filterE:
      null_filter (caps_of_state t) = null_filter (caps_of_state s);
      null_filter' (ctes_of t') = null_filter' (ctes_of s');
      pspace_relation (kheap t) (ksPSpace t'); ready_queues_relation t t';
-     (arch_state t, ksArchState t') \<in> arch_state_relation;
+     (arch_state t, ksArchState t') \<in> arch_state_relation (aobjs_of' t');
      ghost_relation_wrapper t t';
      valid_list s;
      pspace_aligned' s'; pspace_distinct' s'; valid_objs s; valid_mdb s;

--- a/proof/refine/StateRelation.thy
+++ b/proof/refine/StateRelation.thy
@@ -297,7 +297,7 @@ definition state_relation :: "(det_state \<times> kernel_state) set" where
        \<and> cdt_relation (swp cte_at s) (cdt s) (ctes_of s')
        \<and> cdt_list_relation (cdt_list s) (cdt s) (ctes_of s')
        \<and> revokable_relation (is_original_cap s) (null_filter (caps_of_state s)) (ctes_of s')
-       \<and> (arch_state s, ksArchState s') \<in> arch_state_relation
+       \<and> (arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s')
        \<and> interrupt_state_relation (interrupt_irq_node s) (interrupt_states s) (ksInterruptState s')
        \<and> (cur_thread s = ksCurThread s')
        \<and> (idle_thread s = ksIdleThread s')
@@ -344,7 +344,7 @@ lemma state_relationD:
    cdt_relation (swp cte_at s) (cdt s) (ctes_of s') \<and>
    cdt_list_relation (cdt_list s) (cdt s) (ctes_of s') \<and>
    revokable_relation (is_original_cap s) (null_filter (caps_of_state s)) (ctes_of s') \<and>
-   (arch_state s, ksArchState s') \<in> arch_state_relation \<and>
+   (arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s') \<and>
    interrupt_state_relation (interrupt_irq_node s) (interrupt_states s) (ksInterruptState s') \<and>
    cur_thread s = ksCurThread s' \<and>
    idle_thread s = ksIdleThread s' \<and>
@@ -366,7 +366,7 @@ lemma state_relationE [elim?]:
              cdt_relation (swp cte_at s) (cdt s) (ctes_of s') \<and>
              revokable_relation (is_original_cap s) (null_filter (caps_of_state s)) (ctes_of s');
              cdt_list_relation (cdt_list s) (cdt s) (ctes_of s');
-             (arch_state s, ksArchState s') \<in> arch_state_relation;
+             (arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s');
              interrupt_state_relation (interrupt_irq_node s) (interrupt_states s) (ksInterruptState s');
              cur_thread s = ksCurThread s';
              idle_thread s = ksIdleThread s';

--- a/proof/refine/StateRelationPre.thy
+++ b/proof/refine/StateRelationPre.thy
@@ -25,4 +25,17 @@ text \<open>
 type_synonym obj_relation_cut = "Structures_A.kernel_object \<Rightarrow> Structures_H.kernel_object \<Rightarrow> bool"
 type_synonym obj_relation_cuts = "(machine_word \<times> obj_relation_cut) set"
 
+text \<open>Arch object projection for predicates that depend on arch objects only.\<close>
+definition aobj_of':: "kernel_object \<Rightarrow> arch_kernel_object option" where
+  "aobj_of' ko \<equiv> case ko of KOArch ako \<Rightarrow> Some ako | _ \<Rightarrow> None"
+
+lemmas aobj_of'_simps[simp] = aobj_of'_def[split_simps kernel_object.split]
+
+lemma aobj_of'_Some[iff]:
+  "(aobj_of' a = Some ao) = (a = KOArch ao)"
+  by (simp add: aobj_of'_def split: kernel_object.splits)
+
+abbreviation aobjs_of' :: "kernel_state \<Rightarrow> obj_ref \<rightharpoonup> arch_kernel_object" where
+  "aobjs_of' \<equiv> \<lambda>s. ksPSpace s |> aobj_of'"
+
 end

--- a/proof/refine/TcbAcc_R.thy
+++ b/proof/refine/TcbAcc_R.thy
@@ -2048,6 +2048,10 @@ lemma removeFromBitmap_ghost_relation_wrapper[wp]:
   "removeFromBitmap tdom prio \<lbrace>ghost_relation_wrapper s\<rbrace>"
   by (wpsimp simp: bitmap_fun_defs)
 
+crunch threadSet
+  for aobjs_of'[wp]: "\<lambda>s. P (aobjs_of' s)"
+  and ksArch_aobjs_of'[wp]: "\<lambda>s. P (ksArchState s) (aobjs_of' s)"
+
 locale TcbAcc_R_2 = TcbAcc_R +
   assumes removeFromBitmap_valid_bitmapQ_except:
     "\<And>d p. removeFromBitmap d p \<lbrace>valid_bitmapQ_except d p \<rbrace>"
@@ -2167,8 +2171,10 @@ lemma setBoundNotification_state_refs_of'[wp]:
   by (simp add: Un_commute
       | wpsimp simp: fun_upd_def wp: threadSet_state_refs_of')+
 
-crunch setQueue, tcbQueuePrepend, tcbQueueRemove, removeFromBitmap
+crunch setQueue, tcbQueuePrepend, tcbQueueRemove, removeFromBitmap, tcbQueueAppend, tcbQueueAppend
   for ghost_relation_wrapper[wp]: "ghost_relation_wrapper t"
+  and aobjs_of'[wp]: "\<lambda>s. P (aobjs_of' s)"
+  and ksArch_aobjs_of'[wp]: "\<lambda>s. P (ksArchState s) (aobjs_of' s)"
   (wp: crunch_wps)
 
 lemma tcbSchedEnqueue_corres:

--- a/proof/refine/X64/ADT_H.thy
+++ b/proof/refine/X64/ADT_H.thy
@@ -665,7 +665,7 @@ lemma absHeap_correct:
   assumes valid_cur_fpu:   "valid_cur_fpu s"
   assumes pspace_relation: "pspace_relation (kheap s) (ksPSpace s')"
   assumes ghost_relation:  "ghost_relation (kheap s) (gsUserPages s') (gsCNodes s')"
-  assumes arch_state_relation: "(arch_state s, ksArchState s') \<in> arch_state_relation"
+  assumes arch_state_relation: "(arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s')"
 shows
   "absHeap (gsUserPages s') (gsCNodes s') (ksPSpace s') (x64KSCurFPUOwner (ksArchState s')) = kheap s"
 proof -
@@ -1902,17 +1902,13 @@ lemma cr3_expand_unexpand[simp]: "cr3 (cr3_base_address a) (cr3_pcid a) = a"
   by (cases a, simp)
 
 lemma absArchState_correct:
-assumes rel:
-  "(s,s') \<in> state_relation"
-shows
-  "absArchState (ksArchState s') = arch_state s"
-apply (subgoal_tac "(arch_state s, ksArchState s') \<in> arch_state_relation")
- prefer 2
- using rel
- apply (simp add: state_relation_def)
-apply (clarsimp simp add: arch_state_relation_def)
-by (clarsimp simp add: absArchState_def absCR3_def cr3_relation_def x64_irq_relation_def
-             split: X64_H.kernel_state.splits cr3.splits)
+  "(s,s') \<in> state_relation \<Longrightarrow> absArchState (ksArchState s') = arch_state s"
+  apply (prop_tac "(arch_state s, ksArchState s') \<in> arch_state_relation (aobjs_of' s')")
+   apply (simp add: state_relation_def)
+  apply (clarsimp simp: arch_state_relation_def)
+  apply (clarsimp simp: absArchState_def absCR3_def cr3_relation_def x64_irq_relation_def
+                  split: X64_H.kernel_state.splits cr3.splits)
+  done
 
 definition absSchedulerAction where
   "absSchedulerAction action \<equiv>

--- a/proof/refine/X64/ArchArchAcc_R.thy
+++ b/proof/refine/X64/ArchArchAcc_R.thy
@@ -737,7 +737,7 @@ lemma setObject_PD_corres:
    apply fastforce
   apply (simp add: map_to_ctes_upd_other)
   apply (simp add: fun_upd_def)
-  apply (simp add: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
+  apply (clarsimp simp: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
   done
 
 lemma more_pt_inner_beauty:
@@ -819,7 +819,7 @@ lemma setObject_PT_corres:
    subgoal by (fastforce dest: tcbs_of'_non_tcb_update)
   apply (simp add: map_to_ctes_upd_other)
   apply (simp add: fun_upd_def)
-  apply (simp add: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
+  apply (clarsimp simp: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
   done
 
 lemma more_pdpt_inner_beauty:
@@ -902,7 +902,7 @@ lemma setObject_PDPT_corres:
    apply fastforce
   apply (simp add: map_to_ctes_upd_other)
   apply (simp add: fun_upd_def)
-  apply (simp add: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
+  apply (clarsimp simp: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
   done
 
 lemma more_pml4_inner_beauty:
@@ -986,7 +986,7 @@ lemma setObject_PML4_corres:
    apply fastforce
   apply (simp add: map_to_ctes_upd_other)
   apply (simp add: fun_upd_def)
-  apply (simp add: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
+  apply (clarsimp simp: caps_of_state_after_update obj_at_def swp_cte_at_caps_of)
   done
 
 lemma store_pml4e_corres [corres]:

--- a/proof/refine/X64/ArchCSpace_R.thy
+++ b/proof/refine/X64/ArchCSpace_R.thy
@@ -402,6 +402,7 @@ lemma corres_caps_decomposition:
              "\<And>P. \<lbrace>\<lambda>s. P (new_ds' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksDomSchedule s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_cd' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksCurDomain s)\<rbrace>"
              "\<And>P. \<lbrace>\<lambda>s. P (new_dt' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (ksDomainTime s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (new_ao' s)\<rbrace> g \<lbrace>\<lambda>rv s. P (aobjs_of' s)\<rbrace>"
   assumes updated_relations:
     "\<And>s s'. \<lbrakk> P s; P' s'; (s, s') \<in> state_relation \<rbrakk>
               \<Longrightarrow> cdt_relation ((\<noteq>) None \<circ> new_caps s) (new_mdb s) (new_ctes s')
@@ -412,7 +413,7 @@ lemma corres_caps_decomposition:
                   \<and> sched_act_relation (new_action s) (new_sa' s')
                   \<and> revokable_relation (new_rvk s) (null_filter (new_caps s)) (new_ctes s')
                   \<and> interrupt_state_relation (new_irqn s) (new_irqs s) (new_irqs' s')
-                  \<and> (new_as s, new_as' s') \<in> arch_state_relation
+                  \<and> (new_as s, new_as' s') \<in> arch_state_relation (new_ao' s')
                   \<and> new_ct s = new_ct' s'
                   \<and> new_id s = new_id' s'
                   \<and> new_ms s = new_ms' s'
@@ -465,6 +466,12 @@ proof -
     "\<And>P. \<lbrace>\<lambda>s. P (new_irqn s) (new_irqs s)\<rbrace> f
              \<lbrace>\<lambda>rv s. \<exists>irn. interrupt_irq_node s = irn \<and> P irn (interrupt_states s)\<rbrace>"
     by (wp hoare_vcg_ex_lift updates, simp)
+  have g_as_ao'[wp]:
+    "\<And>P. \<lbrace>\<lambda>s'. P (new_as' s') (new_ao' s')\<rbrace> g \<lbrace>\<lambda>_ s'. P (ksArchState s') (aobjs_of' s')\<rbrace>"
+    apply wp_pre
+     apply (wp updates | wps updates)+
+    apply simp
+    done
   note abs_irq_together = abs_irq_together'[simplified]
   show ?thesis
     unfolding state_relation_def swp_cte_at

--- a/proof/refine/X64/ArchInit_R.thy
+++ b/proof/refine/X64/ArchInit_R.thy
@@ -40,7 +40,7 @@ lemma ghost_relation_wrapper_arch_intermediate_state[Init_R_assms]:
   by simp
 
 lemma non_empty_refine_arch_state_relation[Init_R_assms]:
-  "(zeroed_arch_abstract_state, zeroed_arch_intermediate_state) \<in> arch_state_relation"
+  "(zeroed_arch_abstract_state, zeroed_arch_intermediate_state) \<in> arch_state_relation Map.empty"
   unfolding zeroed_arch_abstract_state_def zeroed_arch_intermediate_state_def arch_state_relation_def
   by (simp add: cr3_relation_def x64_irq_relation_def comp_def)
 

--- a/proof/refine/X64/ArchKHeap_R.thy
+++ b/proof/refine/X64/ArchKHeap_R.thy
@@ -116,6 +116,11 @@ lemma obj_relation_cut_same_type:
 lemmas obj_at_simps = gen_obj_at_simps is_other_obj_relation_type_def
                       objBits_simps pageBits_def
 
+(* No aobjs dependency on this architecture *)
+lemma arch_state_relation_no_aobjs[elim!]:
+  "(s, s') \<in> arch_state_relation aobjs' \<Longrightarrow> (s, s') \<in> arch_state_relation aobjs"
+  by (simp add: arch_state_relation_def)
+
 lemma setObject_other_corres:
   fixes ob' :: "'a :: pspace_storable"
   assumes x: "updateObject ob' = updateObject_default ob'"

--- a/proof/refine/X64/ArchRetype_R.thy
+++ b/proof/refine/X64/ArchRetype_R.thy
@@ -1296,10 +1296,10 @@ lemma retype_state_relation[Retype_R_2_assms]:
     using retype_ready_queues_relation[OF _ vs' pn' ko cover num_r]
     by (clarsimp simp: ready_queues_relation_def Let_def)
 
-  have asr: "(arch_state s, ksArchState s') \<in> arch_state_relation" using sr
-    by (blast dest: state_relationD)
+  have asr: "\<And>aobjs. (arch_state s, ksArchState s') \<in> arch_state_relation aobjs" using sr
+    by (clarsimp dest!: state_relationD)
 
-  thus "(arch_state s, ksArchState ?t') \<in> arch_state_relation"
+  thus "\<And>aobjs. (arch_state s, ksArchState ?t') \<in> arch_state_relation aobjs"
     using asr
     by (clarsimp simp: arch_state_relation_def update_gs_def comp_def
                  split: Structures_A.apiobject_type.splits aobject_type.splits)

--- a/proof/refine/X64/ArchStateRelation.thy
+++ b/proof/refine/X64/ArchStateRelation.thy
@@ -174,8 +174,10 @@ fun x64irqstate_to_abstract :: "x64irqstate \<Rightarrow> X64IRQState" where
 definition x64_irq_relation :: "(8 word \<Rightarrow> X64IRQState) \<Rightarrow> (8 word \<Rightarrow> x64irqstate) \<Rightarrow> bool" where
   "x64_irq_relation irq_states irq_states' \<equiv> irq_states = x64irqstate_to_abstract o irq_states'"
 
-definition arch_state_relation :: "(arch_state \<times> X64_H.kernel_state) set" where
-  "arch_state_relation \<equiv> {(s, s') .
+(* aobjs' argument unused on this architecture *)
+definition arch_state_relation ::
+  "(obj_ref \<rightharpoonup> arch_kernel_object) \<Rightarrow> (arch_state \<times> X64_H.kernel_state) set" where
+  "arch_state_relation aobjs' \<equiv> {(s, s') .
          x64_asid_table s = x64KSASIDTable s' o ucast
        \<and> x64_global_pml4 s = x64KSSKIMPML4 s'
        \<and> x64_global_pdpts s = x64KSSKIMPDPTs s'

--- a/proof/refine/X64/Untyped_R.thy
+++ b/proof/refine/X64/Untyped_R.thy
@@ -1438,6 +1438,9 @@ crunch updateMDB, updateNewFreeIndex, setCTE
   for rdyq_projs[wp]:
     "\<lambda>s. P (ksReadyQueues s) (tcbSchedNexts_of s) (tcbSchedPrevs_of s) (\<lambda>d p. inQ d p |< tcbs_of' s)"
 
+crunch updateNewFreeIndex
+  for aobjs_of'[wp]: "\<lambda>s. P (aobjs_of' s)"
+
 lemma insertNewCap_corres:
 notes if_cong[cong del] if_weak_cong[cong]
 shows

--- a/spec/abstract/AARCH64/ArchVSpaceAcc_A.thy
+++ b/spec/abstract/AARCH64/ArchVSpaceAcc_A.thy
@@ -35,6 +35,9 @@ lemmas asid_bits_of_defs = asid_high_bits_of_def asid_low_bits_of_def
 locale_abbrev asid_table :: "'z::state_ext state \<Rightarrow> asid_high_index \<rightharpoonup> obj_ref" where
   "asid_table \<equiv> \<lambda>s. arm_asid_table (arch_state s)"
 
+locale_abbrev asid_map :: "'z::state_ext state \<Rightarrow> asid \<rightharpoonup> vmid" where
+  "asid_map \<equiv> \<lambda>s. arm_asid_map (arch_state s)"
+
 section "Kernel Heap Accessors"
 
 (* declared in Arch as workaround for VER-1099 *)

--- a/spec/abstract/AARCH64/ArchVSpace_A.thy
+++ b/spec/abstract/AARCH64/ArchVSpace_A.thy
@@ -47,7 +47,6 @@ definition vspace_for_pool :: "obj_ref \<Rightarrow> asid \<Rightarrow> (obj_ref
      oreturn $ ap_vspace entry
    }"
 
-(* this is what asid_map encodes in ARM/ARM_HYP; getASIDPoolEntry in Haskell *)
 definition entry_for_asid :: "asid \<Rightarrow> 'z::state_ext state \<Rightarrow> asid_pool_entry option" where
   "entry_for_asid asid = do {
      pool_ptr \<leftarrow> pool_for_asid asid;
@@ -81,14 +80,21 @@ definition find_vspace_for_asid :: "asid \<Rightarrow> (obj_ref,'z::state_ext) l
 
 definition load_vmid :: "asid \<Rightarrow> (vmid option, 'z::state_ext) s_monad" where
   "load_vmid asid \<equiv> do
-     entry \<leftarrow> gets_the $ entry_for_asid asid;
-     return $ ap_vmid entry
+     asid_map \<leftarrow> gets asid_map;
+     return $ asid_map asid
+   od"
+
+definition update_asid_map :: "asid \<Rightarrow> vmid option \<Rightarrow> (unit, 'z::state_ext) s_monad" where
+  "update_asid_map asid vmid_opt \<equiv> do
+     asid_map \<leftarrow> gets asid_map;
+     asid_map' \<leftarrow> return $ asid_map (asid := vmid_opt);
+     modify (\<lambda>s. s\<lparr>arch_state := arch_state s \<lparr>arm_asid_map := asid_map'\<rparr>\<rparr>)
    od"
 
 text \<open>Associate a VMID with an ASID.\<close>
 definition store_vmid :: "asid \<Rightarrow> vmid \<Rightarrow> (unit,'z::state_ext) s_monad" where
   "store_vmid asid hw_asid \<equiv> do
-     update_asid_pool_entry (\<lambda>entry. Some $ ASIDPoolVSpace (Some hw_asid) (ap_vspace entry)) asid;
+     update_asid_map asid (Some hw_asid);
      vmid_table \<leftarrow> gets (arm_vmid_table \<circ> arch_state);
      vmid_table' \<leftarrow> return $ vmid_table (hw_asid \<mapsto> asid);
      modify (\<lambda>s. s \<lparr> arch_state := (arch_state s) \<lparr> arm_vmid_table := vmid_table' \<rparr>\<rparr>)
@@ -116,8 +122,7 @@ definition invalidate_tlb_by_asid_va :: "asid \<Rightarrow> vspace_ref \<Rightar
 
 text \<open>Remove any mapping from this virtual ASID to a VMID.\<close>
 definition invalidate_asid :: "asid \<Rightarrow> (unit,'z::state_ext) s_monad" where
-  "invalidate_asid asid \<equiv>
-     update_asid_pool_entry (\<lambda>entry. Some $ ASIDPoolVSpace None (ap_vspace entry)) asid"
+  "invalidate_asid asid \<equiv> update_asid_map asid None"
 
 text \<open>Remove any mapping from this VMID to an ASID.\<close>
 definition invalidate_vmid_entry :: "vmid \<Rightarrow> (unit,'z::state_ext) s_monad" where
@@ -260,7 +265,7 @@ definition delete_asid :: "asid \<Rightarrow> obj_ref \<Rightarrow> (unit,'z::st
        None \<Rightarrow> return ()
      | Some pool_ptr \<Rightarrow> do
          pool \<leftarrow> get_asid_pool pool_ptr;
-         when (\<exists>vmid. pool (asid_low_bits_of asid) = Some (ASIDPoolVSpace vmid pt)) $ do
+         when (pool (asid_low_bits_of asid) = Some (ASIDPoolVSpace pt)) $ do
            invalidate_tlb_by_asid asid;
            invalidate_asid_entry asid;
            \<comment> \<open>re-read here, because @{text invalidate_asid_entry} changes the ASID pool:\<close>

--- a/spec/abstract/AARCH64/Arch_A.thy
+++ b/spec/abstract/AARCH64/Arch_A.thy
@@ -86,7 +86,7 @@ definition perform_asid_pool_invocation :: "asid_pool_invocation \<Rightarrow> (
        assert $ is_PageTableCap acap;
        set_cap (ArchObjectCap $ update_map_data acap $ Some (asid,0)) ct_slot;
        pt_base \<leftarrow> return $ acap_obj acap;
-       store_asid_pool_entry pool_ptr asid (Some (ASIDPoolVSpace None pt_base))
+       store_asid_pool_entry pool_ptr asid (Some (ASIDPoolVSpace pt_base))
      od"
 
 definition perform_pg_inv_unmap :: "arch_cap \<Rightarrow> cslot_ptr \<Rightarrow> (unit,'z::state_ext) s_monad" where

--- a/spec/abstract/AARCH64/Arch_Structs_A.thy
+++ b/spec/abstract/AARCH64/Arch_Structs_A.thy
@@ -123,7 +123,7 @@ lemma pt_index_ptTranslationBits:
   by (simp add: ptTranslationBits_def)
 
 (* This could also be a record, but we expect further alternatives to be added for SMMU *)
-datatype asid_pool_entry = ASIDPoolVSpace (ap_vmid : "vmid option") (ap_vspace : obj_ref)
+datatype asid_pool_entry = ASIDPoolVSpace (ap_vspace : obj_ref)
 
 type_synonym asid_pool = "asid_low_index \<rightharpoonup> asid_pool_entry"
 
@@ -324,6 +324,7 @@ section \<open>Architecture-specific state\<close>
 record arch_state =
   arm_asid_table :: "asid_high_index \<rightharpoonup> obj_ref"
   arm_kernel_vspace :: "AARCH64_A.arm_vspace_region_uses"
+  arm_asid_map :: "asid \<rightharpoonup> AARCH64_A.vmid"
   arm_vmid_table :: "AARCH64_A.vmid \<rightharpoonup> asid"
   arm_next_vmid :: AARCH64_A.vmid
   arm_us_global_vspace :: "obj_ref"

--- a/spec/abstract/AARCH64/Init_A.thy
+++ b/spec/abstract/AARCH64/Init_A.thy
@@ -48,6 +48,7 @@ definition init_arch_state :: arch_state where
   "init_arch_state \<equiv> \<lparr>
      arm_asid_table = Map.empty,
      arm_kernel_vspace = init_vspace_uses,
+     arm_asid_map = Map.empty,
      arm_vmid_table = Map.empty,
      arm_next_vmid = 0,
      arm_us_global_vspace = arm_global_pt_ptr,


### PR DESCRIPTION
Remove the `VMID` entry from the ASID pool in ASpec and use a global `asid_map` instead, like for ARM. The implementation in Haskell and below is unchanged.

The idea is to remove the VMID entries from kheap so that the infoflow proof does not need to introduce additional kheap infrastructure to show that the VMID is not observable. This means infoflow can for the most part continue to assume kheap equality.

Proofs updated accordingly, with the largest change in Refine where we need to add an `aobjs_of'` parameter to `arch_state_relation` so that we can construct the abstract `asid_map` from the concrete VMID entries in ASID pools. This means generic theories are affected (new interface) and the other architectures need small updates to ignore the additional parameter.

Because it was useful in a few places, I have taken the opportunity to finally implement that option filter for projections that I've mentioned a few times. This is in a separate commit and then used in Refine. There are a few more places where it could be useful, but I have left the rest of the proofs alone for now to reduce noise.