### PR TITLE
Remove Kernel_Config.maxIRQ_def instances from InfoFlow proofs

### DIFF
--- a/proof/infoflow/ARM/Example_Valid_State.thy
+++ b/proof/infoflow/ARM/Example_Valid_State.thy
@@ -27,8 +27,13 @@ consts s0_context :: user_context
 
 (* define the irqs to come regularly every 10 *)
 
+definition timer_irq :: irq where
+  "timer_irq \<equiv> maxIRQ - 1"
+
+abbreviation (input) "timer_int \<equiv> 10"
+
 axiomatization where
-  irq_oracle_def: "ARM.irq_oracle \<equiv> \<lambda>pos. if pos mod 10 = 0 then 10 else 0"
+  irq_oracle_def: "ARM.irq_oracle \<equiv> \<lambda>pos. if pos mod timer_int = 0 then timer_irq else 0"
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
@@ -219,8 +224,6 @@ definition "Silc_cnode_ptr = init_objs_base + 0x18000"
 definition "irq_cnode_ptr = init_objs_base + 0x1C000"
 
 (* init_global_pd \<equiv> {init_objs_base + 0x60000,... init_objs_base + 0x603555} *)
-
-definition "timer_irq \<equiv> 10" (* not sure exactly how this fits in *)
 
 definition "Low_mcp \<equiv> 5 :: word8"
 definition "Low_prio \<equiv> 5 :: word8"
@@ -1155,12 +1158,12 @@ lemma silc_inv_s0:
   apply (clarsimp simp: Invariants_AI.cte_wp_at_caps_of_state )
   by (auto simp:is_transferable.simps dest:s0_caps_of_state)
 
-
 lemma only_timer_irq_s0:
   "only_timer_irq timer_irq s0_internal"
   apply (clarsimp simp: only_timer_irq_def s0_internal_def irq_is_recurring_def is_irq_at_def
                         irq_at_def Let_def irq_oracle_def machine_state0_def timer_irq_def)
-  apply presburger
+  apply (erule_tac x="timer_int - n mod timer_int" in allE)
+  apply (subst (asm) mod_add_left_eq[symmetric], simp)
   done
 
 lemma domain_sep_inv_s0:

--- a/proof/infoflow/RISCV64/Example_Valid_State.thy
+++ b/proof/infoflow/RISCV64/Example_Valid_State.thy
@@ -27,8 +27,13 @@ consts s0_context :: user_context
 
 (* define the irqs to come regularly every 10 *)
 
+definition timer_irq :: irq where
+  "timer_irq \<equiv> maxIRQ - 1"
+
+abbreviation (input) "timer_int \<equiv> 10"
+
 axiomatization where
-  irq_oracle_def: "RISCV64.irq_oracle \<equiv> \<lambda>pos. if pos mod 10 = 0 then 10 else 0"
+  irq_oracle_def: "RISCV64.irq_oracle \<equiv> \<lambda>pos. if pos mod timer_int = 0 then timer_irq else 0"
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
@@ -222,8 +227,6 @@ definition "irq_cnode_ptr = pptr_base + 0x28000"
 
 definition "shared_page_ptr_virt = pptr_base + 0x200000"
 definition "shared_page_ptr_phys = addrFromPPtr shared_page_ptr_virt"
-
-definition "timer_irq \<equiv> 10" (* not sure exactly how this fits in *)
 
 definition "Low_mcp \<equiv> 5 :: priority"
 definition "Low_prio \<equiv> 5 :: priority"
@@ -1220,11 +1223,10 @@ lemma silc_inv_s0:
   apply (clarsimp simp: Invariants_AI.cte_wp_at_caps_of_state )
   by (auto simp:is_transferable.simps dest:s0_caps_of_state)
 
-
 lemma only_timer_irq_s0:
   "only_timer_irq timer_irq s0_internal"
   apply (clarsimp simp: only_timer_irq_def s0_internal_def irq_is_recurring_def is_irq_at_def
-                        irq_at_def Let_def irq_oracle_def machine_state0_def timer_irq_def)
+                        irq_at_def Let_def irq_oracle_def machine_state0_def maxIRQ_def timer_irq_def)
   apply presburger
   done
 

--- a/proof/infoflow/refine/ARM/Example_Valid_StateH.thy
+++ b/proof/infoflow/refine/ARM/Example_Valid_StateH.thy
@@ -2871,8 +2871,12 @@ axiomatization  where
 context begin interpretation Arch . (*FIXME: arch-split*)
 
 lemma timer_irq_not_outside_range[simp]:
-  "\<not> Kernel_Config.maxIRQ < (timer_irq :: irq)"
-  by (simp add: Kernel_Config.maxIRQ_def timer_irq_def)
+  "\<not> maxIRQ < timer_irq"
+  apply (simp add: timer_irq_def)
+  apply (rule leD)
+  apply (rule word_sub_1_le)
+  apply (simp add: word_neq_0_conv maxIRQ_def)
+  done
 
 lemma s0H_invs:
   assumes "1 \<le> maxDomain"
@@ -3099,7 +3103,7 @@ lemma s0H_invs:
   apply (rule conjI)
    apply (clarsimp simp: valid_machine_state'_def s0H_internal_def machine_state0_def)
   apply (rule conjI)
-   apply (clarsimp simp: irqs_masked'_def s0H_internal_def maxIRQ_def)
+   apply (clarsimp simp: irqs_masked'_def s0H_internal_def)
   apply (rule conjI)
    apply (clarsimp simp: sym_heap_def opt_map_def split: option.splits)
    using kh0H_dom_tcb

--- a/proof/infoflow/refine/RISCV64/Example_Valid_StateH.thy
+++ b/proof/infoflow/refine/RISCV64/Example_Valid_StateH.thy
@@ -3239,6 +3239,14 @@ lemma valid_arch_state_s0H:
   apply (clarsimp simp: arch_state0H_def)
   done
 
+lemma timer_irq_not_outside_range[simp]:
+  "\<not> maxIRQ < timer_irq"
+  apply (simp add: timer_irq_def)
+  apply (rule leD)
+  apply (rule word_sub_1_le)
+  apply (simp add: word_neq_0_conv maxIRQ_def)
+  done
+
 lemma s0H_invs:
   assumes "1 \<le> maxDomain"
   notes pteBits_def[simp] objBits_defs[simp]
@@ -3416,7 +3424,7 @@ lemma s0H_invs:
   apply (rule conjI)
    apply (clarsimp simp: valid_machine_state'_def s0H_internal_def machine_state0_def)
   apply (rule conjI)
-   apply (clarsimp simp: irqs_masked'_def s0H_internal_def maxIRQ_def timer_irq_def irqInvalid_def)
+   apply (clarsimp simp: irqs_masked'_def s0H_internal_def irqInvalid_def)
   apply (rule conjI)
    apply (clarsimp simp: sym_heap_def opt_map_def projectKOs split: option.splits)
    using kh0H_dom_tcb

--- a/spec/machine/AARCH64/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/AARCH64/Arch_Kernel_Config_Lemmas.thy
@@ -16,6 +16,10 @@ context Arch begin global_naming AARCH64
 
 (* maxIRQ conditions *)
 
+lemma zero_less_maxIRQ[simp, intro!]:
+  "(0 :: irq) < Kernel_Config.maxIRQ"
+  by (simp add: Kernel_Config.maxIRQ_def)
+
 lemma irqVTimerEvent_le_maxIRQ[simp, intro!]:
   "irqVTimerEvent \<le> Kernel_Config.maxIRQ"
   by (simp add: irqVTimerEvent_def Kernel_Config.maxIRQ_def)

--- a/spec/machine/ARM/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/ARM/Arch_Kernel_Config_Lemmas.thy
@@ -22,6 +22,10 @@ lemma physBase_aligned:
 
 (* maxIRQ conditions *)
 
+lemma zero_less_maxIRQ[simp, intro!]:
+  "(0 :: irq) < Kernel_Config.maxIRQ"
+  by (simp add: Kernel_Config.maxIRQ_def)
+
 lemma maxIRQ_less_2p_irqBits:
   "(Kernel_Config.maxIRQ::nat) < 2^irqBits"
   by (simp add: Kernel_Config.maxIRQ_def Kernel_Config.irqBits_def)

--- a/spec/machine/ARM_HYP/Arch_Kernel_Config_Lemmas.thy
+++ b/spec/machine/ARM_HYP/Arch_Kernel_Config_Lemmas.thy
@@ -21,6 +21,10 @@ lemma physBase_aligned:
 
 (* maxIRQ conditions *)
 
+lemma zero_less_maxIRQ[simp, intro!]:
+  "(0 :: irq) < Kernel_Config.maxIRQ"
+  by (simp add: Kernel_Config.maxIRQ_def)
+
 lemma irqVTimerEvent_le_maxIRQ[simp, intro!]:
   "irqVTimerEvent \<le> Kernel_Config.maxIRQ"
   by (simp add: irqVTimerEvent_def Kernel_Config.maxIRQ_def)


### PR DESCRIPTION
Previously, the InfoFlow example state proofs used a fixed value of 10 for timer IRQs. This required us to unfold `Kernel_Config.maxIRQ_def` when proving `timer_irq < maxIRQ` on ARM architectures. This PR redefines `timer_irq` to `maxIRQ - 1`, and introduces a lemma that entails `Kernel_Config.maxIRQ - 1 < Kernel_Config.maxIRQ`.