### PR TITLE
Multikernel C parameterisation via Gamma0

### DIFF
--- a/proof/asmrefine/SEL4GlobalsSwap.thy
+++ b/proof/asmrefine/SEL4GlobalsSwap.thy
@@ -29,7 +29,7 @@ instance ptr :: (c_type)array_outer_packed ..
 instance tcb_queue_C :: array_outer_packed ..
 instance region_C :: array_outer_packed ..
 
-locale graph_refine_locale = kernel_all_substitute
+locale graph_refine_locale = kernel_all_substitute0
     + assumes globals_list_distinct:
         "globals_list_distinct domain symbol_table globals_list"
       assumes globals_list_ok:

--- a/proof/asmrefine/export/ARM/ArchSEL4SimplExport.thy
+++ b/proof/asmrefine/export/ARM/ArchSEL4SimplExport.thy
@@ -8,7 +8,7 @@ theory ArchSEL4SimplExport
 imports "AsmRefine.SimplExport" "CSpec.Substitute"
 begin
 
-context kernel_all_substitute begin
+context kernel_all_substitute0 begin
 
 lemma ctzl_body_refines:
   "simple_simpl_refines \<Gamma> (Guard ImpossibleSpec \<lbrace>\<acute>x___unsigned_long \<noteq> 0\<rbrace>

--- a/proof/asmrefine/export/SEL4SimplExport.thy
+++ b/proof/asmrefine/export/SEL4SimplExport.thy
@@ -14,7 +14,7 @@ val csenv = let
   in fn () => the_csenv end
 \<close>
 
-context kernel_all_substitute begin
+context kernel_all_substitute0 begin
 
 declare ctcb_offset_defs[simp]
 

--- a/proof/crefine/AARCH64/ADT_C.thy
+++ b/proof/crefine/AARCH64/ADT_C.thy
@@ -1692,8 +1692,8 @@ where
 
 end
 
-locale kernel_global = state_rel + kernel_all_global_addresses
-(* repeating ADT definitions in the c-parser's locale now (not the substitute) *)
+locale kernel_global = state_rel + kernel_all_multi
+(* repeating ADT definitions in the (multikernel-adjusted) C parser's locale now, not the substitute *)
 begin
 
 definition

--- a/proof/crefine/AARCH64/Ipc_C.thy
+++ b/proof/crefine/AARCH64/Ipc_C.thy
@@ -295,9 +295,9 @@ lemma ccap_relation_reply_helpers:
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
 (*FIXME: fupdate simplification issues for 2D arrays *)
 abbreviation "syscallMessageC \<equiv>  kernel_all_global_addresses.fault_messages.[unat MessageID_Syscall]"
-lemmas syscallMessageC_def = kernel_all_substitute.fault_messages_def
-abbreviation "exceptionMessageC \<equiv> kernel_all_substitute.fault_messages.[unat MessageID_Exception]"
-lemmas exceptionMessageC_def = kernel_all_substitute.fault_messages_def
+lemmas syscallMessageC_def = kernel_all_global_addresses.fault_messages_def
+abbreviation "exceptionMessageC \<equiv> kernel_all_global_addresses.fault_messages.[unat MessageID_Exception]"
+lemmas exceptionMessageC_def = kernel_all_global_addresses.fault_messages_def
 
 lemma syscallMessage_ccorres:
   "n < unat n_syscallMessage
@@ -6071,6 +6071,7 @@ lemma receiveIPC_ccorres [corres]:
      apply (wp gbn_wp' | simp add: guard_is_UNIV_def)+
   apply (auto simp: isCap_simps valid_cap'_def)
   done
+
 
 lemma sendSignal_dequeue_ccorres_helper:
   "ccorres (\<lambda>rv rv'. rv' = tcb_ptr_to_ctcb_ptr dest) dest___ptr_to_struct_tcb_C_'

--- a/proof/crefine/AARCH64/Machine_C.thy
+++ b/proof/crefine/AARCH64/Machine_C.thy
@@ -21,8 +21,11 @@ instance virq_C :: array_inner_packed
 
 locale kernel_m = kernel +
 
-(* timer and IRQ common machine ops (function names exist on other platforms *)
+(* The current verification is for unicore only *)
+assumes cpu_0:
+  "cpuNum = 0"
 
+(* timer and IRQ common machine ops (function names exist on other platforms *)
 assumes resetTimer_ccorres:
   "ccorres dc xfdc \<top> UNIV []
            (doMachineOp resetTimer)

--- a/proof/crefine/AARCH64/Refine_C.thy
+++ b/proof/crefine/AARCH64/Refine_C.thy
@@ -1229,8 +1229,8 @@ lemma ccorres_underlying_Fault:
 lemma monadic_rewrite_\<Gamma>:
   "monadic_rewrite True False \<top>
     (exec_C \<Gamma> c)
-    (exec_C (kernel_all_global_addresses.\<Gamma> symbol_table) c)"
-  using spec_refine [of symbol_table domain]
+    (exec_C (kernel_all_multi.\<Gamma> symbol_table cpuNum) c)"
+  using spec_refine [of symbol_table cpuNum domain]
   using spec_simulates_to_exec_simulates
   apply (clarsimp simp: spec_statefn_simulates_via_statefn
                         o_def map_option_case monadic_rewrite_def exec_C_def
@@ -1247,8 +1247,8 @@ lemma no_fail_getActiveIRQ_C:
   done
 
 lemma kernel_all_subset_kernel:
-  "global_automaton (kernel_global.check_active_irq_C symbol_table) (do_user_op_C uop)
-       (kernel_global.kernel_call_C symbol_table fp)
+  "global_automaton (kernel_global.check_active_irq_C symbol_table cpuNum) (do_user_op_C uop)
+       (kernel_global.kernel_call_C symbol_table cpuNum fp)
        \<subseteq> global_automaton check_active_irq_C (do_user_op_C uop) (kernel_call_C fp)"
   apply (clarsimp simp: fw_sim_def rel_semi_def global_automaton_def
                         relcomp_unfold in_lift_state_relation_eq)
@@ -1298,7 +1298,7 @@ lemma kernel_all_subset_kernel:
   done
 
 theorem true_refinement:
-  "kernel_global.ADT_C symbol_table armKSKernelVSpace_C uop
+  "kernel_global.ADT_C symbol_table armKSKernelVSpace_C cpuNum uop
    \<sqsubseteq> ADT_H uop"
   apply (rule refinement_trans[OF _ refinement2])
   apply (simp add: kernel_global.ADT_C_def ADT_C_def)
@@ -1310,7 +1310,7 @@ theorem true_refinement:
   done
 
 theorem true_fp_refinement:
-  "kernel_global.ADT_FP_C symbol_table armKSKernelVSpace_C uop
+  "kernel_global.ADT_FP_C symbol_table armKSKernelVSpace_C cpuNum uop
    \<sqsubseteq> ADT_H uop"
   apply (rule refinement_trans[OF _ fp_refinement])
   apply (simp add: kernel_global.ADT_FP_C_def ADT_FP_C_def)

--- a/proof/crefine/AARCH64/SR_lemmas_C.thy
+++ b/proof/crefine/AARCH64/SR_lemmas_C.thy
@@ -2567,9 +2567,9 @@ lemma unat_scast_numDomains:
 
 (* link up Kernel_Config loaded from the seL4 build system with physBase in C code *)
 lemma physBase_spec:
-  "\<forall>s. \<Gamma>\<turnstile> {s} Call physBase_'proc {t. ret__unsigned_long_' t = Kernel_Config.physBase }"
+  "\<forall>s. \<Gamma>\<turnstile> {s} Call physBase_'proc {t. cpuNum = 0 \<longrightarrow> ret__unsigned_long_' t = Kernel_Config.physBase }"
   apply (rule allI, rule conseqPre, vcg)
-  apply (simp add: Kernel_Config.physBase_def)
+  apply (simp add: Kernel_Config.physBase_def ph_base_def)
   done
 
 lemma rf_sr_obj_update_helper:

--- a/proof/crefine/AARCH64/SyscallArgs_C.thy
+++ b/proof/crefine/AARCH64/SyscallArgs_C.thy
@@ -15,8 +15,8 @@ begin
 
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
 context kernel_m begin
-abbreviation "msgRegistersC \<equiv> kernel_all_substitute.msgRegisters"
-lemmas msgRegistersC_def = kernel_all_substitute.msgRegisters_def
+abbreviation "msgRegistersC \<equiv> kernel_all_global_addresses.msgRegisters"
+lemmas msgRegistersC_def = kernel_all_global_addresses.msgRegisters_def
 end
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/crefine/AARCH64/Tcb_C.thy
+++ b/proof/crefine/AARCH64/Tcb_C.thy
@@ -1106,10 +1106,10 @@ lemma Arch_performTransfer_ccorres:
   done
 
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
-abbreviation "frameRegistersC \<equiv> kernel_all_substitute.frameRegisters"
-lemmas frameRegistersC_def = kernel_all_substitute.frameRegisters_def
-abbreviation "gpRegistersC \<equiv> kernel_all_substitute.gpRegisters"
-lemmas gpRegistersC_def = kernel_all_substitute.gpRegisters_def
+abbreviation "frameRegistersC \<equiv> kernel_all_global_addresses.frameRegisters"
+lemmas frameRegistersC_def = kernel_all_global_addresses.frameRegisters_def
+abbreviation "gpRegistersC \<equiv> kernel_all_global_addresses.gpRegisters"
+lemmas gpRegistersC_def = kernel_all_global_addresses.gpRegisters_def
 
 lemma frame_gp_registers_convs:
   "length AARCH64_H.frameRegisters = unat n_frameRegisters"

--- a/proof/crefine/AARCH64/VSpace_C.thy
+++ b/proof/crefine/AARCH64/VSpace_C.thy
@@ -327,7 +327,7 @@ lemma addrFromKPPtr_spec:
    \<lbrace>\<acute>ret__unsigned_long = addrFromKPPtr (ptr_val (pptr_' s))\<rbrace>"
   apply vcg
   apply (simp add: addrFromKPPtr_def kernelELFBaseOffset_def kernelELFPAddrBase_def
-                   kernelELFBase_def pptrBase_def mask_def)
+                   kernelELFBase_def pptrBase_def mask_def cpu_0)
   done
 
 (* FIXME: move *)
@@ -1576,8 +1576,8 @@ lemma setRegister_ccorres:
 
 lemma msgRegisters_ccorres:
   "n < unat n_msgRegisters \<Longrightarrow>
-  register_from_H (AARCH64_H.msgRegisters ! n) = (index kernel_all_substitute.msgRegisters n)"
-  apply (simp add: kernel_all_substitute.msgRegisters_def msgRegisters_unfold fupdate_def)
+  register_from_H (AARCH64_H.msgRegisters ! n) = (index kernel_all_global_addresses.msgRegisters n)"
+  apply (simp add: kernel_all_global_addresses.msgRegisters_def msgRegisters_unfold fupdate_def)
   apply (simp add: Arrays.update_def n_msgRegisters_def nth_Cons' split: if_split)
   done
 

--- a/proof/crefine/AARCH64/Wellformed_C.thy
+++ b/proof/crefine/AARCH64/Wellformed_C.thy
@@ -12,7 +12,7 @@ theory Wellformed_C
 imports
   "CLib.CTranslationNICTA"
   CLevityCatch
-  "CSpec.Substitute"
+  "CSpec.Multikernel_C"
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/crefine/ARM/ADT_C.thy
+++ b/proof/crefine/ARM/ADT_C.thy
@@ -1552,7 +1552,7 @@ where
 
 end
 
-locale kernel_global = state_rel + kernel_all_global_addresses
+locale kernel_global = state_rel + kernel_all_multi
 (* note we're in the c-parser's locale now, not the substitute *)
 begin
 

--- a/proof/crefine/ARM/Ipc_C.thy
+++ b/proof/crefine/ARM/Ipc_C.thy
@@ -278,9 +278,9 @@ lemma ccap_relation_reply_helpers:
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
 (*FIXME: fupdate simplification issues for 2D arrays *)
 abbreviation "syscallMessageC \<equiv>  kernel_all_global_addresses.fault_messages.[unat MessageID_Syscall]"
-lemmas syscallMessageC_def = kernel_all_substitute.fault_messages_def
-abbreviation "exceptionMessageC \<equiv> kernel_all_substitute.fault_messages.[unat MessageID_Exception]"
-lemmas exceptionMessageC_def = kernel_all_substitute.fault_messages_def
+lemmas syscallMessageC_def = kernel_all_global_addresses.fault_messages_def
+abbreviation "exceptionMessageC \<equiv> kernel_all_global_addresses.fault_messages.[unat MessageID_Exception]"
+lemmas exceptionMessageC_def = kernel_all_global_addresses.fault_messages_def
 
 lemma syscallMessage_ccorres:
   "n < unat n_syscallMessage
@@ -5550,6 +5550,7 @@ lemma receiveIPC_ccorres [corres]:
       apply (wp gbn_wp' | simp add: guard_is_UNIV_def)+
   apply (auto simp:  isCap_simps valid_cap'_def)
   done
+
 
 lemma sendSignal_dequeue_ccorres_helper:
   "ccorres (\<lambda>rv rv'. rv' = tcb_ptr_to_ctcb_ptr dest) dest_'

--- a/proof/crefine/ARM/Machine_C.thy
+++ b/proof/crefine/ARM/Machine_C.thy
@@ -15,6 +15,11 @@ imports Ctac_lemmas_C
 begin
 
 locale kernel_m = kernel +
+
+(* The current verification is for unicore only *)
+assumes cpu_0:
+  "cpuNum = 0"
+
 assumes resetTimer_ccorres:
   "ccorres dc xfdc \<top> UNIV []
            (doMachineOp resetTimer)

--- a/proof/crefine/ARM/Refine_C.thy
+++ b/proof/crefine/ARM/Refine_C.thy
@@ -1079,8 +1079,8 @@ lemma ccorres_underlying_Fault:
 lemma monadic_rewrite_\<Gamma>:
   "monadic_rewrite True False \<top>
     (exec_C \<Gamma> c)
-    (exec_C (kernel_all_global_addresses.\<Gamma> symbol_table) c)"
-  using spec_refine [of symbol_table domain]
+    (exec_C (kernel_all_multi.\<Gamma> symbol_table cpuNum) c)"
+  using spec_refine [of symbol_table cpuNum domain]
   using spec_simulates_to_exec_simulates
   apply (clarsimp simp: spec_statefn_simulates_via_statefn
                         o_def map_option_case monadic_rewrite_def exec_C_def
@@ -1097,8 +1097,8 @@ lemma no_fail_getActiveIRQ_C:
   done
 
 lemma kernel_all_subset_kernel:
-  "global_automaton (kernel_global.check_active_irq_C symbol_table) (do_user_op_C uop)
-       (kernel_global.kernel_call_C symbol_table fp)
+  "global_automaton (kernel_global.check_active_irq_C symbol_table cpuNum) (do_user_op_C uop)
+       (kernel_global.kernel_call_C symbol_table cpuNum fp)
        \<subseteq> global_automaton check_active_irq_C (do_user_op_C uop) (kernel_call_C fp)"
   apply (clarsimp simp: fw_sim_def rel_semi_def global_automaton_def
                         relcomp_unfold in_lift_state_relation_eq)
@@ -1148,7 +1148,7 @@ lemma kernel_all_subset_kernel:
   done
 
 theorem true_refinement:
-  "kernel_global.ADT_C symbol_table armKSKernelVSpace_C uop
+  "kernel_global.ADT_C symbol_table armKSKernelVSpace_C cpuNum uop
    \<sqsubseteq> ADT_H uop"
   apply (rule refinement_trans[OF _ refinement2])
   apply (simp add: kernel_global.ADT_C_def ADT_C_def)
@@ -1160,7 +1160,7 @@ theorem true_refinement:
   done
 
 theorem true_fp_refinement:
-  "kernel_global.ADT_FP_C symbol_table armKSKernelVSpace_C uop
+  "kernel_global.ADT_FP_C symbol_table armKSKernelVSpace_C cpuNum uop
    \<sqsubseteq> ADT_H uop"
   apply (rule refinement_trans[OF _ fp_refinement])
   apply (simp add: kernel_global.ADT_FP_C_def ADT_FP_C_def)

--- a/proof/crefine/ARM/SR_lemmas_C.thy
+++ b/proof/crefine/ARM/SR_lemmas_C.thy
@@ -2201,9 +2201,9 @@ lemma msgRegisters_size_sanity:
 
 (* link up Kernel_Config loaded from the seL4 build system with physBase in C code *)
 lemma physBase_spec:
-  "\<forall>s. \<Gamma>\<turnstile> {s} Call physBase_'proc {t. ret__unsigned_long_' t = Kernel_Config.physBase }"
+  "\<forall>s. \<Gamma>\<turnstile> {s} Call physBase_'proc {t. cpuNum = 0 \<longrightarrow> ret__unsigned_long_' t = Kernel_Config.physBase }"
   apply (rule allI, rule conseqPre, vcg)
-  apply (simp add: Kernel_Config.physBase_def)
+  apply (simp add: Kernel_Config.physBase_def ph_base_def)
   done
 
 lemma rf_sr_obj_update_helper:

--- a/proof/crefine/ARM/SyscallArgs_C.thy
+++ b/proof/crefine/ARM/SyscallArgs_C.thy
@@ -14,8 +14,8 @@ begin
 
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
 context kernel_m begin
-abbreviation "msgRegistersC \<equiv> kernel_all_substitute.msgRegisters"
-lemmas msgRegistersC_def = kernel_all_substitute.msgRegisters_def
+abbreviation "msgRegistersC \<equiv> kernel_all_global_addresses.msgRegisters"
+lemmas msgRegistersC_def = kernel_all_global_addresses.msgRegisters_def
 end
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/crefine/ARM/Tcb_C.thy
+++ b/proof/crefine/ARM/Tcb_C.thy
@@ -1036,10 +1036,10 @@ lemma Arch_performTransfer_ccorres:
   done
 
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
-abbreviation "frameRegistersC \<equiv> kernel_all_substitute.frameRegisters"
-lemmas frameRegistersC_def = kernel_all_substitute.frameRegisters_def
-abbreviation "gpRegistersC \<equiv> kernel_all_substitute.gpRegisters"
-lemmas gpRegistersC_def = kernel_all_substitute.gpRegisters_def
+abbreviation "frameRegistersC \<equiv> kernel_all_global_addresses.frameRegisters"
+lemmas frameRegistersC_def = kernel_all_global_addresses.frameRegisters_def
+abbreviation "gpRegistersC \<equiv> kernel_all_global_addresses.gpRegisters"
+lemmas gpRegistersC_def = kernel_all_global_addresses.gpRegisters_def
 
 lemma frame_gp_registers_convs:
   "length ARM_H.frameRegisters = unat n_frameRegisters"

--- a/proof/crefine/ARM/VSpace_C.thy
+++ b/proof/crefine/ARM/VSpace_C.thy
@@ -710,7 +710,7 @@ lemma ptrFromPAddr_spec:
    Call ptrFromPAddr_'proc
    \<lbrace>\<acute>ret__ptr_to_void =  Ptr (ptrFromPAddr (paddr_' s))\<rbrace>"
   apply vcg
-  apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def)
+  apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def cpu_0)
   done
 
 lemma addrFromPPtr_spec:
@@ -718,7 +718,7 @@ lemma addrFromPPtr_spec:
    Call addrFromPPtr_'proc
    \<lbrace>\<acute>ret__unsigned_long = addrFromPPtr (ptr_val (pptr_' s))\<rbrace>"
   apply vcg
-  apply (simp add: addrFromPPtr_def pptrBaseOffset_def pptrBase_def)
+  apply (simp add: addrFromPPtr_def pptrBaseOffset_def pptrBase_def cpu_0)
   done
 
 lemma addrFromKPPtr_spec:
@@ -727,7 +727,7 @@ lemma addrFromKPPtr_spec:
    \<lbrace>\<acute>ret__unsigned_long = addrFromKPPtr (ptr_val (pptr_' s))\<rbrace>"
   apply vcg
   apply (simp add: addrFromKPPtr_def kernelELFBaseOffset_def kernelELFPAddrBase_def
-                   kernelELFBase_def pptrBase_def mask_def)
+                   kernelELFBase_def pptrBase_def mask_def cpu_0)
   done
 
 abbreviation
@@ -1715,8 +1715,8 @@ lemma setRegister_ccorres:
 
 lemma msgRegisters_ccorres:
   "n < unat n_msgRegisters \<Longrightarrow>
-  register_from_H (ARM_H.msgRegisters ! n) = (index kernel_all_substitute.msgRegisters n)"
-  apply (simp add: kernel_all_substitute.msgRegisters_def msgRegisters_unfold fupdate_def)
+  register_from_H (ARM_H.msgRegisters ! n) = (index kernel_all_global_addresses.msgRegisters n)"
+  apply (simp add: kernel_all_global_addresses.msgRegisters_def msgRegisters_unfold fupdate_def)
   apply (simp add: Arrays.update_def n_msgRegisters_def nth_Cons' split: if_split)
   done
 

--- a/proof/crefine/ARM/Wellformed_C.thy
+++ b/proof/crefine/ARM/Wellformed_C.thy
@@ -11,7 +11,7 @@ theory Wellformed_C
 imports
   "CLib.CTranslationNICTA"
   CLevityCatch
-  "CSpec.Substitute"
+  "CSpec.Multikernel_C"
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/crefine/ARM_HYP/ADT_C.thy
+++ b/proof/crefine/ARM_HYP/ADT_C.thy
@@ -1718,7 +1718,7 @@ where
 
 end
 
-locale kernel_global = state_rel + kernel_all_global_addresses
+locale kernel_global = state_rel + kernel_all_multi
 (* note we're in the c-parser's locale now, not the substitute *)
 begin
 

--- a/proof/crefine/ARM_HYP/Arch_C.thy
+++ b/proof/crefine/ARM_HYP/Arch_C.thy
@@ -2776,7 +2776,7 @@ lemma decodeARMFrameInvocation_ccorres:
                 apply (clarsimp dest!: ccap_relation_PageCap_generics)
                 apply (clarsimp simp: hd_drop_conv_nth hd_conv_nth)
                 (* sync up preprocessor-defined number sources coming from C *)
-                apply (clarsimp simp: fromPAddr_def paddrTop_def pptrBase_def pptrTop_def
+                apply (clarsimp simp: fromPAddr_def paddrTop_def pptrBase_def pptrTop_def cpu_0
                                       pptrBaseOffset_def add.commute from_bool_eq_if')
                apply ceqv
 

--- a/proof/crefine/ARM_HYP/Ipc_C.thy
+++ b/proof/crefine/ARM_HYP/Ipc_C.thy
@@ -349,9 +349,9 @@ lemma ccap_relation_reply_helpers:
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
 (*FIXME: fupdate simplification issues for 2D arrays *)
 abbreviation "syscallMessageC \<equiv>  kernel_all_global_addresses.fault_messages.[unat MessageID_Syscall]"
-lemmas syscallMessageC_def = kernel_all_substitute.fault_messages_def
-abbreviation "exceptionMessageC \<equiv> kernel_all_substitute.fault_messages.[unat MessageID_Exception]"
-lemmas exceptionMessageC_def = kernel_all_substitute.fault_messages_def
+lemmas syscallMessageC_def = kernel_all_global_addresses.fault_messages_def
+abbreviation "exceptionMessageC \<equiv> kernel_all_global_addresses.fault_messages.[unat MessageID_Exception]"
+lemmas exceptionMessageC_def = kernel_all_global_addresses.fault_messages_def
 
 lemma syscallMessage_ccorres:
   "n < unat n_syscallMessage
@@ -6075,6 +6075,7 @@ lemma receiveIPC_ccorres [corres]:
       apply (wp gbn_wp' | simp add: guard_is_UNIV_def)+
   apply (auto simp:  isCap_simps valid_cap'_def)
   done
+
 
 lemma sendSignal_dequeue_ccorres_helper:
   "ccorres (\<lambda>rv rv'. rv' = tcb_ptr_to_ctcb_ptr dest) dest_'

--- a/proof/crefine/ARM_HYP/Machine_C.thy
+++ b/proof/crefine/ARM_HYP/Machine_C.thy
@@ -25,6 +25,11 @@ where
   "setCurrentPDPL2 = undefined"
 
 locale kernel_m = kernel +
+
+(* The current verification is for unicore only *)
+assumes cpu_0:
+  "cpuNum = 0"
+
 assumes resetTimer_ccorres:
   "ccorres dc xfdc \<top> UNIV []
            (doMachineOp resetTimer)

--- a/proof/crefine/ARM_HYP/Refine_C.thy
+++ b/proof/crefine/ARM_HYP/Refine_C.thy
@@ -1105,8 +1105,8 @@ lemma ccorres_underlying_Fault:
 lemma monadic_rewrite_\<Gamma>:
   "monadic_rewrite True False \<top>
     (exec_C \<Gamma> c)
-    (exec_C (kernel_all_global_addresses.\<Gamma> symbol_table) c)"
-  using spec_refine [of symbol_table domain]
+    (exec_C (kernel_all_multi.\<Gamma> symbol_table cpuNum) c)"
+  using spec_refine [of symbol_table cpuNum domain]
   using spec_simulates_to_exec_simulates
   apply (clarsimp simp: spec_statefn_simulates_via_statefn
                         o_def map_option_case monadic_rewrite_def exec_C_def
@@ -1123,8 +1123,8 @@ lemma no_fail_getActiveIRQ_C:
   done
 
 lemma kernel_all_subset_kernel:
-  "global_automaton (kernel_global.check_active_irq_C symbol_table) (do_user_op_C uop)
-       (kernel_global.kernel_call_C symbol_table fp)
+  "global_automaton (kernel_global.check_active_irq_C symbol_table cpuNum) (do_user_op_C uop)
+       (kernel_global.kernel_call_C symbol_table cpuNum fp)
        \<subseteq> global_automaton check_active_irq_C (do_user_op_C uop) (kernel_call_C fp)"
   apply (clarsimp simp: fw_sim_def rel_semi_def global_automaton_def
                         relcomp_unfold in_lift_state_relation_eq)
@@ -1174,7 +1174,7 @@ lemma kernel_all_subset_kernel:
   done
 
 theorem true_refinement:
-  "kernel_global.ADT_C symbol_table armKSKernelVSpace_C uop
+  "kernel_global.ADT_C symbol_table armKSKernelVSpace_C cpuNum uop
    \<sqsubseteq> ADT_H uop"
   apply (rule refinement_trans[OF _ refinement2])
   apply (simp add: kernel_global.ADT_C_def ADT_C_def)
@@ -1186,7 +1186,7 @@ theorem true_refinement:
   done
 
 theorem true_fp_refinement:
-  "kernel_global.ADT_FP_C symbol_table armKSKernelVSpace_C uop
+  "kernel_global.ADT_FP_C symbol_table armKSKernelVSpace_C cpuNum uop
    \<sqsubseteq> ADT_H uop"
   apply (rule refinement_trans[OF _ fp_refinement])
   apply (simp add: kernel_global.ADT_FP_C_def ADT_FP_C_def)

--- a/proof/crefine/ARM_HYP/SR_lemmas_C.thy
+++ b/proof/crefine/ARM_HYP/SR_lemmas_C.thy
@@ -2532,9 +2532,9 @@ lemma unat_scast_numDomains:
 
 (* link up Kernel_Config loaded from the seL4 build system with physBase in C code *)
 lemma physBase_spec:
-  "\<forall>s. \<Gamma>\<turnstile> {s} Call physBase_'proc {t. ret__unsigned_long_' t = Kernel_Config.physBase }"
+  "\<forall>s. \<Gamma>\<turnstile> {s} Call physBase_'proc {t. cpuNum = 0 \<longrightarrow> ret__unsigned_long_' t = Kernel_Config.physBase }"
   apply (rule allI, rule conseqPre, vcg)
-  apply (simp add: Kernel_Config.physBase_def)
+  apply (simp add: Kernel_Config.physBase_def ph_base_def)
   done
 
 lemma rf_sr_obj_update_helper:

--- a/proof/crefine/ARM_HYP/SyscallArgs_C.thy
+++ b/proof/crefine/ARM_HYP/SyscallArgs_C.thy
@@ -14,8 +14,8 @@ begin
 
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
 context kernel_m begin
-abbreviation "msgRegistersC \<equiv> kernel_all_substitute.msgRegisters"
-lemmas msgRegistersC_def = kernel_all_substitute.msgRegisters_def
+abbreviation "msgRegistersC \<equiv> kernel_all_global_addresses.msgRegisters"
+lemmas msgRegistersC_def = kernel_all_global_addresses.msgRegisters_def
 end
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/crefine/ARM_HYP/Tcb_C.thy
+++ b/proof/crefine/ARM_HYP/Tcb_C.thy
@@ -1097,10 +1097,10 @@ lemma Arch_performTransfer_ccorres:
   done
 
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
-abbreviation "frameRegistersC \<equiv> kernel_all_substitute.frameRegisters"
-lemmas frameRegistersC_def = kernel_all_substitute.frameRegisters_def
-abbreviation "gpRegistersC \<equiv> kernel_all_substitute.gpRegisters"
-lemmas gpRegistersC_def = kernel_all_substitute.gpRegisters_def
+abbreviation "frameRegistersC \<equiv> kernel_all_global_addresses.frameRegisters"
+lemmas frameRegistersC_def = kernel_all_global_addresses.frameRegisters_def
+abbreviation "gpRegistersC \<equiv> kernel_all_global_addresses.gpRegisters"
+lemmas gpRegistersC_def = kernel_all_global_addresses.gpRegisters_def
 
 lemma frame_gp_registers_convs:
   "length ARM_HYP_H.frameRegisters = unat n_frameRegisters"

--- a/proof/crefine/ARM_HYP/VSpace_C.thy
+++ b/proof/crefine/ARM_HYP/VSpace_C.thy
@@ -782,7 +782,7 @@ lemma ptrFromPAddr_spec:
    Call ptrFromPAddr_'proc
    \<lbrace>\<acute>ret__ptr_to_void = Ptr (ptrFromPAddr (paddr_' s))\<rbrace>"
   apply vcg
-  apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def)
+  apply (simp add: ptrFromPAddr_def pptrBaseOffset_def pptrBase_def cpu_0)
   done
 
 lemma addrFromPPtr_spec:
@@ -790,7 +790,7 @@ lemma addrFromPPtr_spec:
    Call addrFromPPtr_'proc
    \<lbrace>\<acute>ret__unsigned_long = addrFromPPtr (ptr_val (pptr_' s))\<rbrace>"
   apply vcg
-  apply (simp add: addrFromPPtr_def pptrBaseOffset_def pptrBase_def)
+  apply (simp add: addrFromPPtr_def pptrBaseOffset_def pptrBase_def cpu_0)
   done
 
 lemma addrFromKPPtr_spec:
@@ -799,7 +799,7 @@ lemma addrFromKPPtr_spec:
    \<lbrace>\<acute>ret__unsigned_long = addrFromKPPtr (ptr_val (pptr_' s))\<rbrace>"
   apply vcg
   apply (simp add: addrFromKPPtr_def kernelELFBaseOffset_def kernelELFPAddrBase_def
-                   kernelELFBase_def pptrBase_def mask_def)
+                   kernelELFBase_def pptrBase_def mask_def cpu_0)
   done
 
 abbreviation
@@ -2833,8 +2833,8 @@ lemma setRegister_ccorres:
 
 lemma msgRegisters_ccorres:
   "n < unat n_msgRegisters \<Longrightarrow>
-  register_from_H (ARM_HYP_H.msgRegisters ! n) = (index kernel_all_substitute.msgRegisters n)"
-  apply (simp add: kernel_all_substitute.msgRegisters_def msgRegisters_unfold fupdate_def)
+  register_from_H (ARM_HYP_H.msgRegisters ! n) = (index kernel_all_global_addresses.msgRegisters n)"
+  apply (simp add: kernel_all_global_addresses.msgRegisters_def msgRegisters_unfold fupdate_def)
   apply (simp add: Arrays.update_def n_msgRegisters_def fcp_beta nth_Cons' split: if_split)
   done
 

--- a/proof/crefine/ARM_HYP/Wellformed_C.thy
+++ b/proof/crefine/ARM_HYP/Wellformed_C.thy
@@ -11,7 +11,7 @@ theory Wellformed_C
 imports
   "CLib.CTranslationNICTA"
   CLevityCatch
-  "CSpec.Substitute"
+  "CSpec.Multikernel_C"
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/crefine/RISCV64/ADT_C.thy
+++ b/proof/crefine/RISCV64/ADT_C.thy
@@ -1532,8 +1532,8 @@ where
 
 end
 
-locale kernel_global = state_rel + kernel_all_global_addresses
-(* repeating ADT definitions in the c-parser's locale now (not the substitute) *)
+locale kernel_global = state_rel + kernel_all_multi
+(* repeating ADT definitions in the (multikernel-adjusted) C parser's locale now, not the substitute *)
 begin
 
 definition

--- a/proof/crefine/RISCV64/Ipc_C.thy
+++ b/proof/crefine/RISCV64/Ipc_C.thy
@@ -297,9 +297,9 @@ lemma ccap_relation_reply_helpers:
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
 (*FIXME: fupdate simplification issues for 2D arrays *)
 abbreviation "syscallMessageC \<equiv>  kernel_all_global_addresses.fault_messages.[unat MessageID_Syscall]"
-lemmas syscallMessageC_def = kernel_all_substitute.fault_messages_def
-abbreviation "exceptionMessageC \<equiv> kernel_all_substitute.fault_messages.[unat MessageID_Exception]"
-lemmas exceptionMessageC_def = kernel_all_substitute.fault_messages_def
+lemmas syscallMessageC_def = kernel_all_global_addresses.fault_messages_def
+abbreviation "exceptionMessageC \<equiv> kernel_all_global_addresses.fault_messages.[unat MessageID_Exception]"
+lemmas exceptionMessageC_def = kernel_all_global_addresses.fault_messages_def
 
 lemma syscallMessage_ccorres:
   "n < unat n_syscallMessage

--- a/proof/crefine/RISCV64/Machine_C.thy
+++ b/proof/crefine/RISCV64/Machine_C.thy
@@ -17,6 +17,10 @@ begin
 
 locale kernel_m = kernel +
 
+(* The current verification is for unicore only *)
+assumes cpu_0:
+  "cpuNum = 0"
+
 assumes setVSpaceRoot_ccorres:
   "ccorres dc xfdc \<top> (\<lbrace>\<acute>addr___unsigned_long = pt\<rbrace> \<inter> \<lbrace>\<acute>asid___unsigned_long = asid\<rbrace>) []
            (doMachineOp (RISCV64.setVSpaceRoot pt asid))

--- a/proof/crefine/RISCV64/Refine_C.thy
+++ b/proof/crefine/RISCV64/Refine_C.thy
@@ -1090,8 +1090,8 @@ lemma ccorres_underlying_Fault:
 lemma monadic_rewrite_\<Gamma>:
   "monadic_rewrite True False \<top>
     (exec_C \<Gamma> c)
-    (exec_C (kernel_all_global_addresses.\<Gamma> symbol_table) c)"
-  using spec_refine [of symbol_table domain]
+    (exec_C (kernel_all_multi.\<Gamma> symbol_table cpuNum) c)"
+  using spec_refine [of symbol_table cpuNum domain]
   using spec_simulates_to_exec_simulates
   apply (clarsimp simp: spec_statefn_simulates_via_statefn
                         o_def map_option_case monadic_rewrite_def exec_C_def
@@ -1108,8 +1108,8 @@ lemma no_fail_getActiveIRQ_C:
   done
 
 lemma kernel_all_subset_kernel:
-  "global_automaton (kernel_global.check_active_irq_C symbol_table) (do_user_op_C uop)
-       (kernel_global.kernel_call_C symbol_table fp)
+  "global_automaton (kernel_global.check_active_irq_C symbol_table cpuNum) (do_user_op_C uop)
+       (kernel_global.kernel_call_C symbol_table cpuNum fp)
        \<subseteq> global_automaton check_active_irq_C (do_user_op_C uop) (kernel_call_C fp)"
   apply (clarsimp simp: fw_sim_def rel_semi_def global_automaton_def
                         relcomp_unfold in_lift_state_relation_eq)
@@ -1159,7 +1159,7 @@ lemma kernel_all_subset_kernel:
   done
 
 theorem true_refinement:
-  "kernel_global.ADT_C symbol_table riscvKSKernelVSpace_C uop
+  "kernel_global.ADT_C symbol_table riscvKSKernelVSpace_C cpuNum uop
    \<sqsubseteq> ADT_H uop"
   apply (rule refinement_trans[OF _ refinement2])
   apply (simp add: kernel_global.ADT_C_def ADT_C_def)
@@ -1172,7 +1172,7 @@ theorem true_refinement:
 
 (* FIXME: fastpath
 theorem true_fp_refinement:
-  "kernel_global.ADT_FP_C symbol_table armKSKernelVSpace_C uop
+  "kernel_global.ADT_FP_C symbol_table armKSKernelVSpace_C cpuNum uop
    \<sqsubseteq> ADT_H uop"
   apply (rule refinement_trans[OF _ fp_refinement])
   apply (simp add: kernel_global.ADT_FP_C_def ADT_FP_C_def)

--- a/proof/crefine/RISCV64/SR_lemmas_C.thy
+++ b/proof/crefine/RISCV64/SR_lemmas_C.thy
@@ -2141,9 +2141,9 @@ lemma unat_scast_numDomains:
 
 (* link up Kernel_Config loaded from the seL4 build system with physBase in C code *)
 lemma physBase_spec:
-  "\<forall>s. \<Gamma>\<turnstile> {s} Call physBase_'proc {t. ret__unsigned_long_' t = Kernel_Config.physBase }"
+  "\<forall>s. \<Gamma>\<turnstile> {s} Call physBase_'proc {t. cpuNum = 0 \<longrightarrow> ret__unsigned_long_' t = Kernel_Config.physBase }"
   apply (rule allI, rule conseqPre, vcg)
-  apply (simp add: Kernel_Config.physBase_def)
+  apply (simp add: Kernel_Config.physBase_def ph_base_def)
   done
 
 lemma rf_sr_obj_update_helper:

--- a/proof/crefine/RISCV64/SyscallArgs_C.thy
+++ b/proof/crefine/RISCV64/SyscallArgs_C.thy
@@ -15,8 +15,8 @@ begin
 
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
 context kernel_m begin
-abbreviation "msgRegistersC \<equiv> kernel_all_substitute.msgRegisters"
-lemmas msgRegistersC_def = kernel_all_substitute.msgRegisters_def
+abbreviation "msgRegistersC \<equiv> kernel_all_global_addresses.msgRegisters"
+lemmas msgRegistersC_def = kernel_all_global_addresses.msgRegisters_def
 end
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/crefine/RISCV64/Tcb_C.thy
+++ b/proof/crefine/RISCV64/Tcb_C.thy
@@ -1114,10 +1114,10 @@ lemma Arch_performTransfer_ccorres:
   done
 
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
-abbreviation "frameRegistersC \<equiv> kernel_all_substitute.frameRegisters"
-lemmas frameRegistersC_def = kernel_all_substitute.frameRegisters_def
-abbreviation "gpRegistersC \<equiv> kernel_all_substitute.gpRegisters"
-lemmas gpRegistersC_def = kernel_all_substitute.gpRegisters_def
+abbreviation "frameRegistersC \<equiv> kernel_all_global_addresses.frameRegisters"
+lemmas frameRegistersC_def = kernel_all_global_addresses.frameRegisters_def
+abbreviation "gpRegistersC \<equiv> kernel_all_global_addresses.gpRegisters"
+lemmas gpRegistersC_def = kernel_all_global_addresses.gpRegisters_def
 
 lemma frame_gp_registers_convs:
   "length RISCV64_H.frameRegisters = unat n_frameRegisters"

--- a/proof/crefine/RISCV64/VSpace_C.thy
+++ b/proof/crefine/RISCV64/VSpace_C.thy
@@ -867,7 +867,7 @@ lemma addrFromKPPtr_spec:
    Call addrFromKPPtr_'proc
    \<lbrace>\<acute>ret__unsigned_long = addrFromKPPtr (ptr_val (pptr_' s))\<rbrace>"
   apply vcg
-  apply (simp add: addrFromKPPtr_def kernelELFBaseOffset_def
+  apply (simp add: addrFromKPPtr_def kernelELFBaseOffset_def cpu_0
                    kernelELFBase_def kernelELFPAddrBase_def mask_def pptrTop_def)
   done
 
@@ -1027,8 +1027,8 @@ lemma setRegister_ccorres:
 
 lemma msgRegisters_ccorres:
   "n < unat n_msgRegisters \<Longrightarrow>
-  register_from_H (RISCV64_H.msgRegisters ! n) = (index kernel_all_substitute.msgRegisters n)"
-  apply (simp add: kernel_all_substitute.msgRegisters_def msgRegisters_unfold fupdate_def)
+  register_from_H (RISCV64_H.msgRegisters ! n) = (index kernel_all_global_addresses.msgRegisters n)"
+  apply (simp add: kernel_all_global_addresses.msgRegisters_def msgRegisters_unfold fupdate_def)
   apply (simp add: Arrays.update_def n_msgRegisters_def nth_Cons' split: if_split)
   done
 

--- a/proof/crefine/RISCV64/Wellformed_C.thy
+++ b/proof/crefine/RISCV64/Wellformed_C.thy
@@ -12,7 +12,7 @@ theory Wellformed_C
 imports
   "CLib.CTranslationNICTA"
   CLevityCatch
-  "CSpec.Substitute"
+  "CSpec.Multikernel_C"
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/crefine/X64/ADT_C.thy
+++ b/proof/crefine/X64/ADT_C.thy
@@ -1697,8 +1697,8 @@ where
 
 end
 
-locale kernel_global = state_rel + kernel_all_global_addresses
-(* repeating ADT definitions in the c-parser's locale now (not the substitute) *)
+locale kernel_global = state_rel + kernel_all_multi
+(* repeating ADT definitions in the (multikernel-adjusted) C parser's locale now, not the substitute *)
 begin
 
 definition

--- a/proof/crefine/X64/Ipc_C.thy
+++ b/proof/crefine/X64/Ipc_C.thy
@@ -296,9 +296,9 @@ lemma ccap_relation_reply_helpers:
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
 (*FIXME: fupdate simplification issues for 2D arrays *)
 abbreviation "syscallMessageC \<equiv>  kernel_all_global_addresses.fault_messages.[unat MessageID_Syscall]"
-lemmas syscallMessageC_def = kernel_all_substitute.fault_messages_def
-abbreviation "exceptionMessageC \<equiv> kernel_all_substitute.fault_messages.[unat MessageID_Exception]"
-lemmas exceptionMessageC_def = kernel_all_substitute.fault_messages_def
+lemmas syscallMessageC_def = kernel_all_global_addresses.fault_messages_def
+abbreviation "exceptionMessageC \<equiv> kernel_all_global_addresses.fault_messages.[unat MessageID_Exception]"
+lemmas exceptionMessageC_def = kernel_all_global_addresses.fault_messages_def
 
 lemma syscallMessage_ccorres:
   "n < unat n_syscallMessage

--- a/proof/crefine/X64/Refine_C.thy
+++ b/proof/crefine/X64/Refine_C.thy
@@ -1083,8 +1083,8 @@ lemma ccorres_underlying_Fault:
 lemma monadic_rewrite_\<Gamma>:
   "monadic_rewrite True False \<top>
     (exec_C \<Gamma> c)
-    (exec_C (kernel_all_global_addresses.\<Gamma> symbol_table) c)"
-  using spec_refine [of symbol_table domain]
+    (exec_C (kernel_all_multi.\<Gamma> symbol_table cpuNum) c)"
+  using spec_refine [of symbol_table cpuNum domain]
   using spec_simulates_to_exec_simulates
   apply (clarsimp simp: spec_statefn_simulates_via_statefn
                         o_def map_option_case monadic_rewrite_def exec_C_def
@@ -1101,8 +1101,8 @@ lemma no_fail_getActiveIRQ_C:
   done
 
 lemma kernel_all_subset_kernel:
-  "global_automaton (kernel_global.check_active_irq_C symbol_table) (do_user_op_C uop)
-       (kernel_global.kernel_call_C symbol_table fp)
+  "global_automaton (kernel_global.check_active_irq_C symbol_table cpuNum) (do_user_op_C uop)
+       (kernel_global.kernel_call_C symbol_table cpuNum fp)
        \<subseteq> global_automaton check_active_irq_C (do_user_op_C uop) (kernel_call_C fp)"
   apply (clarsimp simp: fw_sim_def rel_semi_def global_automaton_def
                         relcomp_unfold in_lift_state_relation_eq)
@@ -1152,7 +1152,7 @@ lemma kernel_all_subset_kernel:
   done
 
 theorem true_refinement:
-  "kernel_global.ADT_C symbol_table x64KSKernelVSpace_C uop
+  "kernel_global.ADT_C symbol_table x64KSKernelVSpace_C cpuNum uop
    \<sqsubseteq> ADT_H uop"
   apply (rule refinement_trans[OF _ refinement2])
   apply (simp add: kernel_global.ADT_C_def ADT_C_def)
@@ -1165,7 +1165,7 @@ theorem true_refinement:
 
 (* FIXME: fastpath
 theorem true_fp_refinement:
-  "kernel_global.ADT_FP_C symbol_table armKSKernelVSpace_C uop
+  "kernel_global.ADT_FP_C symbol_table armKSKernelVSpace_C cpuNum uop
    \<sqsubseteq> ADT_H uop"
   apply (rule refinement_trans[OF _ fp_refinement])
   apply (simp add: kernel_global.ADT_FP_C_def ADT_FP_C_def)

--- a/proof/crefine/X64/SyscallArgs_C.thy
+++ b/proof/crefine/X64/SyscallArgs_C.thy
@@ -14,8 +14,8 @@ begin
 
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
 context kernel_m begin
-abbreviation "msgRegistersC \<equiv> kernel_all_substitute.msgRegisters"
-lemmas msgRegistersC_def = kernel_all_substitute.msgRegisters_def
+abbreviation "msgRegistersC \<equiv> kernel_all_global_addresses.msgRegisters"
+lemmas msgRegistersC_def = kernel_all_global_addresses.msgRegisters_def
 end
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/crefine/X64/Tcb_C.thy
+++ b/proof/crefine/X64/Tcb_C.thy
@@ -1105,10 +1105,10 @@ lemma Arch_performTransfer_ccorres:
   done
 
 (*FIXME: arch-split: C kernel names hidden by Haskell names *)
-abbreviation "frameRegistersC \<equiv> kernel_all_substitute.frameRegisters"
-lemmas frameRegistersC_def = kernel_all_substitute.frameRegisters_def
-abbreviation "gpRegistersC \<equiv> kernel_all_substitute.gpRegisters"
-lemmas gpRegistersC_def = kernel_all_substitute.gpRegisters_def
+abbreviation "frameRegistersC \<equiv> kernel_all_global_addresses.frameRegisters"
+lemmas frameRegistersC_def = kernel_all_global_addresses.frameRegisters_def
+abbreviation "gpRegistersC \<equiv> kernel_all_global_addresses.gpRegisters"
+lemmas gpRegistersC_def = kernel_all_global_addresses.gpRegisters_def
 
 lemma frame_gp_registers_convs:
   "length X64_H.frameRegisters = unat n_frameRegisters"

--- a/proof/crefine/X64/VSpace_C.thy
+++ b/proof/crefine/X64/VSpace_C.thy
@@ -1353,8 +1353,8 @@ lemma setRegister_ccorres:
 
 lemma msgRegisters_ccorres:
   "n < unat n_msgRegisters \<Longrightarrow>
-  register_from_H (X64_H.msgRegisters ! n) = (index kernel_all_substitute.msgRegisters n)"
-  apply (simp add: kernel_all_substitute.msgRegisters_def msgRegisters_unfold fupdate_def)
+  register_from_H (X64_H.msgRegisters ! n) = (index kernel_all_global_addresses.msgRegisters n)"
+  apply (simp add: kernel_all_global_addresses.msgRegisters_def msgRegisters_unfold fupdate_def)
   apply (simp add: Arrays.update_def n_msgRegisters_def fcp_beta nth_Cons' split: if_split)
   done
 

--- a/proof/crefine/X64/Wellformed_C.thy
+++ b/proof/crefine/X64/Wellformed_C.thy
@@ -11,7 +11,7 @@ theory Wellformed_C
 imports
   "CLib.CTranslationNICTA"
   CLevityCatch
-  "CSpec.Substitute"
+  "CSpec.Multikernel_C"
 begin
 
 context begin interpretation Arch . (*FIXME: arch-split*)

--- a/proof/crefine/lib/AutoCorresModifiesProofs.thy
+++ b/proof/crefine/lib/AutoCorresModifiesProofs.thy
@@ -642,7 +642,7 @@ fun define_modifies_group fn_info prog_info f_names (acc as (callee_modifies, re
 fun new_modifies_rules filename ctxt = let
     val all_fn_info = Symtab.lookup (AutoCorresFunctionInfo.get (Proof_Context.theory_of ctxt)) filename |> the;
     val ts_info = FunctionInfo.Phasetab.lookup all_fn_info FunctionInfo.TS |> the;
-    val prog_info = ProgramInfo.get_prog_info ctxt filename;
+    val prog_info = ProgramInfo.get_prog_info ctxt "\<Gamma>" filename;
     (* Assume that the user has already generated and named modifies rules
      * for previously-translated callees. *)
     val existing_modifies =

--- a/proof/crefine/lib/CToCRefine.thy
+++ b/proof/crefine/lib/CToCRefine.thy
@@ -7,11 +7,17 @@
 theory CToCRefine
 
 imports
-    "CSpec.Substitute"
+    "CSpec.Multikernel_C"
     "CLib.SimplRewrite"
     Lib.Lib
     "CParser.TypHeapLib"
 begin
+
+lemma spec_statefn_simulates_fun_upd:
+  "\<lbrakk> exec_statefn_simulates g UNIV UNIV v v';
+     spec_statefn_simulates g G G' \<rbrakk>
+    \<Longrightarrow> spec_statefn_simulates g (G(p := Some v)) (G'(p := Some v'))"
+  by (simp add: spec_statefn_simulates_def)
 
 lemma spec_statefn_simulates_lookup_tree_Node:
   "\<lbrakk> exec_statefn_simulates g UNIV UNIV v v';
@@ -44,28 +50,22 @@ val unfold_bodies = Simplifier.make_simproc @{context}
 theorem spec_refine:
   notes if_split[split del]
   shows
-  "spec_statefn_simulates id (kernel_all_global_addresses.\<Gamma> symbol_table)
-     (kernel_all_substitute.\<Gamma> symbol_table domain)"
-  apply (simp add: kernel_all_global_addresses.\<Gamma>_def kernel_all_substitute.\<Gamma>_def)
+  "spec_statefn_simulates id (kernel_all_multi.\<Gamma> symbol_table cpuNum)
+     (kernel_all_substitute.\<Gamma> symbol_table domain cpuNum)"
+  apply (simp add: kernel_all_multi.\<Gamma>_def kernel_all_substitute.\<Gamma>_def)
+  apply (rule spec_statefn_simulates_fun_upd, rule exec_statefn_simulates_comI)
+  apply (simp add: kernel_all_global_addresses.\<Gamma>0_def kernel_all_substitute0.\<Gamma>0_def)
   apply (intro spec_statefn_simulates_lookup_tree_Node spec_statefn_simulates_lookup_tree_Leaf)
   apply (tactic \<open>ALLGOALS (asm_simp_tac (put_simpset HOL_ss @{context} addsimps @{thms switch.simps fst_conv snd_conv}
                   addsimprocs [unfold_bodies] |> Splitter.del_split @{thm if_split}))
               THEN ALLGOALS (TRY o resolve_tac @{context} @{thms exec_statefn_simulates_refl})\<close>)
-
   apply (tactic \<open>ALLGOALS (REPEAT_ALL_NEW (resolve_tac @{context} @{thms exec_statefn_simulates_comI
                       exec_statefn_simulates_additionals}))\<close>)
   apply (unfold id_apply)
   apply (tactic \<open>ALLGOALS (TRY o resolve_tac @{context} @{thms refl bij_id})\<close>)
   apply (tactic \<open>ALLGOALS (TRY o (resolve_tac @{context} @{thms subsetI} THEN' resolve_tac @{context} @{thms CollectI}
            THEN' REPEAT_ALL_NEW (eresolve_tac @{context} @{thms IntE CollectE conjE exE h_t_valid_c_guard conjI} ORELSE' assume_tac @{context})))\<close>)
-  (*
-    apply (tactic {* ALLGOALS (TRY o ((REPEAT_ALL_NEW (rtac @{thm c_guard_field}) THEN' etac @{thm h_t_valid_c_guard})
-                          THEN_ALL_NEW simp_tac @{simpset}
-                          THEN_ALL_NEW simp_tac @{simpset}
-                          THEN_ALL_NEW K no_tac))  *})
-  *)
   apply (rule bij_id[simplified id_def])+
   done (* Woo! *)
 
 end
-

--- a/proof/infoflow/refine/ARM/ArchADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/ARM/ArchADT_IF_Refine_C.thy
@@ -319,7 +319,7 @@ lemma obs_cpspace_user_data_relation[ADT_IF_Refine_assms]:
 end
 
 
-sublocale kernel_m \<subseteq> ADT_IF_Refine_1?: ADT_IF_Refine_1 _ _ _ doUserOp_C_if
+sublocale kernel_m \<subseteq> ADT_IF_Refine_1?: ADT_IF_Refine_1 _ _ _ _ doUserOp_C_if
 proof goal_cases
   interpret Arch .
   case 1 show ?case

--- a/proof/infoflow/refine/RISCV64/ArchADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/RISCV64/ArchADT_IF_Refine_C.thy
@@ -241,7 +241,7 @@ lemma obs_cpspace_user_data_relation[ADT_IF_Refine_assms]:
 end
 
 
-sublocale kernel_m \<subseteq> ADT_IF_Refine_1?: ADT_IF_Refine_1 _ _ _ doUserOp_C_if
+sublocale kernel_m \<subseteq> ADT_IF_Refine_1?: ADT_IF_Refine_1 _ _ _ _ doUserOp_C_if
 proof goal_cases
   interpret Arch .
   case 1 show ?case

--- a/spec/ROOT
+++ b/spec/ROOT
@@ -81,6 +81,7 @@ session ExecSpec in "design" = Word_Lib +
 
 session CSpec in "cspec" = CKernel +
   directories
+    "multikernel/$L4V_ARCH"
     "c/build/$L4V_ARCH/generated/arch/object"
     "c/build/$L4V_ARCH/generated/sel4"
   theories [condition = "SORRY_MODIFIES_PROOFS", quick_and_dirty]

--- a/spec/cspec/AARCH64/Kernel_C.thy
+++ b/spec/cspec/AARCH64/Kernel_C.thy
@@ -109,7 +109,7 @@ lemmas ctcb_offset_defs = ctcb_offset_def ctcb_size_bits_def
 cond_sorry_modifies_proofs SORRY_MODIFIES_PROOFS
 
 install_C_file "../c/build/$L4V_ARCH/kernel_all.c_pp"
-  [machinety=machine_state, ghostty=cghost_state]
+  [machinety=machine_state, ghostty=cghost_state, gamma=\<Gamma>0]
 
 text \<open>Hide unqualified names conflicting with Kernel_Config names. Force use of Kernel_C prefix
   for these:\<close>

--- a/spec/cspec/ARM/Kernel_C.thy
+++ b/spec/cspec/ARM/Kernel_C.thy
@@ -91,7 +91,7 @@ lemmas ctcb_offset_defs = ctcb_offset_def ctcb_size_bits_def
 cond_sorry_modifies_proofs SORRY_MODIFIES_PROOFS
 
 install_C_file "../c/build/$L4V_ARCH/kernel_all.c_pp"
-  [machinety=machine_state, ghostty=cghost_state]
+  [machinety=machine_state, ghostty=cghost_state, gamma=\<Gamma>0]
 
 text \<open>Hide unqualified names conflicting with Kernel_Config names. Force use of Kernel_C prefix
   for these:\<close>

--- a/spec/cspec/ARM_HYP/Kernel_C.thy
+++ b/spec/cspec/ARM_HYP/Kernel_C.thy
@@ -91,7 +91,7 @@ lemmas ctcb_offset_defs = ctcb_offset_def ctcb_size_bits_def
 cond_sorry_modifies_proofs SORRY_MODIFIES_PROOFS
 
 install_C_file "../c/build/$L4V_ARCH/kernel_all.c_pp"
-  [machinety=machine_state, ghostty=cghost_state]
+  [machinety=machine_state, ghostty=cghost_state, gamma=\<Gamma>0]
 
 text \<open>Hide unqualified names conflicting with Kernel_Config names. Force use of Kernel_C prefix
   for these:\<close>

--- a/spec/cspec/KernelState_C.thy
+++ b/spec/cspec/KernelState_C.thy
@@ -10,7 +10,7 @@ theory KernelState_C
 imports
   "Word_Lib.WordSetup"
   "CLib.BitFieldProofsLib"
-  "Substitute"
+  "Multikernel_C"
 begin
 
 type_synonym c_ptr_name = int

--- a/spec/cspec/Multikernel_C.thy
+++ b/spec/cspec/Multikernel_C.thy
@@ -1,0 +1,81 @@
+(*
+ * Copyright 2025, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory Multikernel_C
+imports ArchMultikernel_C
+begin
+
+ML \<open>
+structure GammaLift = struct
+  (* Prove impl theorem for x_proc of the form "\<Gamma> x_'proc = x_body"
+     from existing x_impl on \<Gamma>0 and x_'proc \<noteq> special_'proc.
+     Return (thm name, thm). *)
+  fun prove_impl ctxt special_proc_def gamma_def gamma proc =
+  let
+    val _ = tracing ("Proving impl theorem for " ^ proc)
+    val body_name = unsuffix Hoare.proc_deco proc |> suffix "_body"
+    val impl_name = unsuffix Hoare.proc_deco proc |> suffix HoarePackage.implementationN
+    val impl_goal =
+      Syntax.read_term ctxt (gamma ^ " " ^ proc ^ " = Some " ^ body_name)
+      |> HOLogic.mk_Trueprop
+    val proc_def = Proof_Context.get_thm ctxt (proc ^ "_def")
+    val impl_thm = Proof_Context.get_thm ctxt impl_name
+    fun impl_tac _ = EVERY [
+      simp_tac (ctxt addsimps [gamma_def]) 1,
+      resolve_tac ctxt @{thms conjI} 1,
+      simp_tac (ctxt addsimps [special_proc_def, proc_def]) 1,
+      resolve_tac ctxt @{thms impI} 1,
+      resolve_tac ctxt [impl_thm] 1]
+  in
+    (impl_name, Goal.prove_future ctxt [] [] impl_goal impl_tac)
+  end
+
+  (* Prove all *_impl theorems, except for the procedure "special",
+     which we assume has been overridden. *)
+  fun prove_impls special gamma0 gamma ctxt =
+  let
+    val special_proc = suffix Hoare.proc_deco special
+    val special_proc_def = Proof_Context.get_thm ctxt (special_proc ^ "_def")
+
+    val gamma0_def = Proof_Context.get_thm ctxt (gamma0 ^ "_def")
+    val gamma_def = Proof_Context.get_thm ctxt (gamma ^ "_def")
+
+    (* \<Gamma>0 is a tree definition that mentions all *_proc constants.
+       Start with all constants in \<Gamma>0_def and filter out the one we want *)
+    val proc_names =
+      Term.add_const_names (Thm.concl_of gamma0_def) []
+      |> filter (String.isSuffix Hoare.proc_deco)
+      |> filter (fn name => Long_Name.base_name name <> special_proc)
+      |> map Long_Name.base_name
+
+    val impls = map (prove_impl ctxt special_proc_def gamma_def gamma) proc_names
+  in
+    Local_Theory.notes (map (fn (n, thm) => ((Binding.name n, []), [([thm], [])])) impls) ctxt |> snd
+  end
+end
+\<close>
+
+context kernel_all_substitute
+begin
+
+(* prove *_impl theorems *)
+local_setup \<open>GammaLift.prove_impls special_proc_name "\<Gamma>0" "\<Gamma>"\<close>
+
+(* prove *_modifies theorems in \<Gamma> *)
+local_setup \<open>
+  (fn lthy =>
+      Context_Position.set_visible false lthy |>
+      Modifies_Proofs.prove_all_modifies_goals_local
+        (CalculateState.get_csenv @{theory} "../c/build/$L4V_ARCH/kernel_all.c_pp" |> the)
+        "\<Gamma>"
+        (fn _ => true)
+        [@{typ "globals myvars"}, @{typ int}, @{typ strictc_errortype}] |>
+      Context_Position.restore_visible lthy)
+\<close>
+
+end
+
+end

--- a/spec/cspec/RISCV64/Kernel_C.thy
+++ b/spec/cspec/RISCV64/Kernel_C.thy
@@ -88,7 +88,7 @@ lemmas ctcb_offset_defs = ctcb_offset_def ctcb_size_bits_def
 cond_sorry_modifies_proofs SORRY_MODIFIES_PROOFS
 
 install_C_file "../c/build/$L4V_ARCH/kernel_all.c_pp"
-  [machinety=machine_state, ghostty=cghost_state]
+  [machinety=machine_state, ghostty=cghost_state, gamma=\<Gamma>0]
 
 text \<open>Hide unqualified names conflicting with Kernel_Config names. Force use of Kernel_C prefix
   for these:\<close>

--- a/spec/cspec/Substitute.thy
+++ b/spec/cspec/Substitute.thy
@@ -92,9 +92,9 @@ fun prove_impl_tac ctxt ss =
       in simp_tac (put_simpset ss ctxt addsimps unfolds) n
       end);
 
-fun convert_impls ctxt = let
+fun convert_impls gamma ctxt = let
 
-    val thm = Proof_Context.get_thm ctxt "\<Gamma>_def"
+    val thm = Proof_Context.get_thm ctxt (gamma ^ "_def")
 
     val proc_defs = (Term.add_const_names (Thm.concl_of thm) [])
       |> filter (String.isSuffix Hoare.proc_deco)
@@ -114,12 +114,12 @@ fun convert_impls ctxt = let
   in Local_Theory.notes (map (fn (n, t) => ((Binding.name n, []), [([t], [])])) saves)
     ctxt |> snd end
 
-fun take_all_actions prefix src_ctxt proc tm csenv
+fun take_all_actions prefix src_ctxt proc tm csenv gamma
       styargs ctxt = let
     val (_, ctxt) = convert prefix src_ctxt proc tm (Termtab.empty, ctxt);
   in ctxt
-    |> convert_impls
-    |> Modifies_Proofs.prove_all_modifies_goals_local csenv (fn _ => true) styargs
+    |> convert_impls gamma
+    (* |> Modifies_Proofs.prove_all_modifies_goals_local csenv gamma (fn _ => true) styargs *)
   end
 
 end
@@ -190,7 +190,7 @@ abbreviation
 
 end
 
-locale kernel_all_substitute = substitute_pre
+locale kernel_all_substitute0 = substitute_pre
 begin
 
 ML \<open>
@@ -355,8 +355,9 @@ SubstituteSpecs.take_all_actions
     o guard_halt
     o guard_htd_updates_with_domain
     o guard_acc_ptr_adds)
-  @{term kernel_all_global_addresses.\<Gamma>}
+  @{term kernel_all_global_addresses.\<Gamma>0}
   (CalculateState.get_csenv @{theory} "../c/build/$L4V_ARCH/kernel_all.c_pp" |> the)
+  "\<Gamma>0"
   [@{typ "globals myvars"}, @{typ int}, @{typ strictc_errortype}]
 \<close>
 

--- a/spec/cspec/X64/Kernel_C.thy
+++ b/spec/cspec/X64/Kernel_C.thy
@@ -91,7 +91,7 @@ lemmas ctcb_offset_defs = ctcb_offset_def ctcb_size_bits_def
 cond_sorry_modifies_proofs SORRY_MODIFIES_PROOFS
 
 install_C_file "../c/build/$L4V_ARCH/kernel_all.c_pp"
-  [machinety=machine_state, ghostty=cghost_state]
+  [machinety=machine_state, ghostty=cghost_state, gamma=\<Gamma>0]
 
 text \<open>Hide unqualified names conflicting with Kernel_Config names. Force use of Kernel_C prefix
   for these:\<close>

--- a/spec/cspec/multikernel/AARCH64/ArchMultikernel_C.thy
+++ b/spec/cspec/multikernel/AARCH64/ArchMultikernel_C.thy
@@ -1,0 +1,64 @@
+(*
+ * Copyright 2025, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchMultikernel_C
+imports Substitute
+begin
+
+(* Example definition for how physBase could vary in a multikernel.
+   To be generated from config eventually *)
+definition ph_base :: "nat \<Rightarrow> 32 word" where
+  "ph_base n = 0x80000000 + 0x00010000 * of_nat n"
+
+(* Procedure body that depends on an additional logical parameter *)
+definition
+  "physBase_of_cpu n \<equiv> TRY
+    creturn global_exn_var_'_update ret__unsigned_long_'_update (\<lambda>s. UCAST(32 \<rightarrow> 64) (ph_base n));;
+    Guard DontReach {} SKIP
+  CATCH SKIP
+  END"
+
+locale kernel_all_substitute = kernel_all_substitute0 +
+  fixes cpuNum :: nat
+begin
+
+(* Override procedure environment from kernel source to get paramteric behaviour *)
+definition
+  "\<Gamma> \<equiv> \<Gamma>0 (physBase_'proc \<mapsto> physBase_of_cpu cpuNum)"
+
+(* Provide physBase implementation theorem expected by vcg. Other *_impl theorems will be
+   generated automatically in Multikernel_C.thy *)
+lemma physBase_impl:
+  "\<Gamma> physBase_'proc = Some (physBase_of_cpu cpuNum)"
+  by (simp add: \<Gamma>_def)
+
+(* vcg and similar tools expect physBase_body_def to unfold to a SIMPL command *)
+lemmas physBase_body_def = physBase_of_cpu_def
+
+end
+
+(* Do the same for kernel_all_global_addresses *)
+locale kernel_all_multi = kernel_all_global_addresses +
+  fixes cpuNum :: nat
+begin
+
+definition
+  "\<Gamma> \<equiv> \<Gamma>0 (physBase_'proc \<mapsto> physBase_of_cpu cpuNum)"
+
+lemma physBase_impl:
+  "\<Gamma> physBase_'proc = Some (physBase_of_cpu cpuNum)"
+  by (simp add: \<Gamma>_def)
+
+lemmas physBase_body_def = physBase_of_cpu_def
+
+end
+
+(* Interface to generic proof procedures in Multikernel_C.thy *)
+ML \<open>
+  val special_proc_name = "physBase"
+\<close>
+
+end

--- a/spec/cspec/multikernel/ARM/ArchMultikernel_C.thy
+++ b/spec/cspec/multikernel/ARM/ArchMultikernel_C.thy
@@ -1,0 +1,64 @@
+(*
+ * Copyright 2025, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchMultikernel_C
+imports Substitute
+begin
+
+(* Example definition for how physBase could vary in a multikernel.
+   To be generated from config eventually *)
+definition ph_base :: "nat \<Rightarrow> 32 signed word" where
+  "ph_base n = 0x10000000 + 0x00010000 * of_nat n"
+
+(* Procedure body that depends on an additional logical parameter *)
+definition
+  "physBase_of_cpu n \<equiv> TRY
+     creturn global_exn_var_'_update ret__unsigned_long_'_update (\<lambda>s. SCAST(32 signed \<rightarrow> 32) (ph_base n));;
+     Guard DontReach {} SKIP
+   CATCH SKIP
+   END"
+
+locale kernel_all_substitute = kernel_all_substitute0 +
+  fixes cpuNum :: nat
+begin
+
+(* Override procedure environment from kernel source to get paramteric behaviour *)
+definition
+  "\<Gamma> \<equiv> \<Gamma>0 (physBase_'proc \<mapsto> physBase_of_cpu cpuNum)"
+
+(* Provide physBase implementation theorem expected by vcg. Other *_impl theorems will be
+   generated automatically in Multikernel_C.thy *)
+lemma physBase_impl:
+  "\<Gamma> physBase_'proc = Some (physBase_of_cpu cpuNum)"
+  by (simp add: \<Gamma>_def)
+
+(* vcg and similar tools expect physBase_body_def to unfold to a SIMPL command *)
+lemmas physBase_body_def = physBase_of_cpu_def
+
+end
+
+(* Do the same for kernel_all_global_addresses *)
+locale kernel_all_multi = kernel_all_global_addresses +
+  fixes cpuNum :: nat
+begin
+
+definition
+  "\<Gamma> \<equiv> \<Gamma>0 (physBase_'proc \<mapsto> physBase_of_cpu cpuNum)"
+
+lemma physBase_impl:
+  "\<Gamma> physBase_'proc = Some (physBase_of_cpu cpuNum)"
+  by (simp add: \<Gamma>_def)
+
+lemmas physBase_body_def = physBase_of_cpu_def
+
+end
+
+(* Interface to generic proof procedures in Multikernel_C.thy *)
+ML \<open>
+  val special_proc_name = "physBase"
+\<close>
+
+end

--- a/spec/cspec/multikernel/ARM_HYP/ArchMultikernel_C.thy
+++ b/spec/cspec/multikernel/ARM_HYP/ArchMultikernel_C.thy
@@ -1,0 +1,64 @@
+(*
+ * Copyright 2025, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchMultikernel_C
+imports Substitute
+begin
+
+(* Example definition for how physBase could vary in a multikernel.
+   To be generated from config eventually *)
+definition ph_base :: "nat \<Rightarrow> machine_word" where
+  "ph_base n = physBase + 0x00010000 * of_nat n"
+
+(* Procedure body that depends on an additional logical parameter *)
+definition
+  "physBase_of_cpu n \<equiv> TRY
+     creturn global_exn_var_'_update ret__unsigned_long_'_update (\<lambda>s. ucast (ph_base n));;
+     Guard DontReach {} SKIP
+   CATCH SKIP
+   END"
+
+locale kernel_all_substitute = kernel_all_substitute0 +
+  fixes cpuNum :: nat
+begin
+
+(* Override procedure environment from kernel source to get paramteric behaviour *)
+definition
+  "\<Gamma> \<equiv> \<Gamma>0 (physBase_'proc \<mapsto> physBase_of_cpu cpuNum)"
+
+(* Provide physBase implementation theorem expected by vcg. Other *_impl theorems will be
+   generated automatically in Multikernel_C.thy *)
+lemma physBase_impl:
+  "\<Gamma> physBase_'proc = Some (physBase_of_cpu cpuNum)"
+  by (simp add: \<Gamma>_def)
+
+(* vcg and similar tools expect physBase_body_def to unfold to a SIMPL command *)
+lemmas physBase_body_def = physBase_of_cpu_def
+
+end
+
+(* Do the same for kernel_all_global_addresses *)
+locale kernel_all_multi = kernel_all_global_addresses +
+  fixes cpuNum :: nat
+begin
+
+definition
+  "\<Gamma> \<equiv> \<Gamma>0 (physBase_'proc \<mapsto> physBase_of_cpu cpuNum)"
+
+lemma physBase_impl:
+  "\<Gamma> physBase_'proc = Some (physBase_of_cpu cpuNum)"
+  by (simp add: \<Gamma>_def)
+
+lemmas physBase_body_def = physBase_of_cpu_def
+
+end
+
+(* Interface to generic proof procedures in Multikernel_C.thy *)
+ML \<open>
+  val special_proc_name = "physBase"
+\<close>
+
+end

--- a/spec/cspec/multikernel/RISCV64/ArchMultikernel_C.thy
+++ b/spec/cspec/multikernel/RISCV64/ArchMultikernel_C.thy
@@ -1,0 +1,65 @@
+(*
+ * Copyright 2025, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchMultikernel_C
+imports Substitute
+begin
+
+(* Example definition for how physBase could vary in a multikernel.
+   To be generated from config eventually *)
+definition ph_base :: "nat \<Rightarrow> machine_word" where
+  "ph_base n = physBase + 0x00010000 * of_nat n"
+
+(* Procedure body that depends on an additional logical parameter *)
+definition
+  "physBase_of_cpu n \<equiv> TRY
+     creturn global_exn_var_'_update ret__unsigned_long_'_update (\<lambda>s. ph_base n);;
+     Guard DontReach {} SKIP
+   CATCH SKIP
+   END"
+
+locale kernel_all_substitute = kernel_all_substitute0 +
+  fixes cpuNum :: nat
+begin
+
+(* Override procedure environment from kernel source to get paramteric behaviour *)
+definition
+  "\<Gamma> \<equiv> \<Gamma>0 (physBase_'proc \<mapsto> physBase_of_cpu cpuNum)"
+
+(* Provide physBase implementation theorem expected by vcg. Other *_impl theorems will be
+   generated automatically in Multikernel_C.thy *)
+lemma physBase_impl:
+  "\<Gamma> physBase_'proc = Some (physBase_of_cpu cpuNum)"
+  by (simp add: \<Gamma>_def)
+
+(* vcg and similar tools expect physBase_body_def to unfold to a SIMPL command *)
+lemmas physBase_body_def = physBase_of_cpu_def
+
+end
+
+(* Do the same for kernel_all_global_addresses *)
+locale kernel_all_multi = kernel_all_global_addresses +
+  fixes cpuNum :: nat
+begin
+
+definition
+  "\<Gamma> \<equiv> \<Gamma>0 (physBase_'proc \<mapsto> physBase_of_cpu cpuNum)"
+
+lemma physBase_impl:
+  "\<Gamma> physBase_'proc = Some (physBase_of_cpu cpuNum)"
+  by (simp add: \<Gamma>_def)
+
+lemmas physBase_body_def = physBase_of_cpu_def
+
+end
+
+
+(* Interface to generic proof procedures in Multikernel_C.thy *)
+ML \<open>
+  val special_proc_name = "physBase"
+\<close>
+
+end

--- a/spec/cspec/multikernel/X64/ArchMultikernel_C.thy
+++ b/spec/cspec/multikernel/X64/ArchMultikernel_C.thy
@@ -1,0 +1,54 @@
+(*
+ * Copyright 2025, Proofcraft Pty Ltd
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+theory ArchMultikernel_C
+imports Substitute
+begin
+
+(* There is no physBase on x64, but we still want the top-level of \<Gamma> to be a function update.
+   The function also must mention cpuNum, otherwise \<Gamma> will not depend on cpuNum outside the
+   locale, which means its type would not line up with \<Gamma> in other architectures and generic
+   proofs would fail. The following dummy definition is used below to achieve the
+   cpuNum-dependent function update. *)
+definition
+  "addrFromKPPtr_body' n \<equiv> kernel_all_global_addresses.addrFromKPPtr_body"
+
+
+locale kernel_all_substitute = kernel_all_substitute0 +
+  fixes cpuNum :: nat
+begin
+
+definition
+  "\<Gamma> \<equiv> \<Gamma>0 (addrFromKPPtr_'proc \<mapsto> addrFromKPPtr_body' cpuNum)"
+
+(* Provide implementation theorem expected by vcg. Other *_impl theorems will be
+   generated automatically in Multikernel_C.thy *)
+lemma addrFromKPPtr_impl:
+  "\<Gamma> addrFromKPPtr_'proc = Some addrFromKPPtr_body"
+  by (simp add: \<Gamma>_def addrFromKPPtr_body'_def)
+
+end
+
+(* Do the same for kernel_all_global_addresses *)
+locale kernel_all_multi = kernel_all_global_addresses +
+  fixes cpuNum :: nat
+begin
+
+definition
+  "\<Gamma> \<equiv> \<Gamma>0 (addrFromKPPtr_'proc \<mapsto> addrFromKPPtr_body' cpuNum)"
+
+lemma addrFromKPPtr_impl:
+  "\<Gamma> addrFromKPPtr_'proc = Some addrFromKPPtr_body"
+  by (simp add: \<Gamma>_def addrFromKPPtr_body'_def)
+
+end
+
+(* Interface to generic proof procedures in Multikernel_C.thy *)
+ML \<open>
+  val special_proc_name = "addrFromKPPtr"
+\<close>
+
+end

--- a/tools/asmrefine/GraphRefine.thy
+++ b/tools/asmrefine/GraphRefine.thy
@@ -1733,7 +1733,7 @@ fun inst_graph_tac ctxt = graph_gamma_tac ctxt THEN' inst_graph_node_tac ctxt
 fun mk_graph_refines (funs : ParseGraph.funs) ctxt s = let
     val proc = Syntax.read_term ctxt
         (Long_Name.base_name s ^ "_'proc")
-    val gamma = Syntax.read_term ctxt "\<Gamma>"
+    val gamma = Syntax.read_term ctxt "\<Gamma>0"
     val invs = Syntax.read_term ctxt "simpl_invariant"
     val _ = case head_of invs of Const _ => ()
       | _ => raise TERM ("mk_graph_refines: requires simpl_invariant constant", [])

--- a/tools/asmrefine/testfiles/global_array_swap.thy
+++ b/tools/asmrefine/testfiles/global_array_swap.thy
@@ -15,7 +15,7 @@ typedecl cghost_state
 
 external_file "global_array_swap.c"
 install_C_file "global_array_swap.c"
-  [machinety=machine_state, ghostty=cghost_state]
+  [machinety=machine_state, ghostty=cghost_state, gamma=\<Gamma>0]
 
 setup \<open>DefineGlobalsList.define_globals_list_i
   "global_array_swap.c" @{typ globals}\<close>

--- a/tools/asmrefine/testfiles/global_asm_stmt.thy
+++ b/tools/asmrefine/testfiles/global_asm_stmt.thy
@@ -15,7 +15,7 @@ typedecl cghost_state
 
 external_file "global_asm_stmt.c"
 install_C_file "global_asm_stmt.c"
-  [machinety=machine_state, ghostty=cghost_state]
+  [machinety=machine_state, ghostty=cghost_state, gamma=\<Gamma>0]
 
 setup \<open>DefineGlobalsList.define_globals_list_i
   "global_asm_stmt.c" @{typ globals}\<close>

--- a/tools/asmrefine/testfiles/inf_loop.thy
+++ b/tools/asmrefine/testfiles/inf_loop.thy
@@ -15,7 +15,7 @@ typedecl cghost_state
 
 external_file "inf_loop.c"
 install_C_file "inf_loop.c"
-  [machinety=machine_state, ghostty=cghost_state]
+  [machinety=machine_state, ghostty=cghost_state, gamma=\<Gamma>0]
 
 setup \<open>DefineGlobalsList.define_globals_list_i
   "inf_loop.c" @{typ globals}\<close>

--- a/tools/autocorres/README.md
+++ b/tools/autocorres/README.md
@@ -119,6 +119,10 @@ generated locale (named `file`).
 
 The options are:
 
+  * `gamma = CONSTANT_NAME`: use the given constant name as
+    the name of the procedure environment to expect from the
+    C parser. Default: `"\<Gamma>"`
+
   * `no_heap_abs = FUNC_NAMES`: Disable _heap abstraction_
     on the given list of functions.
 
@@ -203,6 +207,7 @@ An example of invoking AutoCorres with _all_ of the options
 is as follows:
 
     autocorres [
+        gamma = "\<Gamma>",
         no_heap_abs = a b,
         force_heap_abs = c d,
         gen_word_heaps,

--- a/tools/autocorres/autocorres.ML
+++ b/tools/autocorres/autocorres.ML
@@ -24,6 +24,9 @@ struct
  * work around this, but this is a light-weight solution.
  *)
 type autocorres_options = {
+  (* Name of the procedure environment. *)
+  gamma_name : string option ref,
+
   (* Do not lift heaps for these functions. *)
   no_heap_abs : string list option ref,
 
@@ -120,6 +123,10 @@ val named_opt = named_option (Scan.repeat Parse.embedded)
 val nat_opt = named_option Parse.nat
 
 (* Valid options. *)
+val gamma_name_parser =
+  named_option Parse.embedded "gamma" "procedure environment" >>
+  (fn gamma_name => none_to_some (#gamma_name) gamma_name "autocorres: gamma specified multiple times")
+
 val no_heap_abs_parser =
   named_opt "no_heap_abs" "function names" >>
   (fn funcs => none_to_some (#no_heap_abs) funcs "autocorres: no_heap_abs option specified multiple times")
@@ -239,6 +246,7 @@ val function_name_suffix_parser =
  * time; hence the dummy parameter.
  *)
 fun default_opts _ = {
+    gamma_name = ref NONE,
     no_heap_abs = ref NONE,
     force_heap_abs = ref NONE,
     skip_heap_abs = ref NONE,
@@ -268,7 +276,8 @@ fun default_opts _ = {
 val autocorres_parser : (autocorres_options * string) parser =
 let
   val option_parser =
-    (no_heap_abs_parser ||
+    (gamma_name_parser ||
+     no_heap_abs_parser ||
      force_heap_abs_parser ||
      skip_heap_abs_parser ||
      ts_rules_parser ||
@@ -323,8 +332,9 @@ let
                | NONE => error ("autocorres: no such locale: " ^ locale_name)
 
   (* Fetch program information from the C-parser output. *)
-  val prog_info = ProgramInfo.get_prog_info lthy filename
-  val all_simpl_info = FunctionInfo.init_function_info lthy filename
+  val gamma_name = case !(#gamma_name opt) of SOME g => g | NONE => "\<Gamma>"
+  val prog_info = ProgramInfo.get_prog_info lthy gamma_name filename
+  val all_simpl_info = FunctionInfo.init_function_info lthy gamma_name filename
   val all_simpl_functions = Symset.make (Symtab.keys all_simpl_info)
 
   (* Process autocorres options. *)

--- a/tools/autocorres/function_info.ML
+++ b/tools/autocorres/function_info.ML
@@ -92,7 +92,7 @@ sig
   val all_callees : function_info -> symset;
 
   (* Generate initial function_info from the C Parser's output. *)
-  val init_function_info : Proof.context -> string -> function_info Symtab.table;
+  val init_function_info : Proof.context -> string -> string -> function_info Symtab.table;
 
   type call_graph_info = {
       (* Topologically sorted function calls, in dependency order.
@@ -350,9 +350,9 @@ fun recalc_callees base_infos fn_infos = let
           |> Symtab.make)
   end;
 
-fun init_function_info ctxt filename = let
+fun init_function_info ctxt gamma_name filename = let
   val thy = Proof_Context.theory_of ctxt;
-  val prog_info = ProgramInfo.get_prog_info ctxt filename;
+  val prog_info = ProgramInfo.get_prog_info ctxt gamma_name filename;
   val csenv = #csenv prog_info;
 
   (* Get information about a single function. *)

--- a/tools/autocorres/program_info.ML
+++ b/tools/autocorres/program_info.ML
@@ -133,7 +133,7 @@ fun demangle_name (prog_info: prog_info) m =
 (*
  * Extract details from the c-parser about the given program.
  *)
-fun get_prog_info ctxt filename : prog_info =
+fun get_prog_info ctxt gamma_name filename : prog_info =
   let
     val thy = Proof_Context.theory_of ctxt
     val csenv = CalculateState.get_csenv thy filename |> the;
@@ -146,7 +146,7 @@ fun get_prog_info ctxt filename : prog_info =
     (* Get the gamma variable, mapping function numbers to function bodies in
      * SIMPL. *)
     val gamma =
-      (Const (Consts.intern (Proof_Context.consts_of ctxt) "\<Gamma>", dummyT)
+      (Const (Consts.intern (Proof_Context.consts_of ctxt) gamma_name, dummyT)
        |> Syntax.check_term ctxt)
       handle TERM _ => error "autocorres: could not find any functions -- \<Gamma> is not defined."
 

--- a/tools/autocorres/test-seL4/TestSEL4.thy
+++ b/tools/autocorres/test-seL4/TestSEL4.thy
@@ -13,6 +13,6 @@ begin
 (*
  * Test to see if we can parse all of seL4.
  *)
-autocorres [skip_heap_abs, ts_rules = nondet] "../c/build/$L4V_ARCH/kernel_all.c_pp"
+autocorres [skip_heap_abs, ts_rules = nondet, gamma = "\<Gamma>0"] "../c/build/$L4V_ARCH/kernel_all.c_pp"
 
 end

--- a/tools/c-parser/HPInter.ML
+++ b/tools/c-parser/HPInter.ML
@@ -25,10 +25,11 @@ sig
   type fninfo = HPfninfo.t
   val globalsN : string
   val asm_to_string : (term -> string) -> ('typ,term,'fact) Element.ctxt -> string
-  val mk_fninfo : theory -> csenv -> (string -> bool) ->
+  val mk_fninfo : theory -> csenv -> string -> (string -> bool) ->
                   Absyn.ext_decl list -> fninfo list
   val make_function_definitions :
       string ->                  (* name of locale where definitions will live *)
+      string ->                  (* name of procedure environment (\<Gamma>) *)
       csenv ->                   (* result of ProgramAnalysis over declarations *)
       typ list ->                (* type arguments to state type operator *)
       thm list ->                (* theorems defining names of functions *)
@@ -52,7 +53,7 @@ type csenv = ProgramAnalysis.csenv
 
 (* make function information - perform a preliminary analysis on the
    abstract syntax to extract function names, parameters and specifications *)
-fun mk_fninfo thy csenv includeP decllist : fninfo list = let
+fun mk_fninfo thy csenv gamma includeP decllist : fninfo list = let
   open Absyn NameGeneration
   (* don't fold top-level declarations into the table again: the program
      analysis that built the csenv in the first place will have already
@@ -84,7 +85,7 @@ fun mk_fninfo thy csenv includeP decllist : fninfo list = let
           [("", Element.Assumes (map nprop2Assume nameproplist))]
         end
       | fn_modifies slist => let
-          val mgoal = Modifies_Proofs.gen_modify_goalstring csenv fname slist
+          val mgoal = Modifies_Proofs.gen_modify_goalstring csenv gamma fname slist
         in
           [("", Element.Assumes [((Binding.name (fname ^ "_modifies"), []),
                                   [(mgoal, [])])])]
@@ -378,6 +379,7 @@ fun asm_to_string tmw e =
 (* The following is modelled on the code in HoarePackage.procedures_definition
 *)
 fun make_function_definitions localename
+                              gamma_name
                               (cse : ProgramAnalysis.csenv)
                               (styargs : typ list)
                               (nmdefs : thm list)
@@ -437,7 +439,7 @@ let
           end
           (* name for thm, (proc constant, body constant) *)
           val (_, lthy) = StaticFun.define_tree_and_thms_with_defs
-              @{binding \<Gamma>} (map (suffix HoarePackage.implementationN o #fname) fninfo)
+              (Binding.make (gamma_name, \<^here>)) (map (suffix HoarePackage.implementationN o #fname) fninfo)
               nmdefs (map get_body fninfo) @{term "id :: int => int"} lthy
         in
           Local_Theory.exit_global lthy

--- a/tools/c-parser/isar_install.ML
+++ b/tools/c-parser/isar_install.ML
@@ -69,7 +69,8 @@ structure C_Includes = Theory_Data
    val merge = Library.merge (op =)
 end);
 
-datatype additional_options = MachineState of string | GhostState of string | CRoots of string list
+datatype additional_options =
+  MachineState of string | GhostState of string | CRoots of string list | GammaName of string
 
 type install_data = {c_filename : string, locale_names : string list,
         options: (bool * bool * bool),
@@ -160,18 +161,18 @@ in
   ast0 |> SyntaxTransforms.remove_anonstructs |> SyntaxTransforms.remove_typedefs
 end
 
-fun define_naming_scheme [] _ = I
-  | define_naming_scheme fninfo nmdefs = let
+fun define_naming_scheme gamma [] _ = I
+  | define_naming_scheme gamma fninfo nmdefs = let
   fun name_term fni = SOME (HOLogic.mk_string (#fname fni))
   fun name_name fni = #fname fni ^ "_name"
 
   in StaticFun.define_tree_and_thms_with_defs
-      (Binding.name NameGeneration.naming_scheme_name)
+      (Binding.name (NameGeneration.naming_scheme_name gamma))
       (map name_name fninfo) nmdefs
       (map name_term fninfo) @{term "id :: int => int"}
   #> snd end
 
-fun define_function_names fninfo thy = let
+fun define_function_names gamma fninfo thy = let
   open Feedback
   fun decl1 (fni, (n, defs, lthy)) = let
     open TermsTypes
@@ -192,7 +193,7 @@ fun define_function_names fninfo thy = let
   end
   val (_, defs, lthy) =
       List.foldl decl1 (1, [], Named_Target.theory_init thy) fninfo
-  val lthy' = define_naming_scheme fninfo (List.rev defs) lthy
+  val lthy' = define_naming_scheme gamma fninfo (List.rev defs) lthy
 in
   (defs, Local_Theory.exit_global lthy')
 end
@@ -314,6 +315,10 @@ fun install_C_file0 (((((memsafe),ctyps),cdefs),s),statetylist_opt) thy = let
       case get_first (fn (GhostState s) => SOME s | _ => NONE) statetylist of
         NONE => TermsTypes.unit
       | SOME s => Syntax.read_typ_global thy s
+  val gamma =
+      case get_first (fn (GammaName s) => SOME s | _ => NONE) statetylist of
+        NONE => "\<Gamma>"
+      | SOME s => s
   val thy = Config.put_global CalculateState.current_C_filename s thy
   val thy = CalculateState.store_ghostty (s, gstate_ty) thy
   val anon_vars = Config.get_global thy use_anon_vars
@@ -427,17 +432,19 @@ in
           case toTranslate of
               NONE => (fn _ => true)
             | SOME set => (fn s => Binaryset.member(set,s))
-      val fninfo : HPInter.fninfo list = HPInter.mk_fninfo thy cse toTranslateP ast
-      val (nmdefs, thy) = define_function_names fninfo thy
+      val fninfo : HPInter.fninfo list = HPInter.mk_fninfo thy cse gamma toTranslateP ast
+      val (nmdefs, thy) = define_function_names gamma fninfo thy
       val compile_bodies =
           stmt_translation.define_functions (globty, styargs)
                                             mungedb
                                             cse
+                                            gamma
                                             fninfo
                                             rcdinfo
                                             ms
       val (loc2, thy) =
           HPInter.make_function_definitions localename
+                                            gamma
                                             cse
                                             styargs
                                             (List.rev nmdefs)
@@ -448,7 +455,7 @@ in
                                             thy
       val thy =
           if not (Symtab.is_empty (get_defined_functions cse)) then
-            Modifies_Proofs.prove_all_modifies_goals thy cse toTranslateP styargs loc2
+            Modifies_Proofs.prove_all_modifies_goals thy cse gamma toTranslateP styargs loc2
           else thy (* like this is ever going to happen *)
     in
       C_Installs.map (fn ss =>
@@ -527,6 +534,7 @@ val defsN = "c_defs"
 val mtypN = "machinety"
 val ghosttypN = "ghostty"
 val rootsN = "roots"
+val gammaN = "gamma"
 
 local
   structure P = Parse
@@ -542,7 +550,8 @@ val file_inclusion = let
   val typoptions =
       P.reserved mtypN |-- (P.$$$ "=" |-- P.embedded >> MachineState) ||
       P.reserved ghosttypN |-- (P.$$$ "=" |-- P.embedded >> GhostState) ||
-      P.reserved rootsN |-- (P.$$$ "=" |-- (P.$$$ "[" |-- P.enum1 "," P.embedded --| P.$$$ "]") >> CRoots)
+      P.reserved rootsN |-- (P.$$$ "=" |-- (P.$$$ "[" |-- P.enum1 "," P.embedded --| P.$$$ "]") >> CRoots) ||
+      P.reserved gammaN |-- (P.$$$ "=" |-- P.embedded >> GammaName)
 in
     ((Scan.option (P.$$$ memsafeN)) --
      (Scan.option (P.$$$ typesN)) --

--- a/tools/c-parser/modifies_proofs.ML
+++ b/tools/c-parser/modifies_proofs.ML
@@ -33,17 +33,18 @@ sig
      goal as something that can be modified.
   *)
 
-  val gen_modify_goalstring : csenv -> string -> string list -> string
+  val gen_modify_goalstring : csenv -> string -> string -> string list -> string
 
   val modifies_vcg_tactic : local_theory -> int -> tactic
   val modifies_tactic : thm -> local_theory -> tactic
 
-  val prove_all_modifies_goals_local : csenv -> (string -> bool) -> typ list ->
+  val prove_all_modifies_goals_local : csenv -> string -> (string -> bool) -> typ list ->
                                        local_theory -> local_theory
 
-  val prove_all_modifies_goals : theory -> csenv -> (string -> bool) ->
+  val prove_all_modifies_goals : theory -> csenv -> string -> (string -> bool) ->
                                  typ list -> string -> theory
-   (* string is the name of the locale where the theorems about Gamma live *)
+   (* first string is the name of the procedure environment Gamma *)
+   (* second string is the name of the locale where the theorems about Gamma live *)
 
   val sorry_modifies_proofs : bool Config.T
   val calculate_modifies_proofs : bool Config.T
@@ -82,14 +83,14 @@ fun cond_sorry_modifies_proofs VAR ctxt =
     ctxt'
   end
 
-fun gen_modify_goalstring csenv fname modstrings = let
+fun gen_modify_goalstring csenv gamma fname modstrings = let
   fun foldthis (vname, vset) =
       case MSymTab.lookup (ProgramAnalysis.get_addressed csenv) (MString.mk vname) of
         NONE => Binaryset.add(vset, vname)
       | SOME _ => Binaryset.add(vset, NameGeneration.global_heap)
   val vset = List.foldl foldthis (Binaryset.empty String.compare) modstrings
 in
-    "\<forall>\<sigma>. \<Gamma> \<turnstile>\<^bsub>/UNIV\<^esub> {\<sigma>} Call "^
+    "\<forall>\<sigma>. "^ gamma ^" \<turnstile>\<^bsub>/UNIV\<^esub> {\<sigma>} Call "^
     fname ^ "_'proc " ^
     "{t. t may_only_modify_globals \<sigma> in [" ^
     commas (Binaryset.listItems vset) ^ "]}"
@@ -292,7 +293,7 @@ in
     | NONE => prove_mod_inv_prop ()
 end
 
-fun prove_all_modifies_goals_local csenv includeP tyargs lthy = let
+fun prove_all_modifies_goals_local csenv gamma includeP tyargs lthy = let
   open ProgramAnalysis
   val _ = Feedback.informStr (0, "Proving automatically calculated modifies proofs")
   val globs_all_addressed = Config.get lthy CalculateState.globals_all_addressed
@@ -300,7 +301,7 @@ fun prove_all_modifies_goals_local csenv includeP tyargs lthy = let
   (* first enter the locale where \<Gamma> exists, and where all the
      mappings from function name to function body exist *)
   val lconsts = Proof_Context.consts_of lthy
-  val gamma_nm = Consts.intern lconsts "\<Gamma>"
+  val gamma_nm = Consts.intern lconsts gamma
   val gamma_t = Syntax.check_term lthy (Const(gamma_nm, dummyT))
   val {callgraph,callers} = compute_callgraphs csenv
 
@@ -426,14 +427,14 @@ in
   lthy
 end
 
-fun prove_all_modifies_goals thy csenv includeP tyargs globloc =
+fun prove_all_modifies_goals thy csenv gamma includeP tyargs globloc =
   if Config.get_global thy calculate_modifies_proofs then
     let
       val lthy = Named_Target.init [] globloc thy
     in
       lthy
         |> Local_Theory.begin_nested |> snd
-        |> prove_all_modifies_goals_local csenv includeP tyargs
+        |> prove_all_modifies_goals_local csenv gamma includeP tyargs
         |> Local_Theory.end_nested
         |> Local_Theory.exit_global
     end

--- a/tools/c-parser/name_generation.ML
+++ b/tools/c-parser/name_generation.ML
@@ -20,7 +20,7 @@ sig
   val adglob_rcd_tyname : string
   val adglob_struct_var : string
 
-  val naming_scheme_name : string
+  val naming_scheme_name : string -> string
 
   val enum_const_name : string -> string
   val enum_const_summary_lemma_sfx : string
@@ -234,7 +234,7 @@ val adglob_struct_var = "adglobs"
 val phantom_state_name = "phantom_machine_state"
 val ghost_state_name = "ghost'state"
 
-val naming_scheme_name = "\\" ^ "<Gamma>_naming"
+fun naming_scheme_name gamma = gamma ^ "_naming"
 val owned_by_fn_name = "owner'ship"
 
 val internalAnonStructPfx = "ISA_anon_struct|"

--- a/tools/c-parser/stmt_translation.ML
+++ b/tools/c-parser/stmt_translation.ML
@@ -171,6 +171,7 @@ end
 
 fun stmt_term (ctxt : Proof.context)
               (cse : ProgramAnalysis.csenv)
+              (gamma : string)
               (fname : string)
               (termbuilders : varinfo termbuilder)
               (varinfo : MString.t -> varinfo option)
@@ -181,7 +182,7 @@ fun stmt_term (ctxt : Proof.context)
               (ms : bool)
               (stmt : Absyn.statement) : stmt_result = let
   val stmt_term =
-      stmt_term ctxt cse fname termbuilders varinfo fninfo
+      stmt_term ctxt cse gamma fname termbuilders varinfo fninfo
                 statetype globty styargs ms
   val sg = Proof_Context.theory_of ctxt
   val progname = Config.get_global sg CalculateState.current_C_filename
@@ -460,7 +461,7 @@ in
           | (FnPtrCall(rty, _ (* argtys *)), _) => let
               val call_ei = expr_term call_e
               open NameGeneration
-              val naming = Const (Sign.intern_const sg naming_scheme_name,
+              val naming = Const (Sign.intern_const sg (naming_scheme_name gamma),
                     int --> mk_option_ty string_ty)
               val (pbody, pguard) = MemoryModelExtras.mk_lookup_proc_pair
                       symbol_table naming
@@ -771,7 +772,7 @@ in
   CNameTab.fold foldthis state Symtab.empty
 end
 
-fun fndefn_term (state : CalculateState.mungedb) cse fninfo rcdinfo ms globty styargs ctxt decl = let
+fun fndefn_term (state : CalculateState.mungedb) cse gamma fninfo rcdinfo ms globty styargs ctxt decl = let
   val thy = Proof_Context.theory_of ctxt
   open CalculateState
   val statetype = hd styargs
@@ -794,7 +795,7 @@ fun fndefn_term (state : CalculateState.mungedb) cse fninfo rcdinfo ms globty st
   in
     (cse2ecenv cse, get_senv cse)
   end
-  val stmt_trans = stmt_term ctxt cse fname termbuilders
+  val stmt_trans = stmt_term ctxt cse gamma fname termbuilders
                              varinfo fninfo
                              statetype globty styargs ms
   val (body_f, body_parses) = trans_list stmt_trans styargs body
@@ -859,6 +860,7 @@ end
 fun define_functions (globty, styargs)
                      (vdecls : CalculateState.mungedb)
                      cse
+                     gamma
                      fninfo
                      rcdinfo
                      ms
@@ -868,7 +870,7 @@ let
   open TermsTypes CalculateState
   val fns = extract_defined_functions ast
   val function_info =
-      map (fndefn_term vdecls cse fninfo rcdinfo ms globty styargs ctxt) fns
+      map (fndefn_term vdecls cse gamma fninfo rcdinfo ms globty styargs ctxt) fns
 in
   function_info
 end

--- a/tools/c-parser/testfiles/modifies_assumptions.thy
+++ b/tools/c-parser/testfiles/modifies_assumptions.thy
@@ -9,7 +9,7 @@ imports "CParser.CTranslation"
 begin
 
 external_file "modifies_assumptions.c"
-install_C_file "modifies_assumptions.c"
+install_C_file "modifies_assumptions.c" [gamma = \<Gamma>0]
 
 context modifies_assumptions
 begin
@@ -25,7 +25,7 @@ thm h_modifies
 thm j_modifies
 thm k_modifies
 
-lemma "\<Gamma> f_'proc = Some f_body"
+lemma "\<Gamma>0 f_'proc = Some f_body"
 apply (simp add: f_impl)
 done
 


### PR DESCRIPTION
Use the SIMPL procedure environment to make CKernel and CSpec parametric, adjusting the C proofs accordingly. The PR has an example of a parametric function `physBase_of_cpu`.

This is a milestone in the Dyvercon project for Cyberagentur. The current state is the version approved for public release. It will need to be rebased before it can be merged.

The current version manually takes the current value of `physBase` in C. Before the PR can be merged, we should add a proof check against the actual C version, which is still available visible in the original procedure context.

- [ ] rebase and resolve conflicts since then
- [ ] add proof check against C pyhsBase
