### PR TITLE
aarch64: remove plic_complete_claim

### DIFF
--- a/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
@@ -175,10 +175,6 @@ qed
 
 context Arch begin arch_global_naming
 
-lemma plic_complete_claim_empty_fail[wp, EmptyFail_AI_assms]:
-  "empty_fail (plic_complete_claim irq)"
-  by (clarsimp simp: plic_complete_claim_def)
-
 lemma vgic_maintenance_empty_fail[wp]: "empty_fail vgic_maintenance"
   by (wpsimp simp: get_gic_vcpu_ctrl_eisr0_def
                    get_gic_vcpu_ctrl_eisr1_def

--- a/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
@@ -81,15 +81,6 @@ lemma maskInterrupt_invs_ARCH[Interrupt_AI_assms]:
    \<lbrace>\<lambda>rv. invs\<rbrace>"
   by (rule maskInterrupt_invs)
 
-crunch plic_complete_claim (* FIXME AARCH64: remove plic_complete_claim *)
-  for device_state_inv[wp]: "\<lambda>ms. P (device_state ms)"
-
-lemma dmo_plic_complete_claim[wp]: (* FIXME AARCH64: remove plic_complete_claim *)
-  "do_machine_op (plic_complete_claim irq) \<lbrace>invs\<rbrace>"
-  apply (wp dmo_invs)
-  apply (auto simp: plic_complete_claim_def machine_op_lift_def machine_rest_lift_def in_monad select_f_def)
-  done
-
 lemma no_cap_to_obj_with_diff_IRQHandler_ARCH[Interrupt_AI_assms]:
   "no_cap_to_obj_with_diff_ref (IRQHandlerCap irq) S = \<top>"
   by (rule ext, simp add: no_cap_to_obj_with_diff_ref_def

--- a/proof/invariant-abstract/AARCH64/Machine_AI.thy
+++ b/proof/invariant-abstract/AARCH64/Machine_AI.thy
@@ -260,7 +260,6 @@ crunch_ignore (valid, empty_fail, no_fail)
     invalidateTranslationASID_impl
     invalidateTranslationSingle_impl
     isb_impl
-    plic_complete_claim_impl
     resetTimer_impl
     set_gic_vcpu_ctrl_apr_impl
     set_gic_vcpu_ctrl_hcr_impl
@@ -321,7 +320,6 @@ crunch
   invalidateTranslationASID,
   invalidateTranslationSingle,
   isb,
-  plic_complete_claim,
   resetTimer,
   set_gic_vcpu_ctrl_apr,
   set_gic_vcpu_ctrl_hcr,

--- a/proof/refine/AARCH64/Interrupt_R.thy
+++ b/proof/refine/AARCH64/Interrupt_R.thy
@@ -444,12 +444,6 @@ lemma isnt_irq_handler_strg:
   "(\<not> isIRQHandlerCap cap) \<longrightarrow> (\<forall>irq. cap = IRQHandlerCap irq \<longrightarrow> P irq)"
   by (clarsimp simp: isCap_simps)
 
-lemma dmo_plic_complete_claim_invs'[wp]:
-  "doMachineOp (AARCH64.plic_complete_claim irq) \<lbrace>invs'\<rbrace>"
-  apply (wp dmo_invs')
-  apply (clarsimp simp: in_monad AARCH64.plic_complete_claim_def machine_op_lift_def machine_rest_lift_def select_f_def)
-  done
-
 lemma doMachineOp_maskInterrupt_False[wp]:
   "\<lbrace> \<lambda>s. invs' s \<and> intStateIRQTable (ksInterruptState s) irq \<noteq> irqstate.IRQInactive \<rbrace>
    doMachineOp (maskInterrupt False irq)

--- a/spec/design/skel/AARCH64/ArchInterrupt_H.thy
+++ b/spec/design/skel/AARCH64/ArchInterrupt_H.thy
@@ -15,7 +15,7 @@ begin
 
 context Arch begin arch_global_naming (H)
 
-#INCLUDE_HASKELL SEL4/Object/Interrupt/AARCH64.hs CONTEXT AARCH64_H bodies_only ArchInv= Arch= NOT plic_complete_claim
+#INCLUDE_HASKELL SEL4/Object/Interrupt/AARCH64.hs CONTEXT AARCH64_H bodies_only ArchInv= Arch=
 
 end
 

--- a/spec/design/skel/AARCH64/Hardware_H.thy
+++ b/spec/design/skel/AARCH64/Hardware_H.thy
@@ -14,7 +14,7 @@ begin
 context Arch begin arch_global_naming (H)
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/AARCH64.hs Platform=Platform.AARCH64 CONTEXT AARCH64_H \
-  NOT PT_Type plic_complete_claim getMemoryRegions getDeviceRegions getKernelDevices \
+  NOT PT_Type getMemoryRegions getDeviceRegions getKernelDevices \
   loadWord storeWord storeWordVM getActiveIRQ ackInterrupt maskInterrupt deactivateInterrupt \
   configureTimer resetTimer debugPrint getRestartPC setNextPC clearMemory \
   clearMemoryVM initMemory freeMemory setHardwareASID wordFromPDE wordFromPTE \
@@ -50,7 +50,7 @@ arch_requalify_types (H)
 
 context Arch begin arch_global_naming (H)
 
-#INCLUDE_HASKELL SEL4/Machine/Hardware/AARCH64.hs CONTEXT AARCH64_H instanceproofs NOT plic_complete_claim HardwareASID VMFaultType VMPageSize VMPageEntry HypFaultType
+#INCLUDE_HASKELL SEL4/Machine/Hardware/AARCH64.hs CONTEXT AARCH64_H instanceproofs NOT HardwareASID VMFaultType VMPageSize VMPageEntry HypFaultType
 
 #INCLUDE_HASKELL SEL4/Machine/Hardware/AARCH64.hs CONTEXT AARCH64_H ONLY wordFromPTE
 

--- a/spec/machine/AARCH64/MachineOps.thy
+++ b/spec/machine/AARCH64/MachineOps.thy
@@ -104,10 +104,6 @@ consts' setIRQTrigger_impl :: "irq \<Rightarrow> bool \<Rightarrow> unit machine
 definition setIRQTrigger :: "irq \<Rightarrow> bool \<Rightarrow> unit machine_monad" where
   "setIRQTrigger irq trigger \<equiv> machine_op_lift (setIRQTrigger_impl irq trigger)"
 
-consts' plic_complete_claim_impl :: "irq \<Rightarrow> unit machine_rest_monad"
-definition plic_complete_claim :: "irq \<Rightarrow> unit machine_monad" where
-  "plic_complete_claim irq \<equiv> machine_op_lift (plic_complete_claim_impl irq)"
-
 text \<open>
   Interrupts that cannot occur while the kernel is running (e.g. at preemption points),
   but that can occur from user mode.\<close>


### PR DESCRIPTION
Remove remaining left-overs from the RISCV64 machine operation plic_complete_claim from the AARCH64 specs and proofs.

The operation was previous defined, and some properties proved about it, but was entirely unused, since it does not exist in reality on seL4/AArch64.