### PR TITLE
github: add AARCH64 to MCS test matrix

### DIFF
--- a/.github/workflows/rt-proof.yml
+++ b/.github/workflows/rt-proof.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ARM, RISCV64]
+        arch: [ARM, RISCV64, AARCH64]
     # test only most recent push to PR:
     concurrency:
       group: l4v-${{ github.workflow }}-${{ github.event.number }}-idx-${{ strategy.job-index }}


### PR DESCRIPTION
Needs to be done on `master` to take effect for PRs on `rt`.