### PR TITLE
aarch64 infoflow: fix ArchArch_IF.thy for Isabelle2025

### DIFF
--- a/proof/ROOT
+++ b/proof/ROOT
@@ -168,8 +168,7 @@ session InfoFlowC in "infoflow/refine" = InfoFlowCBase +
   directories
     "$L4V_ARCH"
   theories
-    "Noninterference_Refinement"
-    "Example_Valid_StateH"
+    "InfoFlowC_Image_Toplevel"
 
 (*
  * capDL

--- a/proof/infoflow/AARCH64/ArchADT_IF.thy
+++ b/proof/infoflow/AARCH64/ArchADT_IF.thy
@@ -19,6 +19,88 @@ context Arch begin global_naming AARCH64
 
 named_theorems ADT_IF_assms
 
+lemmas [ADT_IF_assms] =
+  thread_set_no_etcb_change_cur_fpu_in_cur_domain
+  thread_set_no_etcb_change_cur_vcpu_in_cur_domain
+  handle_event_valid_cur_vcpu
+  cur_vcpu_in_cur_domain_updates
+  cur_fpu_in_cur_domain_updates
+
+lemma dmo_getActiveIRQ_wp'[ADT_IF_assms]:
+  "\<lbrace>(\<lambda>s. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
+           (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>))
+    and domain_sep_inv False st and valid_irq_states\<rbrace>
+   do_machine_op (getActiveIRQ in_kernel)
+   \<lbrace>P\<rbrace>"
+  apply (simp add: do_machine_op_def getActiveIRQ_def non_kernel_IRQs_def)
+  apply (wp modify_wp | wpc)+
+  apply clarsimp
+  apply (erule use_valid)
+   apply (wp modify_wp)
+  apply (fastforce simp: domain_sep_inv_def non_kernel_IRQs_def
+                         valid_irq_states_def valid_irq_masks_def irq_at_def)
+  done
+
+lemma dmo_getActiveIRQ_wp[ADT_IF_assms]:
+  "\<lbrace>(\<lambda>s. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
+           (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>))\<rbrace>
+   do_machine_op (getActiveIRQ False)
+   \<lbrace>P\<rbrace>"
+  apply (simp add: do_machine_op_def getActiveIRQ_def non_kernel_IRQs_def)
+  apply (wp modify_wp | wpc)+
+  apply clarsimp
+  apply (erule use_valid)
+   apply (wp modify_wp)
+  apply (auto simp: Let_def non_kernel_IRQs_def irq_at_def split: if_splits)
+  done
+
+lemma thread_set_valid_cur_vcpu_unchanged_strong:
+  "\<lbrakk>\<And>tcb. tcb_vcpu (tcb_arch (f tcb)) = tcb_vcpu (tcb_arch tcb); \<And>tcb. tcb_domain (f tcb) = tcb_domain tcb\<rbrakk>
+   \<Longrightarrow> thread_set f tptr \<lbrace>valid_cur_vcpu\<rbrace>"
+  apply (rule valid_cur_vcpu_lift_weak; (solves wpsimp)?)
+   apply (clarsimp simp: thread_set_def)
+   apply (wpsimp wp: set_object_wp)
+   apply (fastforce simp: pred_tcb_at_def obj_at_def get_tcb_def)
+  apply (clarsimp simp: in_cur_domain_def)
+  apply (wp_pre, wps, wpsimp wp: thread_set_no_change_etcb_at, clarsimp)
+  done
+
+lemma thread_set_tcb_context_valid_cur_vcpu[wp]:
+  "thread_set (tcb_arch_update (arch_tcb_context_set tc)) tcb \<lbrace>valid_cur_vcpu\<rbrace>"
+  by (wpsimp wp: thread_set_valid_cur_vcpu_unchanged_strong simp: arch_tcb_context_set_def)
+
+crunch do_user_op_if
+  for cur_vcpu_in_cur_domain[wp]: "cur_vcpu_in_cur_domain"
+  and cur_fpu_in_cur_domain[wp]: "cur_fpu_in_cur_domain"
+  and valid_cur_vcpu[wp]: "valid_cur_vcpu"
+  (simp: do_user_op_if_def)
+
+lemma deleted_irq_handler_valid_irq_states[wp]:
+  "deleted_irq_handler irq \<lbrace>valid_irq_states\<rbrace>"
+  unfolding deleted_irq_handler_def set_irq_state_def valid_irq_states_def valid_irq_masks_def maskInterrupt_def
+  by (wpsimp wp: dmo_wp)
+
+lemma dmo_getActiveIRQ_valid_irq_states[wp]:
+  "do_machine_op (getActiveIRQ in_kernel) \<lbrace>valid_irq_states\<rbrace>"
+  unfolding getActiveIRQ_def by wpsimp
+
+crunch prepare_thread_delete, arch_finalise_cap, arch_post_cap_deletion
+  for valid_irq_states[wp]: "\<lambda>s :: det_state. valid_irq_states s"
+  (wp: crunch_wps mapM_x_wp hoare_drop_imps simp: crunch_simps)
+
+end
+
+
+global_interpretation ADT_IF_1?: ADT_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (unfold valid_cur_hyp_def cur_hyp_in_cur_domain_def)?; (fact ADT_IF_assms | wp)?)
+qed
+
+
+context Arch begin global_naming AARCH64
+
 (* FIXME: clagged from AInvs.do_user_op_invs *)
 lemma do_user_op_if_invs[ADT_IF_assms]:
   "\<lbrace>invs and ct_running\<rbrace>
@@ -79,13 +161,7 @@ lemma do_use_op_guarded_pas_domain[ADT_IF_assms, wp]:
 
 lemma tcb_arch_ref_tcb_context_set[ADT_IF_assms, simp]:
   "tcb_arch_ref (tcb_arch_update (arch_tcb_context_set tc) tcb) = tcb_arch_ref tcb"
-  by (simp add: tcb_arch_ref_def)
-
-crunch arch_switch_to_idle_thread, arch_switch_to_thread
-  for pspace_aligned[ADT_IF_assms, wp]: "\<lambda>s :: det_state. pspace_aligned s"
-  and valid_vspace_objs[ADT_IF_assms, wp]: "\<lambda>s :: det_state. valid_vspace_objs s"
-  and valid_arch_state[ADT_IF_assms, wp]: "\<lambda>s :: det_state. valid_arch_state s"
-  (wp: crunch_wps simp: crunch_simps)
+  by (simp add: tcb_arch_ref_def arch_tcb_context_set_def)
 
 crunch arch_activate_idle_thread, arch_switch_to_thread
   for cur_thread[ADT_IF_assms, wp]: "\<lambda>s. P (cur_thread s)"
@@ -106,14 +182,14 @@ lemma arch_invoke_irq_control_noErr[ADT_IF_assms, wp]:
   by (cases a; wpsimp)
 
 lemma getActiveIRQ_None[ADT_IF_assms]:
-  "(None,s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) s)  \<Longrightarrow>
+  "(None,s') \<in> fst (do_machine_op (getActiveIRQ False) s)  \<Longrightarrow>
    irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = None"
   apply (erule use_valid)
    apply (wp dmo_getActiveIRQ_wp)
   by simp
 
 lemma getActiveIRQ_Some[ADT_IF_assms]:
-  "(Some i, s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) s)
+  "(Some i, s') \<in> fst (do_machine_op (getActiveIRQ False) s)
    \<Longrightarrow> irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = Some i"
   apply (erule use_valid)
    apply (wp dmo_getActiveIRQ_wp)
@@ -165,12 +241,14 @@ lemma idle_globals_lift_scheduler:
 
 lemma invs_pt_not_idle_thread[intro]:
   "invs s \<Longrightarrow> arm_us_global_vspace (arch_state s) \<noteq> idle_thread s"
+  apply clarsimp
+  apply (frule invs_valid_idle)
+  apply (frule invs_valid_global_arch_objs)
   by (fastforce dest: valid_global_arch_objs_pt_at
-                simp: invs_def valid_state_def valid_arch_state_def valid_global_objs_def
-                      obj_at_def valid_idle_def pred_tcb_at_def empty_table_def)
+                simp: obj_at_def valid_idle_def pred_tcb_at_def)
 
 lemma kernel_entry_if_idle_equiv[ADT_IF_assms]:
-  "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and idle_equiv st
+  "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and domain_sep_inv irqs st and idle_equiv st
          and (\<lambda>s. ct_idle s \<longrightarrow> tc = idle_context s)\<rbrace>
    kernel_entry_if e tc
    \<lbrace>\<lambda>_. idle_equiv st\<rbrace>"
@@ -235,11 +313,18 @@ lemma do_user_op_if_irq_measure_if[ADT_IF_assms]:
          | wps |wp dmo_wp | wpc)+
   done
 
-crunch set_flags
+crunch set_flags, arch_post_set_flags
   for irq_states_of_state[wp]: "\<lambda>s. P (irq_state_of_state s)"
 
+lemma checked_cap_insert_valid_irq_states[wp]:
+  "check_cap_at a b (check_cap_at c d (cap_insert a b e)) \<lbrace>valid_irq_states\<rbrace>"
+  by (wpsimp simp: check_cap_at_def)+
+
+crunch set_mcpriority
+  for valid_irq_states[wp]: valid_irq_states
+
 lemma invoke_tcb_irq_state_inv[ADT_IF_assms]:
-  "\<lbrace>(\<lambda>s. irq_state_inv st s) and domain_sep_inv False sta
+  "\<lbrace>(\<lambda>s. irq_state_inv st s) and domain_sep_inv False (sta :: det_state) and valid_irq_states
                              and tcb_inv_wf tinv and K (irq_is_recurring irq st)\<rbrace>
    invoke_tcb tinv
    \<lbrace>\<lambda>_ s. irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
@@ -252,7 +337,8 @@ lemma invoke_tcb_irq_state_inv[ADT_IF_assms]:
     defer
       apply ((wp irq_state_inv_triv | simp)+)[2]
     apply (simp add: split_def cong: option.case_cong)
-  by (wp hoare_vcg_all_liftE_R hoare_vcg_all_lift hoare_vcg_const_imp_liftE_R
+ by (clarsimp split del: if_split cong: conj_cong
+     | wp hoare_vcg_all_liftE_R hoare_vcg_all_lift hoare_vcg_const_imp_liftE_R
          checked_cap_insert_domain_sep_inv cap_delete_deletes
          cap_delete_irq_state_inv[where st=st and sta=sta and irq=irq]
          cap_delete_irq_state_next[where st=st and sta=sta and irq=irq]
@@ -264,24 +350,43 @@ lemma invoke_tcb_irq_state_inv[ADT_IF_assms]:
       | wp (once) irq_state_inv_triv hoare_drop_imps
       | clarsimp split: option.splits | intro impI conjI allI)+
 
+crunch freeMemory
+  for irq_masks[wp]: "\<lambda>s. P (irq_masks s)"
+  (wp: mapM_x_wp)
+
+lemma valid_irq_states_kheap_update[simp]:
+  "valid_irq_states (kheap_update f s) = valid_irq_states s"
+  by (simp add: valid_irq_states_def)
+
+crunch delete_objects
+  for valid_irq_states[wp]: valid_irq_states
+  (wp: dmo_machine_state_lift simp: crunch_simps detype_def)
+
 lemma reset_untyped_cap_irq_state_inv[ADT_IF_assms]:
-  "\<lbrace>irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
+  "\<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state) and valid_irq_states and K (irq_is_recurring irq st)\<rbrace>
    reset_untyped_cap slot
    \<lbrace>\<lambda>y. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>y. irq_state_next st\<rbrace>"
   apply (cases "irq_is_recurring irq st", simp_all)
   apply (simp add: reset_untyped_cap_def)
   apply (rule hoare_pre)
-   apply (wp no_irq_clearMemory mapME_x_wp' hoare_vcg_const_imp_lift
-             get_cap_wp preemption_point_irq_state_inv'[where irq=irq]
-          | rule irq_state_inv_triv
-          | simp add: unless_def
-          | wp (once) dmo_wp)+
-  done
+  by (wp no_irq_clearMemory hoare_vcg_const_imp_lift set_cap_domain_sep_inv
+         hoare_post_addE[where Q'="domain_sep_inv False sta and valid_irq_states", OF mapME_x_wp']
+         get_cap_wp preemption_point_irq_state_inv'[where irq=irq]
+      | rule hoare_vcg_conj_lift
+      | rule irq_state_inv_triv
+      | simp add: unless_def
+      | wp (once) dmo_wp
+      | fastforce)+
 
-crunch
-  handle_vm_fault, handle_hypervisor_fault
-  for irq_state_of_state[ADT_IF_assms, wp]: "\<lambda>s. P (irq_state_of_state s)"
-  (wp: crunch_wps dmo_wp simp: crunch_simps)
+lemma handle_vm_fault_irq_state_of_state[ADT_IF_assms]:
+  "handle_vm_fault thread fault \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  unfolding handle_vm_fault_def addressTranslateS1_def
+  by (wpsimp wp: dmo_wp)
+
+lemma handle_hypervisor_fault_irq_state_of_state[ADT_IF_assms]:
+  "handle_hypervisor_fault thread fault \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  by (cases fault, wpsimp wp: dmo_wp split_del: if_split)
+
 
 text \<open>Not true of invoke_untyped any more.\<close>
 crunch create_cap
@@ -297,35 +402,50 @@ crunch arch_invoke_irq_control
 
 lemma handle_reserved_irq_non_kernel_IRQs[ADT_IF_assms]:
   "\<lbrace>P and K (irq \<notin> non_kernel_IRQs)\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_. P\<rbrace>"
-  by (wpsimp simp: handle_reserved_irq_def)
+  unfolding handle_reserved_irq_def
+  apply (rule hoare_gen_asm)
+  apply (wpsimp wp: when_wp[where P'="\<bottom>"] simp: non_kernel_IRQs_def irq_vppi_event_index_def)
+  done
 
-lemma thread_set_pas_refined[ADT_IF_assms]:
-  assumes cps: "\<And>tcb. \<forall>(getF, v)\<in>ran tcb_cap_cases. getF (f tcb) = getF tcb"
-       and st: "\<And>tcb. tcb_state (f tcb) = tcb_state tcb"
-      and ntfn: "\<And>tcb. tcb_bound_notification (f tcb) = tcb_bound_notification tcb"
-       and dom: "\<And>tcb. tcb_domain (f tcb) = tcb_domain tcb"
-     shows "thread_set f t \<lbrace>pas_refined aag\<rbrace>"
-  by (wpsimp wp: tcb_domain_map_wellformed_lift_strong thread_set_state_vrefs thread_set_edomains[OF dom]
-           simp: pas_refined_def state_objs_to_policy_def
-      | wps thread_set_caps_of_state_trivial[OF cps]
-            thread_set_thread_st_auth_trivT[OF st]
-            thread_set_thread_bound_ntfns_trivT[OF ntfn])+
+lemma thread_set_context_state_hyp_refs_of:
+  "thread_set (tcb_arch_update (arch_tcb_context_set ctxt)) t \<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>"
+  apply (wpsimp simp: thread_set_def wp: set_object_wp )
+  apply (erule_tac P=P in back_subst)
+  apply (rule ext)
+  apply (simp add: state_hyp_refs_of_def get_tcb_def arch_tcb_context_set_def
+            split: option.splits kernel_object.splits)
+  done
+
+lemma thread_set_context_pas_refined[ADT_IF_assms]:
+  "thread_set (tcb_arch_update (arch_tcb_context_set ctxt)) t \<lbrace>pas_refined aag\<rbrace>"
+  unfolding pas_refined_def state_objs_to_policy_def
+  apply (rule hoare_weaken_pre)
+   apply (wpsimp wp: tcb_domain_map_wellformed_lift_strong thread_set_edomains)
+   apply (wps thread_set_state_vrefs thread_set_context_state_hyp_refs_of)
+   apply (rule hoare_lift_Pf2[where f="caps_of_state"])
+    apply (rule hoare_lift_Pf2[where f="thread_st_auth"])
+     apply (rule hoare_lift_Pf2[where f="thread_bound_ntfns"])
+      apply wp
+     apply (wpsimp wp: thread_set_thread_bound_ntfns_trivT )
+    apply (wpsimp wp: thread_set_thread_st_auth_trivT)
+   apply (wpsimp wp: thread_set_caps_of_state_trivial simp: ran_tcb_cap_cases)
+  apply simp
+  done
+
+crunch init_arch_objects
+  for irq_states_of_state[ADT_IF_assms, wp]: "\<lambda>s. P (irq_state_of_state s)"
+  (wp: crunch_wps dmo_wp)
 
 end
 
 
-global_interpretation ADT_IF_1?: ADT_IF_1
+global_interpretation ADT_IF_2?: ADT_IF_2
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact ADT_IF_assms | wp init_arch_objects_inv)?)
+    by (unfold_locales; (fact ADT_IF_assms | wp)?)
 qed
 
 sublocale valid_initial_state \<subseteq> valid_initial_state?: ADT_valid_initial_state ..
-
-
-hide_fact ADT_IF_1.do_user_op_silc_inv
-requalify_facts AARCH64.do_user_op_silc_inv
-declare do_user_op_silc_inv[wp]
 
 end

--- a/proof/infoflow/AARCH64/ArchArch_IF.thy
+++ b/proof/infoflow/AARCH64/ArchArch_IF.thy
@@ -321,7 +321,7 @@ lemma pt_walk_reads_equiv:
     apply clarsimp
    apply (erule_tac x="pptr_from_pte x2" in meta_allE)
    apply (drule meta_mp)
-    apply (subst (asm) vs_lookup_split_Some[OF order_less_imp_le[OF bit1.pred]])
+    apply (subst (asm) vs_lookup_split_Some[OF order_less_imp_le[OF bit0.pred]])
       apply fastforce+
     apply (erule_tac pt_ptr=pt in pt_walk_is_subject; fastforce)
    apply (erule (1) meta_mp)
@@ -346,7 +346,7 @@ lemma pt_lookup_from_level_reads_respects:
   apply (frule vs_lookup_table_is_aligned; clarsimp)
   apply (prop_tac "pt_walk level (level - 1) pt vref (ptes_of s) =
                    Some (level - 1, pptr_from_pte rv)")
-   apply (fastforce simp: vs_lookup_split_Some[OF order_less_imp_le[OF bit1.pred]]
+   apply (fastforce simp: vs_lookup_split_Some[OF order_less_imp_le[OF bit0.pred]]
                           pt_walk.simps obind_def)
   apply (rule conjI)
    apply (erule_tac level=level and bot_level="level-1" and pt_ptr=pt in pt_walk_is_subject; fastforce)

--- a/proof/infoflow/AARCH64/ArchArch_IF.thy
+++ b/proof/infoflow/AARCH64/ArchArch_IF.thy
@@ -8,6 +8,16 @@ theory ArchArch_IF
 imports Arch_IF
 begin
 
+(* FIXME AARCH64 IF: clean and refactor theory *)
+
+(* FIXME AARCH64 IF: consider modelling some of these *)
+axiomatization dmo_reads_respects where
+  dmo_getESR_reads_respects: "reads_respects aag l \<top> (do_machine_op AARCH64.getESR)" and
+  dmo_getFAR_reads_respects: "reads_respects aag l \<top> (do_machine_op AARCH64.getFAR)" and
+  dmo_doSMC_mop_reads_respects: "reads_respects aag l \<top> (do_machine_op (AARCH64.doSMC_mop args))" and
+  dmo_addressTranslateS1_reads_respects: "reads_respects aag l \<top> (do_machine_op (AARCH64.addressTranslateS1 w))"
+
+
 context Arch begin global_naming AARCH64
 
 named_theorems Arch_IF_assms
@@ -61,6 +71,13 @@ crunch set_irq_state, arch_post_cap_deletion, handle_arch_fault_reply
   for irq_state_of_state[Arch_IF_assms, wp]: "\<lambda>s. P (irq_state_of_state s)"
   (wp: crunch_wps dmo_wp simp: crunch_simps maskInterrupt_def)
 
+crunch readVCPUHardwareReg, check_export_arch_timer, writeVCPUHardwareReg, maskInterrupt,
+       enableFpuEL01, isb, dsb, setHCR, setSCTLR, sendSGI, set_gic_vcpu_ctrl_hcr,
+       set_gic_vcpu_ctrl_lr, set_gic_vcpu_ctrl_apr, set_gic_vcpu_ctrl_vmcr, get_gic_vcpu_ctrl_hcr,
+       get_gic_vcpu_ctrl_lr, get_gic_vcpu_ctrl_apr, get_gic_vcpu_ctrl_vmcr, do_flush,
+       invalidateTranslationASID, writeFpuState, disableFpu, enableFpu, deactivateInterrupt
+  for irq_state[wp]: "\<lambda>ms. P (irq_state ms)"
+
 crunch arch_switch_to_idle_thread, arch_switch_to_thread
   for irq_state_of_state[Arch_IF_assms, wp]: "\<lambda>s :: det_state. P (irq_state_of_state s)"
   (wp: dmo_wp modify_wp crunch_wps whenE_wp
@@ -69,17 +86,17 @@ crunch arch_switch_to_idle_thread, arch_switch_to_thread
 
 crunch arch_invoke_irq_handler
   for irq_state_of_state[Arch_IF_assms, wp]: "\<lambda>s. P (irq_state_of_state s)"
-  (wp: dmo_wp simp: maskInterrupt_def plic_complete_claim_def)
+  (wp: dmo_wp simp: maskInterrupt_def)
 
 crunch arch_perform_invocation
   for irq_state_of_state[wp]: "\<lambda>s. P (irq_state_of_state s)"
-  (wp: dmo_wp modify_wp simp: cache_machine_op_defs
+  (wp: dmo_wp modify_wp simp: cache_machine_op_defs doSMC_mop_def
    wp: crunch_wps simp: crunch_simps ignore: ignore_failure)
 
 crunch arch_finalise_cap, prepare_thread_delete
   for irq_state_of_state[Arch_IF_assms, wp]: "\<lambda>s :: det_state. P (irq_state_of_state s)"
   (wp: modify_wp crunch_wps dmo_wp
-   simp: crunch_simps hwASIDFlush_def)
+   simp: crunch_simps)
 
 lemma equiv_asid_machine_state_update[Arch_IF_assms, simp]:
   "equiv_asid asid (machine_state_update f s) s' = equiv_asid asid s s'"
@@ -101,17 +118,9 @@ lemma as_user_set_register_reads_respects'[Arch_IF_assms]:
 
 lemma store_word_offs_reads_respects[Arch_IF_assms]:
   "reads_respects aag l \<top> (store_word_offs ptr offs v)"
-  apply (simp add: store_word_offs_def)
-  apply (rule equiv_valid_get_assert)
-  apply (simp add: storeWord_def)
-  apply (simp add: do_machine_op_bind)
-  apply wp
-     apply (rule use_spec_ev)
-     apply (rule do_machine_op_spec_reads_respects)
-      apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def in_monad)
-      apply (fastforce intro: equiv_forI elim: equiv_forE simp: upto.simps comp_def)
-     apply (rule use_spec_ev do_machine_op_spec_reads_respects assert_ev2
-            | simp add: spec_equiv_valid_def | wp modify_wp)+
+  apply (simp add: store_word_offs_def storeWord_def do_machine_op_bind)
+  apply (wpsimp wp: equiv_valid_get_assert do_machine_op_reads_respects assert_ev2 modify_ev
+         | fastforce intro: equiv_forI elim: equiv_forE simp: upto.simps comp_def)+
   done
 
 lemma set_simple_ko_globals_equiv[Arch_IF_assms]:
@@ -139,8 +148,8 @@ lemma set_thread_state_globals_equiv[Arch_IF_assms]:
                     split: option.splits kernel_object.splits)+
   done
 
-lemma set_cap_globals_equiv''[Arch_IF_assms]:
-  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
+lemma set_cap_globals_equiv'[Arch_IF_assms]:
+  "\<lbrace>globals_equiv s and valid_global_arch_objs\<rbrace>
    set_cap cap p
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding set_cap_def
@@ -160,16 +169,24 @@ lemma as_user_globals_equiv[Arch_IF_assms]:
                    dest: valid_global_arch_objs_pt_at)
   done
 
-declare arch_prepare_set_domain_inv[Arch_IF_assms]
-declare arch_prepare_next_domain_inv[Arch_IF_assms]
+crunch arch_prepare_set_domain, arch_prepare_next_domain
+  for irq_state_of_state[Arch_IF_assms, wp]: "\<lambda>s. P (irq_state_of_state s)"
+
+lemma equiv_hyp_machine_state_rest_update[Arch_IF_assms]:
+  "equiv_hyp P st (s\<lparr>machine_state := ms\<lparr>machine_state_rest := r\<rparr>\<rparr>) = equiv_hyp P st (s\<lparr>machine_state := ms\<rparr>)"
+  by (simp add: equiv_hyp_def equiv_for_def)
+
+lemma equiv_fpu_machine_state_rest_update[Arch_IF_assms]:
+  "equiv_fpu P st (s\<lparr>machine_state := ms\<lparr>machine_state_rest := r\<rparr>\<rparr>) = equiv_fpu P st (s\<lparr>machine_state := ms\<rparr>)"
+  by (simp add: equiv_fpu_def equiv_for_def)
 
 end
 
 
-requalify_facts
-  AARCH64.set_simple_ko_globals_equiv
-  AARCH64.retype_region_irq_state_of_state
-  AARCH64.arch_perform_invocation_irq_state_of_state
+arch_requalify_facts
+  set_simple_ko_globals_equiv
+  retype_region_irq_state_of_state
+  arch_perform_invocation_irq_state_of_state
 
 declare
   retype_region_irq_state_of_state[wp]
@@ -249,15 +266,8 @@ lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq:
   apply (fastforce simp: equiv_asids_def equiv_asid_def intro: aag_can_read_own_asids)
   done
 
-lemma set_vm_root_states_equiv_for[wp]:
-  "set_vm_root thread \<lbrace>states_equiv_for P Q R S st\<rbrace>"
-  unfolding set_vm_root_def catch_def fun_app_def
-  by (wpsimp wp: do_machine_op_mol_states_equiv_for
-                 hoare_vcg_all_lift whenE_wp hoare_drop_imps
-           simp: setVSpaceRoot_def dmo_bind_valid if_apply_def2)+
-
 lemma find_vspace_for_asid_reads_respects:
-   "reads_respects aag l (K (asid \<noteq> 0 \<and> aag_can_read_asid aag asid)) (find_vspace_for_asid asid)"
+   "reads_respects aag l (K ( aag_can_read_asid aag asid)) (find_vspace_for_asid asid)"
   unfolding find_vspace_for_asid_def
   apply wpsimp
      apply (simp add: throw_opt_def)
@@ -268,14 +278,30 @@ lemma find_vspace_for_asid_reads_respects:
   apply (erule equiv_forE)
   apply (erule_tac x=asid in allE)
   apply clarsimp
-  apply (fastforce simp: vspace_for_asid_def pool_for_asid_def vspace_for_pool_def
+  apply (fastforce simp: vspace_for_asid_def entry_for_asid_def entry_for_pool_def
+                         pool_for_asid_def vspace_for_pool_def
                          opt_map_def obind_def obj_at_def equiv_asid_def
                   split: option.splits)
   done
 
+crunch invalidate_tlb_by_asid
+  for states_equiv_for[wp]: "states_equiv_for P Q R S st"
+  and scheduler_action[wp]: "\<lambda>s. P (scheduler_action s)"
+  and work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
+  (wp: do_machine_op_mol_states_equiv_for ignore: do_machine_op simp: invalidateTranslationASID_def)
+
+lemma invalidate_tlb_by_asid_reads_respects:
+  "reads_respects aag l (\<lambda>_. True) (invalidate_tlb_by_asid asid)"
+  by (wpsimp wp: reads_respects_unobservable_unit_return)
+
+lemma invalidate_tlb_by_asid_va_reads_respects:
+  "reads_respects aag l \<top> (invalidate_tlb_by_asid_va asid vaddr)"
+  unfolding invalidate_tlb_by_asid_va_def invalidateTranslationSingle_def
+  by (wpsimp wp: reads_respects_unobservable_unit_return do_machine_op_mol_states_equiv_for)
+
 lemma ptes_of_reads_equiv:
-  "\<lbrakk> is_subject aag (table_base ptr); reads_equiv aag s t \<rbrakk>
-     \<Longrightarrow> ptes_of s ptr = ptes_of t ptr"
+  "\<lbrakk> is_subject aag (table_base pt_t ptr); reads_equiv aag s t \<rbrakk>
+     \<Longrightarrow> ptes_of s pt_t ptr = ptes_of t pt_t ptr"
   by (fastforce elim: reads_equivE equiv_forE simp: ptes_of_def obind_def opt_map_def)
 
 lemma pt_walk_reads_equiv:
@@ -287,15 +313,15 @@ lemma pt_walk_reads_equiv:
   apply (induct level arbitrary: pt; clarsimp)
   apply (simp (no_asm) add: pt_walk.simps)
   apply (clarsimp simp: obind_def split: if_splits)
-  apply (subgoal_tac "ptes_of s (pt_slot_offset level pt vptr) =
-                      ptes_of t (pt_slot_offset level pt vptr)")
+  apply (subgoal_tac "ptes_of s (level_type level) (pt_slot_offset level pt vptr) =
+                      ptes_of t (level_type level) (pt_slot_offset level pt vptr)")
    apply (clarsimp split: option.splits)
    apply (frule_tac bot_level="level-1" in vs_lookup_table_extend)
      apply (fastforce simp: pt_walk.simps obind_def)
     apply clarsimp
    apply (erule_tac x="pptr_from_pte x2" in meta_allE)
    apply (drule meta_mp)
-    apply (subst (asm) vs_lookup_split_Some[OF order_less_imp_le[OF bit0.pred]])
+    apply (subst (asm) vs_lookup_split_Some[OF order_less_imp_le[OF bit1.pred]])
       apply fastforce+
     apply (erule_tac pt_ptr=pt in pt_walk_is_subject; fastforce)
    apply (erule (1) meta_mp)
@@ -320,7 +346,7 @@ lemma pt_lookup_from_level_reads_respects:
   apply (frule vs_lookup_table_is_aligned; clarsimp)
   apply (prop_tac "pt_walk level (level - 1) pt vref (ptes_of s) =
                    Some (level - 1, pptr_from_pte rv)")
-   apply (fastforce simp: vs_lookup_split_Some[OF order_less_imp_le[OF bit0.pred]]
+   apply (fastforce simp: vs_lookup_split_Some[OF order_less_imp_le[OF bit1.pred]]
                           pt_walk.simps obind_def)
   apply (rule conjI)
    apply (erule_tac level=level and bot_level="level-1" and pt_ptr=pt in pt_walk_is_subject; fastforce)
@@ -333,13 +359,12 @@ lemma unmap_page_table_reads_respects:
      (pas_refined aag and pspace_aligned and valid_vspace_objs and valid_asid_table
                       and K (asid \<noteq> 0 \<and> is_subject_asid aag asid \<and> vaddr \<in> user_region))
      (unmap_page_table asid vaddr pt)"
-  unfolding unmap_page_table_def fun_app_def
+  unfolding unmap_page_table_def fun_app_def cleanByVA_PoU_def
   apply (rule gen_asm_ev)
   apply (rule equiv_valid_guard_imp)
-   apply (wp dmo_mol_reads_respects store_pte_reads_respects get_pte_rev
-             pt_lookup_from_level_reads_respects pt_lookup_from_level_is_subject
-             find_vspace_for_asid_wp find_vspace_for_asid_reads_respects hoare_vcg_all_liftE_R
-          | wpc | simp add: sfence_def | wp (once) hoare_drop_imps)+
+   apply (wp dmo_mol_reads_respects store_pte_reads_respects invalidate_tlb_by_asid_reads_respects
+             pt_lookup_from_level_reads_respects find_vspace_for_asid_reads_respects
+          | wpc | simp | fastforce intro: hoare_strengthen_postE_R[OF pt_lookup_from_level_is_subject])+
   apply clarsimp
   apply (frule vspace_for_asid_is_subject)
      apply (fastforce dest: vspace_for_asid_vs_lookup vs_lookup_table_vref_independent)+
@@ -354,12 +379,12 @@ lemma perform_page_table_invocation_reads_respects:
   apply (rule equiv_valid_guard_imp)
    apply (wp dmo_mol_reads_respects store_pte_reads_respects set_cap_reads_respects mapM_x_ev''
              unmap_page_table_reads_respects get_cap_rev
-          | wpc | simp add: sfence_def)+
+          | wpc | simp add: cleanByVA_PoU_def cleanCacheRange_PoU_def)+
   apply (case_tac pti; clarsimp simp: authorised_page_table_inv_def)
   apply (clarsimp simp: valid_pti_def)
   apply (frule cte_wp_valid_cap)
    apply fastforce
-  apply (clarsimp simp:  is_PageTableCap_def valid_cap_def wellformed_mapdata_def)
+  apply (clarsimp simp: is_PageTableCap_def valid_cap_def wellformed_mapdata_def add_mask_fold)
   done
 
 lemma unmap_page_reads_respects:
@@ -367,13 +392,12 @@ lemma unmap_page_reads_respects:
      (pas_refined aag and pspace_aligned and valid_vspace_objs and valid_asid_table
                       and K (asid \<noteq> 0 \<and> is_subject_asid aag asid \<and> vptr \<in> user_region))
      (unmap_page pgsz asid vptr pptr)"
-  unfolding unmap_page_def catch_def fun_app_def
-  supply gets_the_ev[wp del]
-  apply (simp add: unmap_page_def swp_def cong: vmpage_size.case_cong)
-  apply (simp add: unlessE_def gets_the_def)
+  unfolding unmap_page_def catch_def fun_app_def cleanByVA_PoU_def
+  apply (simp add: unmap_page_def unlessE_def gets_the_def cong: vmpage_size.case_cong)
   apply (wp gets_ev' dmo_mol_reads_respects get_pte_rev throw_on_false_reads_respects
             find_vspace_for_asid_reads_respects store_pte_reads_respects[simplified]
-         | wpc | wp (once) hoare_drop_imps | simp add: sfence_def is_aligned_mask[symmetric])+
+            invalidate_tlb_by_asid_va_reads_respects
+         | wpc | simp add: is_aligned_mask[symmetric])+
   apply (clarsimp simp: pt_lookup_slot_def)
   apply (frule (3) vspace_for_asid_is_subject)
   apply safe
@@ -386,6 +410,13 @@ lemma unmap_page_reads_respects:
                      dest: vspace_for_asid_vs_lookup vs_lookup_table_vref_independent)+
   done
 
+lemma perform_flush_reads_respects:
+  "reads_respects aag l \<top> (perform_flush type vstart vend pstart space asid)"
+  unfolding perform_flush_def do_flush_def isb_def dsb_def
+            cleanCacheRange_PoU_def invalidateCacheRange_I_def
+            cleanInvalidateCacheRange_RAM_def cleanCacheRange_RAM_def invalidateCacheRange_RAM_def
+  by (cases type; wpsimp wp: dmo_mol_reads_respects when_ev simp: dmo_distr)
+
 lemma perform_page_invocation_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
@@ -394,17 +425,18 @@ lemma perform_page_invocation_reads_respects:
                                            and pspace_aligned and is_subject aag \<circ> cur_thread)
                     (perform_page_invocation pgi)"
   unfolding perform_page_invocation_def fun_app_def when_def perform_pg_inv_map_def
-            perform_pg_inv_unmap_def perform_pg_inv_get_addr_def
+            perform_pg_inv_unmap_def perform_pg_inv_get_addr_def cleanByVA_PoU_def
   apply (rule equiv_valid_guard_imp)
    apply (wp dmo_mol_reads_respects mapM_x_ev'' store_pte_reads_respects set_cap_reads_respects
-             mapM_ev'' store_pte_reads_respects unmap_page_reads_respects  dmo_mol_2_reads_respects
+             mapM_ev'' store_pte_reads_respects unmap_page_reads_respects
              get_cap_rev set_mrs_reads_respects set_message_info_reads_respects
-          | simp add: sfence_def
+             invalidate_tlb_by_asid_va_reads_respects get_pte_rev perform_flush_reads_respects
+          | simp add: dmo_distr
           | wpc | wp (once) hoare_drop_imps[where Q'="\<lambda>r s. r"])+
-  apply (clarsimp simp: authorised_page_inv_def valid_page_inv_def)
-  apply (auto simp: cte_wp_at_caps_of_state authorised_slots_def cap_links_asid_slot_def
-                    label_owns_asid_slot_def valid_arch_cap_def wellformed_mapdata_def
-             dest!: clas_caps_of_state pas_refined_Control)+
+  apply (case_tac pgi; clarsimp simp: authorised_page_inv_def valid_page_inv_def)
+   apply (auto simp: cte_wp_at_caps_of_state authorised_slots_def cap_links_asid_slot_def
+                     label_owns_asid_slot_def valid_arch_cap_def wellformed_mapdata_def
+              dest!: clas_caps_of_state pas_refined_Control)
   done
 
 lemma equiv_asids_arm_asid_table_update:
@@ -418,7 +450,7 @@ lemma equiv_asids_arm_asid_table_update:
 
 lemma arm_asid_table_update_reads_respects:
   "reads_respects aag l (K (is_subject aag pool_ptr))
-     (do r \<leftarrow> gets (arm_asid_table \<circ> arch_state);
+     (do r \<leftarrow> gets asid_table;
          modify (\<lambda>s. s\<lparr>arch_state :=
                        arch_state s\<lparr>arm_asid_table := r(asid_high_bits_of asid \<mapsto> pool_ptr)\<rparr>\<rparr>)
       od)"
@@ -431,14 +463,15 @@ lemma arm_asid_table_update_reads_respects:
    apply (rule modify_ev2)
    apply clarsimp
    apply (drule (1) is_subject_kheap_eq[rotated])
-   apply (fastforce simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_for_def
-                  intro!: equiv_asids_arm_asid_table_update)
+   apply (clarsimp simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def
+                         equiv_for_def equiv_hyp_def equiv_fpu_def)
+   apply (fastforce intro!: equiv_asids_arm_asid_table_update)
   apply wpsimp
   done
 
 lemma perform_asid_control_invocation_reads_respects:
   notes K_bind_ev[wp del]
-  shows "reads_respects aag l (K (authorised_asid_control_inv aag aci))
+  shows "reads_respects aag l (invs and ct_active and valid_aci aci and K (authorised_asid_control_inv aag aci))
                         (perform_asid_control_invocation aci)"
   unfolding perform_asid_control_invocation_def
   apply (rule gen_asm_ev)
@@ -451,7 +484,7 @@ lemma perform_asid_control_invocation_reads_respects:
    apply (wpc)
    apply (rule bind_ev)
      apply (rule K_bind_ev)
-     apply (rule_tac P'=\<top> in bind_ev)
+     apply (rule_tac bind_ev)
        apply (rule K_bind_ev)
        apply (rule bind_ev)
          apply (rule bind_ev)
@@ -470,39 +503,13 @@ lemma set_asid_pool_reads_respects:
   unfolding set_asid_pool_def
   by (wpsimp wp: set_object_reads_respects get_asid_pool_rev)
 
-lemma copy_global_mappings_valid_arch_state:
-  "\<lbrace>valid_arch_state and valid_global_vspace_mappings and pspace_aligned
-                     and (\<lambda>s. x \<notin> global_refs s \<and> is_aligned x pt_bits)\<rbrace>
-   copy_global_mappings x
-   \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  unfolding copy_global_mappings_def including classic_wp_pre
-  apply simp
-  apply wp
-   apply (rule_tac Q'="\<lambda>_. valid_arch_state and valid_global_vspace_mappings and pspace_aligned
-                                           and (\<lambda>s. x \<notin> global_refs s \<and> is_aligned x pt_bits)"
-                in hoare_strengthen_post)
-    apply (wp mapM_x_wp[OF _ subset_refl]
-              store_pte_valid_arch_state_unreachable
-              store_pte_valid_global_vspace_mappings)
-    apply (simp only: pt_index_def)
-    apply (subst table_base_offset_id)
-      apply clarsimp
-     apply (clarsimp simp: pte_bits_def word_size_bits_def pt_bits_def
-                           table_size_def ptTranslationBits_def mask_def)
-     apply (word_bitwise, fastforce)
-    apply clarsimp
-    apply (simp_all)
-  apply (clarsimp simp: valid_arch_state_def)
-  apply (subst (asm) table_base_plus; simp add: mask_def)
-  done
-
 lemma set_asid_pool_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
+  "\<lbrace>globals_equiv s and valid_global_arch_objs\<rbrace>
    set_asid_pool ptr pool
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding set_asid_pool_def
   apply (wpsimp wp: set_object_globals_equiv[THEN hoare_set_object_weaken_pre] simp: a_type_def)
-  apply (fastforce simp: valid_arch_state_def obj_at_def dest: valid_global_arch_objs_pt_at)
+  apply (fastforce simp: obj_at_def dest: valid_global_arch_objs_pt_at)
   done
 
 lemma perform_asid_pool_invocation_reads_respects_g:
@@ -514,19 +521,11 @@ lemma perform_asid_pool_invocation_reads_respects_g:
                      reads_respects_g[OF get_asid_pool_rev]
                      set_asid_pool_globals_equiv set_cap_reads_respects
                      doesnt_touch_globalsI get_cap_auth_wp[where aag=aag] get_cap_rev
-                     copy_global_mappings_reads_respects_g copy_global_mappings_valid_arch_state
                      set_cap_reads_respects_g get_cap_reads_respects_g
           | strengthen valid_arch_state_global_arch_objs
           | wp (once) hoare_drop_imps)+
   apply (clarsimp simp: invs_arch_state invs_valid_global_objs invs_psp_aligned
-                        invs_valid_global_vspace_mappings authorised_asid_pool_inv_def
-                  cong: conj_cong)
-  apply (frule (1) caps_of_state_valid)
-  apply (clarsimp simp: is_ArchObjectCap_def is_PageTableCap_def
-                        valid_cap_def cap_aligned_def pt_bits_def aag_cap_auth_def
-                        cap_auth_conferred_def arch_cap_auth_conferred_def)
-  apply (frule global_pt_in_global_refs[OF invs_valid_global_arch_objs])
-  apply (fastforce dest: pas_refined_Control cap_not_in_valid_global_refs)
+                        invs_valid_global_vspace_mappings authorised_asid_pool_inv_def)
   done
 
 lemma equiv_asids_arm_asid_table_delete:
@@ -549,11 +548,11 @@ lemma arm_asid_table_delete_ev2:
                                                                      else rv' a\<rparr>\<rparr>))"
   apply (rule modify_ev2)
   (* slow 15s *)
-  by (auto simp: reads_equiv_def2 affects_equiv_def2
+  by (auto simp: reads_equiv_def2 affects_equiv_def2 equiv_hyp_def
+                 equiv_fpu_def equiv_for_def get_tcb_def cur_fpu_for_def
          intro!: states_equiv_forI equiv_forI equiv_asids_arm_asid_table_delete
           elim!: states_equiv_forE equiv_forE
            elim: is_subject_kheap_eq[simplified reads_equiv_def2 states_equiv_for_def, rotated])
-
 
 lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq':
   "\<lbrakk> (\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of base
@@ -563,7 +562,7 @@ lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq':
   apply (insert asid_high_bits_0_eq_1)
   apply (case_tac "base = 0")
    apply (subgoal_tac "is_subject_asid aag 1")
-    apply simp
+    apply (simp del: asid_high_bits_of_0)
     apply (rule requiv_arm_asid_table_asid_high_bits_of_asid_eq[where aag=aag])
       apply (erule_tac x=1 in allE)
       apply simp+
@@ -571,6 +570,44 @@ lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq':
     apply (erule_tac x=base in allE)
     apply simp+
   done
+
+lemma states_equiv_for_asid_map_update[simp]:
+  "states_equiv_for P Q R S st (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_map := asid_map'\<rparr>\<rparr>) =
+   states_equiv_for P Q R S st s"
+ by (auto simp: states_equiv_for_def equiv_for_def equiv_hyp_def equiv_fpu_def get_tcb_def cur_fpu_for_def
+          intro: equiv_asids_triv' split: if_splits)
+
+lemma states_equiv_for_vmid_table_update[simp]:
+  "states_equiv_for P Q R S st (s\<lparr>arch_state := arch_state s\<lparr>arm_vmid_table := table\<rparr>\<rparr>) =
+   states_equiv_for P Q R S st s"
+ by (auto simp: states_equiv_for_def equiv_for_def equiv_hyp_def equiv_fpu_def get_tcb_def cur_fpu_for_def
+          intro: equiv_asids_triv' split: if_splits)
+
+lemma states_equiv_for_next_vmid_update[simp]:
+  "states_equiv_for P Q R S st (s\<lparr>arch_state := arch_state s\<lparr>arm_next_vmid := vmid\<rparr>\<rparr>) =
+   states_equiv_for P Q R S st s"
+ by (auto simp: states_equiv_for_def equiv_for_def equiv_hyp_def equiv_fpu_def get_tcb_def cur_fpu_for_def
+          intro: equiv_asids_triv' split: if_splits)
+
+crunch get_vmid
+  for states_equiv_for[wp]: "states_equiv_for P Q R S st"
+  (wp: do_machine_op_mol_states_equiv_for ignore: do_machine_op simp: invalidateTranslationASID_def)
+
+lemma set_vm_root_states_equiv_for:
+  "set_vm_root thread \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+  unfolding set_vm_root_def catch_def fun_app_def set_global_user_vspace_def arm_context_switch_def
+  by (wpsimp wp: do_machine_op_mol_states_equiv_for
+                 hoare_vcg_all_lift whenE_wp hoare_drop_imps
+           simp: setVSpaceRoot_def dmo_bind_valid if_apply_def2)+
+
+crunch invalidate_asid_entry
+  for states_equiv_for[wp]: "states_equiv_for P Q R S st"
+
+crunch invalidate_asid_entry
+  for sched_act[wp]: "\<lambda>s. P (scheduler_action s)"
+
+crunch invalidate_asid_entry
+  for wuc[wp]: "\<lambda>s. P (work_units_completed s)"
 
 lemma delete_asid_pool_reads_respects:
   "reads_respects aag l (K (\<forall>asid'. asid' \<noteq> 0 \<and> asid_high_bits_of asid' = asid_high_bits_of base
@@ -593,10 +630,13 @@ lemma delete_asid_pool_reads_respects:
         apply (rule equiv_valid_2_guard_imp)
           apply (rule equiv_valid_2_bind)
              apply (rule equiv_valid_2_bind)
-                apply (rule equiv_valid_2_unobservable)
-                           apply (wp set_vm_root_states_equiv_for)+
-               apply (rule arm_asid_table_delete_ev2)
-              apply (wp)+
+                apply (rule equiv_valid_2_bind)
+                   apply (rule equiv_valid_2_unobservable)
+                              apply (wp set_vm_root_states_equiv_for)+
+                  apply (rule arm_asid_table_delete_ev2)
+                 apply (wp)+
+               apply (rule equiv_valid_2_unobservable)
+                          apply (wpsimp wp: mapM_wp_inv)+
             apply (rule equiv_valid_2_unobservable)
   by (wp mapM_wp' return_ev2
       | rule conjI | drule (1) requiv_arm_asid_table_asid_high_bits_of_asid_eq'
@@ -634,59 +674,39 @@ lemma set_asid_pool_delete_ev2:
      (set_asid_pool a (pool(asid_low_bits_of asid := None)))
      (set_asid_pool a (pool'(asid_low_bits_of asid := None)))"
   apply (clarsimp simp: equiv_valid_2_def)
-  apply (frule_tac s'=b in set_asid_pool_state_equal_except_kheap)
-  apply (frule_tac s'=ba in set_asid_pool_state_equal_except_kheap)
-  apply (clarsimp simp: states_equal_except_kheap_asid_def)
-  apply (rule conjI)
-   apply (clarsimp simp: states_equiv_for_def reads_equiv_def equiv_for_def | rule conjI)+
-    apply (case_tac "x=a")
-     apply (clarsimp simp: opt_map_def split: option.splits)
-    apply (fastforce)
-   apply (clarsimp simp: equiv_asids_def equiv_asid_def | rule conjI)+
-    apply (case_tac "pool_ptr = a")
-     apply (clarsimp)
-     apply (erule_tac x="pasASIDAbs aag asid" in ballE)
-      apply (clarsimp)
-      apply (erule_tac x=asid in allE)+
-      apply (clarsimp)
-     apply (drule aag_can_read_own_asids, simp)
-    apply (erule_tac x="pasASIDAbs aag asida" in ballE)
-     apply (clarsimp)
-     apply (erule_tac x=asida in allE)+
-     apply (clarsimp)
-    apply (clarsimp)
-   apply (clarsimp)
-   apply (case_tac "pool_ptr=a")
-    apply (erule_tac x="pasASIDAbs aag asida" in ballE; clarsimp)
+  apply (erule use_valid)
+   apply (wpsimp simp: set_asid_pool_def wp: set_object_wp)
+  apply clarsimp
+  apply (erule use_valid)
+   apply (wpsimp simp: set_asid_pool_def wp: set_object_wp)
+  apply clarsimp
+  apply (prop_tac "aag_can_read aag a \<or> aag_can_affect aag l a \<longrightarrow> pool = pool'")
+   apply (erule reads_equivE)
+   apply (erule equiv_forE)
+   apply (erule_tac x=a in meta_allE)
+   apply clarsimp
+   apply (clarsimp simp: equiv_for_def)
+   apply (erule affects_equivE)
+   apply (erule equiv_forE)
+   apply (erule_tac x=a in meta_allE)
+   apply clarsimp
    apply (clarsimp simp: opt_map_def split: option.splits)
-  apply (clarsimp simp: affects_equiv_def equiv_for_def states_equiv_for_def | rule conjI)+
-   apply (case_tac "x=a")
-    apply (clarsimp simp: opt_map_def split: option.splits)
-   apply (fastforce)
-  apply (clarsimp simp: equiv_asids_def equiv_asid_def | rule conjI)+
-   apply (case_tac "pool_ptr=a")
-    apply (clarsimp simp: opt_map_def split: option.splits)
-    apply (erule_tac x=asid in allE)+
-    apply (clarsimp simp: asid_pool_at_kheap)
-   apply (erule_tac x=asida in allE)+
-   apply (clarsimp)
-  apply (clarsimp)
-  apply (case_tac "pool_ptr=a")
-   apply (clarsimp simp: opt_map_def split: option.splits)
-  apply (clarsimp simp: opt_map_def split: option.splits)
+  apply (clarsimp simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_for_def)
+  apply (clarsimp simp: equiv_asids_def equiv_asid_def obj_at_def opt_map_def | rule conjI)+
   done
 
 lemma delete_asid_reads_respects:
   "reads_respects aag l (K (asid \<noteq> 0 \<and> is_subject_asid aag asid)) (delete_asid asid pt)"
   unfolding delete_asid_def
+  supply fun_upd_apply[simp del]
   apply (subst equiv_valid_def2)
-  apply (rule_tac W="\<top>\<top>" and Q="\<lambda>rv s. rv = arm_asid_table (arch_state s) \<and>
+  apply (rule_tac W="\<top>\<top>" and Q="\<lambda>rv s. rv = asid_table s (asid_high_bits_of asid) \<and>
                                         is_subject_asid aag asid \<and> asid \<noteq> 0" in equiv_valid_rv_bind)
     apply (rule equiv_valid_rv_guard_imp[OF equiv_valid_rv_trivial])
      apply (wp, simp)
-   apply (case_tac "rv (asid_high_bits_of asid) = rv' (asid_high_bits_of asid)")
+   apply (case_tac "rv = rv'")
     apply (simp)
-    apply (case_tac "rv' (asid_high_bits_of asid)")
+    apply (case_tac "rv")
      apply (simp)
      apply (wp return_ev2, simp)
     apply (simp)
@@ -697,44 +717,120 @@ lemma delete_asid_reads_respects:
          apply (clarsimp | rule conjI)+
           apply (rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
              apply (rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
-                apply (subst equiv_valid_def2[symmetric])
-                apply (rule reads_respects_unobservable_unit_return)
-                     apply (wp set_vm_root_states_equiv_for)+
-               apply (rule set_asid_pool_delete_ev2)
-              apply (wp)+
+                apply (rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
+                   apply (rule_tac R'="\<top>\<top>" in equiv_valid_2_bind)
+                      apply (subst equiv_valid_def2[symmetric])
+                      apply (rule reads_respects_unobservable_unit_return)
+                           apply (wp set_vm_root_states_equiv_for)+
+                     apply (rule set_asid_pool_delete_ev2)
+                    apply (wp)+
+                  apply (rule equiv_valid_2_unobservable)
+                             apply (wpsimp wp: do_machine_op_mol_states_equiv_for invalidate_tlb_by_asid_reads_respects)+
+               apply (rule equiv_valid_2_unobservable)
+                          apply wpsimp+
+              apply (wpsimp wp: hoare_vcg_imp_lift')+
             apply (rule equiv_valid_2_unobservable)
-                       apply (wpsimp wp: do_machine_op_mol_states_equiv_for simp: hwASIDFlush_def)+
+                       apply (wpsimp wp: hoare_vcg_imp_lift')+
          apply (clarsimp | rule return_ev2)+
         apply (rule equiv_valid_2_guard_imp)
           apply (wp get_asid_pool_revrv)
          apply (simp)+
        apply (wp)+
-     apply (clarsimp simp: asid_pools_of_ko_at obj_at_def)+
+     apply (clarsimp simp: obj_at_def)+
    apply (clarsimp simp: equiv_valid_2_def reads_equiv_def
                          equiv_asids_def equiv_asid_def states_equiv_for_def)
    apply (erule_tac x="pasASIDAbs aag asid" in ballE)
     apply (clarsimp)
    apply (drule aag_can_read_own_asids)
    apply wpsimp+
+  apply (clarsimp simp: pool_for_asid_def)
   done
+
+lemma globals_equiv_arm_asid_map_update[simp]:
+  "globals_equiv s (t\<lparr>arch_state := arch_state t\<lparr>arm_asid_map := x\<rparr>\<rparr>) = globals_equiv s t"
+  by (simp add: globals_equiv_def)
 
 lemma globals_equiv_arm_asid_table_update[simp]:
   "globals_equiv s (t\<lparr>arch_state := arch_state t\<lparr>arm_asid_table := x\<rparr>\<rparr>) = globals_equiv s t"
   by (simp add: globals_equiv_def)
 
+lemma globals_equiv_arm_vmid_table_update[simp]:
+  "globals_equiv s (t\<lparr>arch_state := arch_state t\<lparr>arm_vmid_table := x\<rparr>\<rparr>) = globals_equiv s t"
+  by (simp add: globals_equiv_def)
+
+lemma globals_equiv_arm_next_vmid_update[simp]:
+  "globals_equiv s (t\<lparr>arch_state := arch_state t\<lparr>arm_next_vmid := x\<rparr>\<rparr>) = globals_equiv s t"
+  by (simp add: globals_equiv_def)
+
+lemma valid_global_arch_objs_arm_asid_table_update[simp]:
+  "valid_global_arch_objs (s\<lparr>arch_state := arch_state s\<lparr>arm_asid_table := x\<rparr>\<rparr>) = valid_global_arch_objs s"
+  by (simp add: valid_global_arch_objs_def)
+
+lemma set_global_user_vspace_globals_equiv[wp]:
+  "set_global_user_vspace \<lbrace>globals_equiv s\<rbrace>"
+  unfolding set_global_user_vspace_def setVSpaceRoot_def
+  by wpsimp
+
+lemma update_asid_pool_entry_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and valid_global_arch_objs\<rbrace>
+   update_asid_pool_entry f asid
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding update_asid_pool_entry_def
+  by (wpsimp wp: set_asid_pool_globals_equiv)
+
+crunch invalidate_vmid_entry, invalidate_asid
+  for globals_equiv[wp]: "globals_equiv st"
+  (wp: crunch_wps dmo_mol_reads_respects simp: crunch_simps)
+
+lemma find_free_vmid_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and valid_global_arch_objs\<rbrace>
+   find_free_vmid
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding find_free_vmid_def invalidateTranslationASID_def
+  by wpsimp
+
+crunch get_vmid
+  for globals_equiv[wp]: "globals_equiv st"
+  (wp: crunch_wps dmo_mol_reads_respects simp: crunch_simps)
+
+lemma arm_context_switch_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and valid_global_arch_objs\<rbrace>
+   arm_context_switch vspace asid
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding arm_context_switch_def setVSpaceRoot_def
+  by (wpsimp wp: dmo_mol_reads_respects)
+
 lemma set_vm_root_globals_equiv[wp]:
-  "set_vm_root tcb \<lbrace>globals_equiv s\<rbrace>"
+  "\<lbrace>globals_equiv s and valid_global_arch_objs\<rbrace>
+   set_vm_root tcb
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   by (wpsimp wp: dmo_mol_globals_equiv hoare_vcg_all_lift hoare_drop_imps
            simp: set_vm_root_def setVSpaceRoot_def)
 
+crunch invalidate_asid_entry
+  for globals_equiv[wp]: "globals_equiv st"
+  (wp: crunch_wps dmo_mol_reads_respects simp: crunch_simps)
+
+lemma invalidate_tlb_by_asid_globals_equiv[wp]:
+  "invalidate_tlb_by_asid asid \<lbrace>globals_equiv s\<rbrace>"
+  unfolding invalidate_tlb_by_asid_def invalidateTranslationASID_def
+  by wpsimp
+
+lemma invalidate_tlb_by_asid_va_globals_equiv[wp]:
+  "invalidate_tlb_by_asid_va asid vaddr \<lbrace>globals_equiv s\<rbrace>"
+  unfolding invalidate_tlb_by_asid_va_def invalidateTranslationSingle_def
+  by wpsimp
+
 lemma delete_asid_pool_globals_equiv[wp]:
-  "delete_asid_pool base ptr \<lbrace>globals_equiv s\<rbrace>"
+  "\<lbrace>globals_equiv s and valid_global_arch_objs\<rbrace>
+   delete_asid_pool base ptr
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding delete_asid_pool_def
   by (wpsimp wp: set_vm_root_globals_equiv mapM_wp[OF _ subset_refl] modify_wp)
 
 lemma vs_lookup_slot_not_global:
   "\<lbrakk> vs_lookup_slot level asid vref s = Some (level, pte); level \<le> max_pt_level;
-     pte_refs_of s pte = Some pt; vref \<in> user_region; invs s \<rbrakk>
+     pte_refs_of (level_type level) pte s = Some pt; vref \<in> user_region; invs s \<rbrakk>
      \<Longrightarrow> pt \<notin> global_refs s"
   apply (prop_tac "vs_lookup_target level asid vref s = Some (level, pt)")
    apply (clarsimp simp: vs_lookup_target_def obind_def split: if_splits)
@@ -745,24 +841,9 @@ lemma unmap_page_table_globals_equiv:
   "\<lbrace>invs and globals_equiv st and K (vaddr \<in> user_region)\<rbrace>
    unmap_page_table asid vaddr pt
    \<lbrace>\<lambda>rv. globals_equiv st\<rbrace>"
-  unfolding unmap_page_table_def
-  apply (wp store_pte_globals_equiv pt_lookup_from_level_wrp | wpc | simp add: sfence_def)+
+  unfolding unmap_page_table_def cleanByVA_PoU_def
+  apply (wp store_pte_globals_equiv pt_lookup_from_level_wrp | wpc | simp)+
   apply clarsimp
-  apply (rule_tac x=asid in exI)
-  apply clarsimp
-  apply (case_tac "level = asid_pool_level")
-   apply (fastforce dest: vs_lookup_slot_no_asid simp: ptes_of_Some valid_arch_state_asid_table)
-  apply (drule vs_lookup_slot_table_base; clarsimp)
-  apply (drule reachable_page_table_not_global, clarsimp+)
-  apply (fastforce dest: global_pt_in_global_refs[OF invs_valid_global_arch_objs])
-  done
-
-lemma unmap_page_table_valid_arch_state:
-  "\<lbrace>invs and valid_arch_state and K (vaddr \<in> user_region)\<rbrace>
-   unmap_page_table asid vaddr pt
-   \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  unfolding unmap_page_table_def
-  apply (wpsimp wp: store_pte_valid_arch_state_unreachable pt_lookup_from_level_wrp simp: sfence_def)
   apply (rule_tac x=asid in exI)
   apply clarsimp
   apply (case_tac "level = asid_pool_level")
@@ -773,73 +854,67 @@ lemma unmap_page_table_valid_arch_state:
 
 lemma mapM_x_swp_store_pte_globals_equiv:
   "\<lbrace>globals_equiv s and pspace_aligned and valid_arch_state and valid_global_vspace_mappings
-                    and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)\<rbrace>
-   mapM_x (swp store_pte pte) slots
+                    and (\<lambda>s. \<forall>x \<in> set slots. table_base pt_t x \<notin> global_refs s)\<rbrace>
+   mapM_x (swp (store_pte pt_t) pte) slots
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   apply (rule_tac Q'="\<lambda>_. pspace_aligned and globals_equiv s and valid_arch_state
                                         and valid_global_vspace_mappings
-                                        and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)"
+                                        and (\<lambda>s. \<forall>x \<in> set slots. table_base pt_t x \<notin> global_refs s)"
                in hoare_strengthen_post)
    apply (wp mapM_x_wp' store_pte_valid_arch_state_unreachable
              store_pte_valid_global_vspace_mappings store_pte_globals_equiv | simp)+
-    apply (clarsimp simp: valid_arch_state_def)
-    apply (fastforce dest: global_pt_in_global_refs[OF invs_valid_global_arch_objs])
-   apply auto
+    apply (auto simp: global_refs_def)
   done
 
 lemma mapM_x_swp_store_pte_valid_ko_at_arch[wp]:
   "\<lbrace>pspace_aligned and valid_arch_state and valid_global_vspace_mappings
-                   and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)\<rbrace>
-   mapM_x (swp store_pte A) slots
+                   and (\<lambda>s. \<forall>x \<in> set slots. table_base pt_t x \<notin> global_refs s)\<rbrace>
+   mapM_x (swp (store_pte pt_t) pte) slots
    \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
   apply (rule_tac Q'="\<lambda>_. pspace_aligned and valid_arch_state and valid_global_vspace_mappings
-                                        and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)"
+                                        and (\<lambda>s. \<forall>x \<in> set slots. table_base pt_t x \<notin> global_refs s)"
                in hoare_strengthen_post)
    apply (wp mapM_x_wp' store_pte_valid_arch_state_unreachable
              store_pte_valid_global_vspace_mappings store_pte_globals_equiv | simp)+
-    apply (clarsimp simp: valid_arch_state_def)
-   apply (fastforce dest: global_pt_in_global_refs[OF invs_valid_global_arch_objs])
-  apply auto
   done
 
 
 definition authorised_for_globals_page_table_inv ::
   "page_table_invocation \<Rightarrow> 's :: state_ext state \<Rightarrow> bool" where
   "authorised_for_globals_page_table_inv pti \<equiv> \<lambda>s.
-     case pti of PageTableMap cap ptr pde p \<Rightarrow> p && ~~ mask pt_bits \<noteq> arm_us_global_vspace (arch_state s)
+     case pti of PageTableMap cap ptr pte p lvl \<Rightarrow> table_base (level_type lvl) p \<noteq> arm_us_global_vspace (arch_state s)
                                         | _ \<Rightarrow> True"
 
-
 lemma perform_pt_inv_map_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_arch_state and (\<lambda>s. table_base x14 \<noteq> global_pt s)\<rbrace>
-   perform_pt_inv_map x11 x12 x13 x14
+  "\<lbrace>globals_equiv st and valid_arch_state and (\<lambda>s. table_base (level_type lvl) p \<noteq> global_pt s)\<rbrace>
+   perform_pt_inv_map cap sl pte p lvl
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding perform_pt_inv_map_def
-  by (wpsimp wp: store_pte_globals_equiv set_cap_globals_equiv'' simp: sfence_def)
+  unfolding perform_pt_inv_map_def cleanByVA_PoU_def
+  by (wpsimp wp: store_pte_globals_equiv set_cap_globals_equiv)
 
 lemma perform_pt_inv_unmap_globals_equiv:
   "\<lbrace>invs and globals_equiv st and cte_wp_at ((=) (ArchObjectCap cap)) ct_slot\<rbrace>
    perform_pt_inv_unmap cap ct_slot
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding perform_pt_inv_unmap_def
-  apply (wpsimp wp: set_cap_globals_equiv'' mapM_x_swp_store_pte_globals_equiv)
+  unfolding perform_pt_inv_unmap_def cleanCacheRange_PoU_def
+  apply (wpsimp wp: set_cap_globals_equiv mapM_x_swp_store_pte_globals_equiv)
      apply (strengthen invs_imps invs_valid_global_vspace_mappings)
      apply (clarsimp cong: conj_cong)
      apply (wpsimp wp: unmap_page_table_globals_equiv unmap_page_table_invs)
     apply wpsimp+
-  apply auto
+  apply (intro conjI)
    apply (drule cte_wp_valid_cap, fastforce)
    apply (clarsimp simp: is_PageTableCap_def valid_cap_def valid_arch_cap_def wellformed_mapdata_def)
   apply (frule cte_wp_valid_cap, fastforce)
   apply (clarsimp simp: is_PageTableCap_def valid_cap_def valid_arch_cap_def wellformed_mapdata_def)
-  apply (prop_tac "table_base x = acap_obj cap")
-   apply (prop_tac "is_aligned x41 pt_bits")
+  apply (prop_tac "table_base x42 x = acap_obj cap")
+   apply (prop_tac "is_aligned x41 (pt_bits x42)")
     apply (fastforce dest: is_aligned_pt simp: valid_arch_cap_def)
    apply (simp only: is_aligned_neg_mask_eq')
    apply (clarsimp simp: add_mask_fold)
    apply (drule subsetD[OF upto_enum_step_subset], clarsimp)
-   apply (drule neg_mask_mono_le[where n=pt_bits])
-   apply (drule neg_mask_mono_le[where n=pt_bits])
+   apply (drule_tac n="pt_bits x42" in neg_mask_mono_le)
+   apply (drule_tac n="pt_bits x42" in neg_mask_mono_le)
    apply (fastforce dest: plus_mask_AND_NOT_mask_eq)
   apply clarsimp
   apply (frule invs_valid_global_refs)
@@ -852,68 +927,46 @@ lemma perform_page_table_invocation_globals_equiv:
    perform_page_table_invocation pti
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding perform_page_table_invocation_def
-  apply (wpsimp wp: store_pte_globals_equiv set_cap_globals_equiv''
+  apply (wpsimp wp: store_pte_globals_equiv set_cap_globals_equiv
                     perform_pt_inv_map_globals_equiv
                     perform_pt_inv_unmap_globals_equiv)
   apply (case_tac pti; clarsimp simp: authorised_for_globals_page_table_inv_def valid_pti_def)
   done
 
 lemma mapM_swp_store_pte_globals_equiv:
-  "\<lbrace>globals_equiv s and pspace_aligned and valid_arch_state and valid_global_vspace_mappings
-                    and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)\<rbrace>
-   mapM (swp store_pte pte) slots
+  "\<lbrace>globals_equiv s and (\<lambda>s. \<forall>x \<in> set slots. table_base pt_t x \<notin> global_refs s)\<rbrace>
+   mapM (swp (store_pte pt_t) pte) slots
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  apply (rule_tac Q'="\<lambda>_. pspace_aligned and globals_equiv s and valid_arch_state
-                                        and valid_global_vspace_mappings
-                                        and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)"
+  apply (rule_tac Q'="\<lambda>_. globals_equiv s and (\<lambda>s. \<forall>x \<in> set slots. table_base pt_t x \<notin> global_refs s)"
                in hoare_strengthen_post)
    apply (wp mapM_wp' store_pte_valid_arch_state_unreachable
              store_pte_valid_global_vspace_mappings store_pte_globals_equiv | simp)+
-    apply (clarsimp simp: valid_arch_state_def)
-    apply (fastforce dest: global_pt_in_global_refs[OF invs_valid_global_arch_objs])
-   apply auto
-  done
-
-lemma mapM_swp_store_pte_valid_ko_at_arch[wp]:
-  "\<lbrace>globals_equiv s and pspace_aligned and valid_arch_state and valid_global_vspace_mappings
-                    and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)\<rbrace>
-   mapM (swp store_pte pte) slots
-   \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  apply (rule_tac Q'="\<lambda>_. pspace_aligned and globals_equiv s and valid_arch_state
-                                        and valid_global_vspace_mappings
-                                        and (\<lambda>s. \<forall>x \<in> set slots. table_base x \<notin> global_refs s)"
-               in hoare_strengthen_post)
-   apply (wp mapM_wp' store_pte_valid_arch_state_unreachable
-             store_pte_valid_global_vspace_mappings store_pte_globals_equiv | simp)+
-    apply (clarsimp simp: valid_arch_state_def)
-    apply (fastforce dest: global_pt_in_global_refs[OF invs_valid_global_arch_objs])
-   apply auto
+    apply (auto simp: global_refs_def)
   done
 
 lemma unmap_page_globals_equiv:
   "\<lbrace>globals_equiv st and invs and K (vptr \<in> user_region)\<rbrace>
    unmap_page pgsz asid vptr pptr
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding unmap_page_def including no_pre
+  unfolding unmap_page_def cleanByVA_PoU_def including no_pre
   apply (induct pgsz)
-    apply (wpsimp wp: store_pte_globals_equiv | simp add: sfence_def)+
+    apply (wpsimp wp: store_pte_globals_equiv | simp)+
     apply (rule hoare_weaken_preE[OF find_vspace_for_asid_wp])
     apply clarsimp
     apply (frule (1) pt_lookup_slot_vs_lookup_slotI0)
     apply (drule vs_lookup_slot_table_base; clarsimp?)
     apply (drule reachable_page_table_not_global; clarsimp?)
-    apply (fastforce dest: global_pt_in_global_refs[OF invs_valid_global_arch_objs])
+    apply fastforce
    apply (rule hoare_pre)
-    apply (wpsimp wp: store_pte_globals_equiv mapM_swp_store_pte_globals_equiv hoare_drop_imps
-           | simp add: sfence_def)+
+    apply (wpsimp wp: store_pte_globals_equiv mapM_swp_store_pte_globals_equiv hoare_drop_imps)+
    apply (frule (1) pt_lookup_slot_vs_lookup_slotI0)
    apply (drule vs_lookup_slot_level)
    apply (case_tac "x = asid_pool_level")
     apply (fastforce dest: vs_lookup_slot_no_asid simp: ptes_of_Some valid_arch_state_asid_table)
    apply (drule vs_lookup_slot_table_base; clarsimp?)
    apply (drule reachable_page_table_not_global; clarsimp?)
-   apply (fastforce dest: global_pt_in_global_refs[OF invs_valid_global_arch_objs])
-  apply (wpsimp wp: store_pte_globals_equiv | simp add: sfence_def)+
+   apply fastforce
+  apply (wpsimp wp: store_pte_globals_equiv)+
   apply (rule hoare_weaken_preE[OF find_vspace_for_asid_wp])
   apply clarsimp
   apply (frule (1) pt_lookup_slot_vs_lookup_slotI0)
@@ -922,7 +975,7 @@ lemma unmap_page_globals_equiv:
    apply (fastforce dest: vs_lookup_slot_no_asid simp: ptes_of_Some valid_arch_state_asid_table)
   apply (drule vs_lookup_slot_table_base; clarsimp?)
   apply (drule reachable_page_table_not_global; clarsimp?)
-  apply (fastforce dest: global_pt_in_global_refs[OF invs_valid_global_arch_objs])
+  apply fastforce
   done
 
 
@@ -930,7 +983,6 @@ definition authorised_for_globals_page_inv ::
   "page_invocation \<Rightarrow> 'z :: state_ext state \<Rightarrow> bool"  where
   "authorised_for_globals_page_inv pgi \<equiv> \<lambda>s.
      case pgi of PageMap cap ptr m \<Rightarrow> (\<exists>slot. cte_wp_at (parent_for_refs m) slot s) | _ \<Rightarrow> True"
-
 
 lemma length_msg_lt_msg_max:
   "length msg_registers < msg_max_length"
@@ -967,22 +1019,9 @@ lemma perform_pg_inv_get_addr_globals_equiv:
   unfolding perform_pg_inv_get_addr_def
   by (wpsimp wp: set_message_info_globals_equiv set_mrs_globals_equiv)
 
-lemma unmap_page_valid_arch_state:
-  "\<lbrace>invs and K (vptr \<in> user_region)\<rbrace>
-   unmap_page pgsz asid vptr pptr
-   \<lbrace>\<lambda>_. valid_arch_state\<rbrace>"
-  unfolding unmap_page_def
-  apply (wpsimp wp: store_pte_valid_arch_state_unreachable)
-  apply (frule invs_arch_state)
-  apply (frule invs_valid_global_vspace_mappings)
-  apply clarsimp
-  apply (frule (1) pt_lookup_slot_vs_lookup_slotI0)
-  apply (drule vs_lookup_slot_level)
-  apply (case_tac "x = asid_pool_level")
-   apply (fastforce dest: vs_lookup_slot_no_asid simp: ptes_of_Some valid_arch_state_asid_table)
-  apply (drule vs_lookup_slot_table_base; clarsimp?)
-  apply (drule reachable_page_table_not_global; clarsimp?)
-  done
+crunch unmap_page
+  for valid_global_arch_objs[wp]: "valid_global_arch_objs"
+  (wp: crunch_wps simp: crunch_simps)
 
 lemma perform_pg_inv_unmap_globals_equiv:
   "\<lbrace>invs and globals_equiv st and cte_wp_at ((=) (ArchObjectCap cap)) ct_slot\<rbrace>
@@ -991,10 +1030,10 @@ lemma perform_pg_inv_unmap_globals_equiv:
   unfolding perform_pg_inv_unmap_def
   apply (rule hoare_weaken_pre)
    apply (wp mapM_swp_store_pte_globals_equiv hoare_vcg_all_lift mapM_x_swp_store_pte_globals_equiv
-             set_cap_globals_equiv'' unmap_page_globals_equiv store_pte_globals_equiv
+             set_cap_globals_equiv' unmap_page_globals_equiv store_pte_globals_equiv
              store_pte_globals_equiv hoare_weak_lift_imp set_message_info_globals_equiv
-             unmap_page_valid_arch_state perform_pg_inv_get_addr_globals_equiv
-          | wpc | simp add: do_machine_op_bind sfence_def)+
+             perform_pg_inv_get_addr_globals_equiv
+          | wpc | simp add: do_machine_op_bind)+
   apply (clarsimp simp: acap_map_data_def)
   apply (intro conjI; clarsimp)
   apply (clarsimp split: arch_cap.splits)
@@ -1003,15 +1042,23 @@ lemma perform_pg_inv_unmap_globals_equiv:
   done
 
 lemma perform_pg_inv_map_globals_equiv:
-  "\<lbrace>invs and globals_equiv st and (\<lambda>s. table_base slot \<noteq> global_pt s)\<rbrace>
-   perform_pg_inv_map cap ct_slot pte slot
+  "\<lbrace>invs and globals_equiv st and (\<lambda>s. table_base (level_type lvl) slot \<noteq> global_pt s)\<rbrace>
+   perform_pg_inv_map cap ct_slot pte slot lvl
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  unfolding perform_pg_inv_map_def
-  by (wp mapM_swp_store_pte_globals_equiv hoare_vcg_all_lift mapM_x_swp_store_pte_globals_equiv
-         set_cap_globals_equiv'' unmap_page_globals_equiv store_pte_globals_equiv
+  unfolding perform_pg_inv_map_def cleanByVA_PoU_def
+  apply (wp mapM_swp_store_pte_globals_equiv hoare_vcg_all_lift mapM_x_swp_store_pte_globals_equiv
+         set_cap_globals_equiv' unmap_page_globals_equiv store_pte_globals_equiv
          store_pte_globals_equiv hoare_weak_lift_imp set_message_info_globals_equiv
-         unmap_page_valid_arch_state perform_pg_inv_get_addr_globals_equiv
-      | wpc | simp add: do_machine_op_bind sfence_def | fastforce)+
+          perform_pg_inv_get_addr_globals_equiv
+      | wpc | simp add: do_machine_op_bind | rule conjI; rule impI, wp hoare_drop_imps)+
+  apply fastforce
+  done
+
+lemma perform_flush_globals_equiv[wp]:
+  "perform_flush type vstart vend pstart space asid \<lbrace>globals_equiv st\<rbrace>"
+  unfolding perform_flush_def do_flush_def cleanCacheRange_RAM_def invalidateCacheRange_RAM_def
+            cleanInvalidateCacheRange_RAM_def cleanCacheRange_PoU_def invalidateCacheRange_I_def isb_def dsb_def
+  by (cases type; wpsimp wp: dmo_mol_reads_respects when_ev simp: dmo_distr)
 
 lemma perform_page_invocation_globals_equiv:
   "\<lbrace>invs and authorised_for_globals_page_inv pgi and valid_page_inv pgi
@@ -1025,7 +1072,6 @@ lemma perform_page_invocation_globals_equiv:
     apply (clarsimp simp: valid_page_inv_def same_ref_def)
     apply (drule vs_lookup_slot_table_base; clarsimp)
     apply (drule reachable_page_table_not_global, clarsimp+)
-    apply (fastforce dest: global_pt_in_global_refs[OF invs_valid_global_arch_objs])
    apply (clarsimp simp: valid_page_inv_def)
   apply clarsimp
   apply (fastforce dest: invs_valid_idle
@@ -1052,7 +1098,7 @@ lemma perform_asid_control_invocation_globals_equiv:
   apply (rule hoare_pre)
    apply wpc
    apply (rename_tac word1 cslot_ptr1 cslot_ptr2 word2)
-   apply (wp modify_wp cap_insert_globals_equiv''
+   apply (wp modify_wp cap_insert_globals_equiv
              retype_region_ASIDPoolObj_globals_equiv[simplified]
              retype_region_invs_extras(5)[where sz=pageBits]
              retype_region_invs_extras(6)[where sz=pageBits]
@@ -1094,8 +1140,7 @@ lemma perform_asid_control_invocation_globals_equiv:
     apply (simp add: word_bw_assocs pageBits_def mask_zero)
    apply (wp add: delete_objects_invs_ex delete_objects_pspace_no_overlap[where dev=False]
                   delete_objects_globals_equiv hoare_vcg_ex_lift
-             del: Untyped_AI.delete_objects_pspace_no_overlap
-          | simp add: page_bits_def)+
+             del: Untyped_AI.delete_objects_pspace_no_overlap | simp)+
   apply (clarsimp simp: conj_comms
                         invs_psp_aligned invs_valid_objs valid_aci_def)
   apply (clarsimp simp: cte_wp_at_caps_of_state)
@@ -1109,13 +1154,11 @@ lemma perform_asid_control_invocation_globals_equiv:
    apply (clarsimp simp: global_refs_def ptr_range_memI)
   apply (rule conjI)
    apply clarify
-   apply (frule global_pt_in_global_refs[OF invs_valid_global_arch_objs])
    apply (drule_tac p="global_pt sa" in ptr_range_memI)
    apply fastforce
   apply (rule conjI, fastforce simp: global_refs_def)
   apply (rule conjI)
    apply clarify
-   apply (frule global_pt_in_global_refs[OF invs_valid_global_arch_objs])
    apply fastforce
   apply (rule conjI)
    apply (drule untyped_slots_not_in_untyped_range)
@@ -1135,7 +1178,7 @@ lemma store_asid_pool_entry_globals_equiv:
    store_asid_pool_entry pool_ptr asid ptr
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding store_asid_pool_entry_def
-  by (wp modify_wp set_asid_pool_globals_equiv set_cap_globals_equiv'' get_cap_wp | wpc | simp)+
+  by (wp modify_wp set_asid_pool_globals_equiv set_cap_globals_equiv get_cap_wp | wpc | fastforce)+
 
 lemma perform_asid_pool_invocation_globals_equiv:
   "\<lbrace>globals_equiv s and invs and valid_apinv api\<rbrace>
@@ -1143,24 +1186,2254 @@ lemma perform_asid_pool_invocation_globals_equiv:
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding perform_asid_pool_invocation_def
   apply (rule hoare_weaken_pre)
-   apply (wp modify_wp set_asid_pool_globals_equiv set_cap_globals_equiv''
-             store_asid_pool_entry_globals_equiv copy_global_mappings_globals_equiv
-             copy_global_mappings_valid_arch_state get_cap_wp
+   apply (wp modify_wp set_asid_pool_globals_equiv set_cap_globals_equiv
+             store_asid_pool_entry_globals_equiv get_cap_wp
           | wpc | simp)+
   apply (clarsimp simp: valid_apinv_def cong: conj_cong)
-  apply (intro conjI; fastforce?)
-    apply (frule global_pt_in_global_refs[OF invs_valid_global_arch_objs])
-    apply (clarsimp simp: cte_wp_at_caps_of_state)
-    apply (frule (1) cap_not_in_valid_global_refs)
-    apply (clarsimp simp: acap_obj_def is_pt_cap_def split: arch_cap.splits)
-   apply (rule caps_of_state_aligned_page_table)
-    apply (fastforce simp: cte_wp_at_caps_of_state is_pt_cap_def is_PageTableCap_def
-                    split: option.splits)
-   apply clarsimp
-  apply (clarsimp simp: cte_wp_at_caps_of_state)
-  apply (frule (1) cap_not_in_valid_global_refs)
-  apply (clarsimp simp: acap_obj_def is_pt_cap_def split: arch_cap.splits)
   done
+
+crunch perform_vspace_invocation
+  for globals_equiv[wp]: "globals_equiv st"
+  (simp: sendSGI_def wp: dmo_mol_globals_equiv)
+
+lemma perform_sgi_invocation_globals_equiv[wp]:
+  "perform_sgi_invocation iv \<lbrace>globals_equiv s\<rbrace>"
+  unfolding perform_sgi_invocation_def sendSGI_def
+  by wpsimp
+
+lemma perform_vspace_invocation_reads_respects:
+  "reads_respects aag l \<top> (perform_vspace_invocation iv)"
+  unfolding perform_vspace_invocation_def
+  by (cases iv; wpsimp wp: perform_flush_reads_respects)
+
+
+(* Helpful groupings *)
+
+definition vcpu_enable_2 where
+  "vcpu_enable_2 vr \<equiv> do
+     vcpu_enable vr;
+     modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_current_vcpu := Some (vr, True)\<rparr>\<rparr>)
+   od"
+
+definition vcpu_restore_2 where
+  "vcpu_restore_2 vr \<equiv> do
+     vcpu_restore vr;
+     modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_current_vcpu := Some (vr, True)\<rparr>\<rparr>)
+   od"
+
+definition vcpu_disable_2 where
+  "vcpu_disable_2 vr \<equiv> do
+     vcpu_disable (Some vr);
+     modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_current_vcpu := Some (vr, False)\<rparr>\<rparr>)
+   od"
+
+definition vcpu_save_hcr where
+  "vcpu_save_hcr vr \<equiv> do
+     hcr <- do_machine_op get_gic_vcpu_ctrl_hcr;
+     vgic_update vr (vgic_hcr_update (\<lambda>_. hcr))
+   od"
+
+definition vcpu_save_vmcr where
+  "vcpu_save_vmcr vr \<equiv> do
+     vmcr <- do_machine_op get_gic_vcpu_ctrl_vmcr;
+     vgic_update vr (vgic_vmcr_update (\<lambda>_. vmcr))
+   od"
+
+definition vcpu_save_apr where
+  "vcpu_save_apr vr \<equiv> do
+     apr <- do_machine_op get_gic_vcpu_ctrl_apr;
+     vgic_update vr (vgic_apr_update (\<lambda>_. apr))
+   od"
+
+definition vcpu_save_lr where
+  "vcpu_save_lr vr reg \<equiv> do
+     lr <- do_machine_op (get_gic_vcpu_ctrl_lr (word_of_nat reg));
+     vgic_update_lr vr reg lr
+   od"
+
+definition vcpu_save_lrs where
+  "vcpu_save_lrs vr \<equiv> do
+     num_list_regs <- gets (arm_gicvcpu_numlistregs \<circ> arch_state);
+     return [0..<num_list_regs] >>= mapM (vcpu_save_lr vr);
+     return ()
+   od"
+
+lemmas vcpu_save_vgic_defs =
+  vcpu_save_hcr_def
+  vcpu_save_vmcr_def
+  vcpu_save_apr_def
+  vcpu_save_lr_def
+  vcpu_save_lrs_def
+
+
+(* FIXME AARCH64 IF: reads_respects and reads_respects_scheduler proofs are too specific to reuse.
+   To allow reuse, we introduce a more generic equiv_valid relation over states_equiv_for_labels.
+   Unfortunately, this means recreating much of the existing infrastructure. *)
+
+locale_abbrev reads_respects_l_2 where
+  "reads_respects_l_2 aag L \<equiv> equiv_valid_2 (\<lambda>_ _. True) (states_equiv_for_labels aag L) (states_equiv_for_labels aag L)"
+
+locale_abbrev reads_respects_l where
+  "reads_respects_l aag L \<equiv> equiv_valid_inv (\<lambda>_ _. True) (states_equiv_for_labels aag L)"
+
+lemma reads_respects_l_2_invisible:
+  "\<lbrakk> modifies_at_most aag {l. \<not>L l} Q f; modifies_at_most aag {l. \<not>L l} Q' g;
+     \<And>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace>; \<And>P. g \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace>;
+     \<forall>s t. P s \<and> P' t \<longrightarrow> (\<forall>(rva,s') \<in> fst (f s). \<forall>(rvb,t') \<in> fst (g t). R rva rvb) \<rbrakk>
+     \<Longrightarrow> reads_respects_l_2 aag L R (P and Q) (P' and Q') f g"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def modifies_at_most_def)
+  apply (rename_tac u s' v t')
+  apply (drule_tac x=s in spec)
+  apply (drule_tac x=t in spec)
+  apply (drule_tac x=s in spec)
+  apply (drule_tac x=t in spec)
+  apply clarsimp
+  apply (drule (1) bspec, clarsimp)+
+  apply (prop_tac "states_equiv_for_labels aag L s s'")
+   apply (subgoal_tac "equiv_for (\<lambda>x. \<exists>x\<in>pasDomainAbs aag x. L x) ready_queues s s'")
+    apply (clarsimp simp: equiv_but_for_labels_def states_equiv_for_def)
+   apply (clarsimp simp: equiv_for_def)
+   apply (erule use_valid, erule meta_allE, assumption)
+   apply simp
+  apply (prop_tac "states_equiv_for_labels aag L t t'")
+   apply (subgoal_tac "equiv_for (\<lambda>x. \<exists>x\<in>pasDomainAbs aag x. L x) ready_queues t t'")
+    apply (clarsimp simp: equiv_but_for_labels_def states_equiv_for_def)
+   apply (clarsimp simp: equiv_for_def)
+   apply (erule use_valid, erule meta_allE, assumption)
+   apply (erule use_valid, erule meta_allE, assumption)
+   apply simp
+  by (drule (1) states_equiv_for_trans,
+      drule states_equiv_for_sym,
+      drule (1) states_equiv_for_trans,
+      drule states_equiv_for_sym,
+      solves simp)
+
+lemma reads_respects_l_invisible:
+  "\<lbrakk> modifies_at_most aag {l. \<not>L l} Q f; \<And>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace>;
+     \<forall>s t. P s \<and> P t \<longrightarrow> (\<forall>(rva,s') \<in> fst (f s). \<forall>(rvb,t') \<in> fst (f t). rva = rvb) \<rbrakk>
+     \<Longrightarrow> reads_respects_l aag L (P and Q) f"
+  unfolding equiv_valid_def2 by (fastforce intro!: reads_respects_l_2_invisible)
+
+lemma reads_respects_l_unit_cases':
+  "\<lbrakk> reads_respects_l aag l (P and K (l (pasObjectAbs aag ptr))) f;
+     modifies_at_most aag {pasObjectAbs aag ptr} Q f; \<And>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+     \<Longrightarrow> reads_respects_l aag l (if l (pasObjectAbs aag ptr) then P else Q) (f :: (det_state,unit) nondet_monad)"
+  apply (case_tac "l (pasObjectAbs aag ptr)")
+   apply (erule equiv_valid_guard_imp, clarsimp)
+  apply clarsimp
+  apply (rule reads_respects_l_invisible[where P="\<top>", simplified])
+    apply (fastforce simp: modifies_at_most_def equiv_but_for_labels_def elim: states_equiv_for_guard_imp)
+   apply simp
+  apply simp
+  done
+
+lemmas reads_respects_l_unit_cases = reads_respects_l_unit_cases'[OF _ modifies_at_mostI]
+
+definition aag_can_affect_label_via where
+  "aag_can_affect_label_via aag l d \<equiv> aag_can_affect_label aag l \<and> d \<in> subjectReads (pasPolicy aag) l"
+
+locale_abbrev aag_can_read_or_affect_label where
+  "aag_can_read_or_affect_label aag l \<equiv> \<lambda>d.
+     aag_can_read_label aag d \<or> aag_can_affect_label_via aag l d"
+
+(* The states_equiv_for parts of reads_respects *)
+definition roa_equiv where
+  "roa_equiv aag l s s' \<equiv> states_equiv_for_labels aag (aag_can_read_or_affect_label aag l) s s'"
+
+(* The parts of reads_respects besides states_equiv_for *)
+definition roa_inv where
+  "roa_inv s s' \<equiv>
+     cur_thread s = cur_thread s' \<and>
+     cur_domain s = cur_domain s' \<and>
+     scheduler_action s = scheduler_action s' \<and>
+     work_units_completed s = work_units_completed s' \<and>
+     equiv_irq_state (machine_state s) (machine_state s')"
+
+lemma reads_equiv_for_labels:
+  "reads_equiv aag s s' \<longleftrightarrow> states_equiv_for_labels aag (aag_can_read_label aag) s s' \<and> roa_inv s s'"
+  by (auto simp: reads_equiv_def roa_inv_def states_equiv_for_def
+                 equiv_for_def equiv_asids_def equiv_hyp_def equiv_fpu_def)
+
+lemma affects_equiv_for_labels:
+  "affects_equiv aag l s s' \<longleftrightarrow> states_equiv_for_labels aag (aag_can_affect_label_via aag l) s s'"
+  by (auto intro: states_equiv_for_guard_imp[where P=\<bottom> and Q=\<bottom> and R=\<bottom> and S=\<bottom>]
+            simp: affects_equiv_def aag_can_affect_label_via_def states_equiv_for_def
+                  equiv_for_def equiv_asids_def equiv_hyp_False equiv_fpu_False)
+
+lemma roa_equiv_def2:
+  "roa_equiv aag l s s' \<longleftrightarrow> states_equiv_for_labels aag (aag_can_read_label aag) s s' \<and>
+                            states_equiv_for_labels aag (aag_can_affect_label_via aag l) s s'"
+  by (auto simp: roa_equiv_def states_equiv_for_def comp_def bex_disj_distrib
+                 equiv_for_disj equiv_asids_def equiv_fpu_def equiv_hyp_def)
+
+lemma reads_respects_def2:
+  "reads_respects aag l P f \<longleftrightarrow> equiv_valid_inv roa_inv (roa_equiv aag l) P f"
+  by (auto intro!: iff_allI
+             simp: equiv_valid_def2 equiv_valid_2_def roa_equiv_def2
+                   reads_equiv_for_labels affects_equiv_for_labels )
+
+lemma reads_respects_from_labels:
+  assumes ev: "\<And>L. reads_respects_l aag L P f"
+    and inv: "\<And>P. f \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace>"
+    "\<And>P. f \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace>"
+    "\<And>P. f \<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace>"
+    "\<And>P. f \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace>"
+    "\<And>P. f \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  shows "reads_respects aag l P f"
+  unfolding reads_respects_def2 roa_inv_def roa_equiv_def
+  apply (rule equiv_valid_inv_split)
+   apply (rule equiv_valid_rv_inv_lift)
+     apply (rule hoare_weaken_pre)
+      apply (wps inv)
+      apply wp
+     apply auto[3]
+  apply (fastforce intro: ev)
+  done
+
+lemma equiv_valid_guard_necessary:
+  assumes hoare: "\<lbrace>not P'\<rbrace> f \<lbrace>\<bottom>\<bottom>\<rbrace>"
+  and ev: "equiv_valid I A B (P and P') f"
+  shows "equiv_valid I A B P f"
+  using ev
+  apply (simp add: equiv_valid_def2 equiv_valid_2_def)
+  apply (erule all_forward)+
+  apply (fastforce dest: use_valid[OF _ hoare])
+  done
+
+lemma set_object_reads_respects_l:
+  "reads_respects_l aag L \<top> (set_object ptr obj)"
+  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def set_object_def get_object_def
+                       bind_def' get_def gets_def put_def return_def fail_def assert_def)
+  apply (erule states_equiv_for_identical_kheap_updates)
+  apply (clarsimp simp: identical_kheap_updates_def)
+  done
+
+lemma set_vcpu_reads_respects_l[wp]:
+  "reads_respects_l aag l \<top> (set_vcpu vr vcpu)"
+  unfolding set_vcpu_def
+  apply (rule_tac P'="vcpu_at vr" in equiv_valid_guard_necessary)
+   apply (rule wp_pre)
+    apply (rule hoare_set_object_weaken_pre)
+    apply wp
+   apply (clarsimp simp: obj_at_def)
+  apply (wpsimp wp: set_object_reads_respects_l)
+  done
+
+lemma get_vcpu_reads_respects_l[wp]:
+  "reads_respects_l aag l (K (l (pasObjectAbs aag vr))) (get_vcpu vr)"
+  unfolding get_vcpu_def gets_map_def
+  apply (subst gets_apply)
+  apply (wpsimp wp: gets_apply_ev)
+  apply (auto simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_for_def opt_map_def)
+  done
+
+(* equiv_but_for_labels proofs *)
+
+lemma set_vcpu_equiv_but_for_labels[wp]:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag vr \<in> L)\<rbrace>
+   set_vcpu vr vcpu
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding set_vcpu_def
+  apply (rule wp_pre)
+   apply (rule hoare_set_object_weaken_pre)
+   apply (wp set_object_equiv_but_for_labels)
+  apply (clarsimp simp: opt_map_def obj_at_def)
+  done
+
+lemma vcpu_update_equiv_but_for_labels[wp]:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag vr \<in> L)\<rbrace>
+   vcpu_update vr f
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vcpu_update_def by wpsimp
+
+lemma vgic_update_equiv_but_for_labels[wp]:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag vr \<in> L)\<rbrace>
+   vgic_update vr f
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vgic_update_def by wpsimp
+
+lemma vgic_update_lr_equiv_but_for_labels[wp]:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag vr \<in> L)\<rbrace>
+   vgic_update_lr vr reg irq
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vgic_update_lr_def by wpsimp
+
+lemma dmo_mol_equiv_but_for_labels[wp]:
+  "do_machine_op (machine_op_lift f) \<lbrace>equiv_but_for_labels aag L st\<rbrace>"
+  unfolding equiv_but_for_labels_def
+  by (wpsimp wp: do_machine_op_mol_states_equiv_for)
+
+lemma dmo_equiv_but_for_labels_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (underlying_memory ms)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (device_state ms)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (irq_state ms)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (vcpu_state ms)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (fpu_state ms)\<rbrace>"
+  shows "do_machine_op f \<lbrace>equiv_but_for_labels aag L st\<rbrace>"
+  unfolding equiv_but_for_labels_def states_equiv_for_def equiv_asids_def equiv_hyp_def equiv_fpu_def cur_fpu_for_def
+  by (wpsimp wp: equiv_for_lift2 assms dmo_wp)
+
+lemma dmo_equiv_but_for_labels_vcpu:
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (underlying_memory ms)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (device_state ms)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (irq_state ms)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (fpu_state ms)\<rbrace>"
+  shows "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+         do_machine_op f
+         \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding equiv_but_for_labels_def states_equiv_for_def equiv_asids_def equiv_hyp_def equiv_fpu_def cur_fpu_for_def
+  apply wp
+   apply clarsimp
+   apply (rule hoare_vcg_conj_lift, solves "wpsimp wp: equiv_for_lift2 assms dmo_wp")+
+   apply (rule hoare_vcg_conj_lift)
+    apply (rule_tac Q'="\<lambda>_ s. equiv_for (\<lambda>x. pasObjectAbs aag x \<notin> L) cur_vcpu_of st s \<and>
+                              cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None"
+                 in hoare_strengthen_post)
+     apply (wpsimp wp: equiv_for_lift2 assms dmo_wp)
+    defer
+    apply (wpsimp wp: equiv_for_lift2 assms dmo_wp)
+   apply clarsimp
+  apply (clarsimp simp: equiv_for_def cur_vcpu_for_def split: option.splits)
+   apply (clarsimp simp: cur_vcpu_of_def split: option.splits)
+  apply (clarsimp split: if_splits)
+  apply (erule_tac x=x in allE)
+  apply (clarsimp simp: cur_vcpu_of_def split: option.splits if_splits)
+  done
+
+lemma dmo_get_hcr_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s\<rbrace>
+   do_machine_op get_gic_vcpu_ctrl_hcr
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_lift)
+
+lemma dmo_set_hcr_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+   do_machine_op (set_gic_vcpu_ctrl_hcr val)
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_vcpu)
+
+lemma dmo_setSCTLR_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+   do_machine_op (setSCTLR val)
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_vcpu)
+
+lemma dmo_setHCR_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+   do_machine_op (setHCR val)
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_vcpu)
+
+lemma dmo_maskInterrupt_equiv_but_for_labels[wp]:
+  "do_machine_op (maskInterrupt b irq) \<lbrace>equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_lift)
+
+lemma dmo_check_export_arch_timer_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+   do_machine_op check_export_arch_timer
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_vcpu)
+
+lemma dmo_writeVCPUHardwareReg_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+   do_machine_op (writeVCPUHardwareReg reg val)
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_vcpu)
+
+lemma dmo_readVCPUHardwareReg_inv[wp]:
+  "do_machine_op (readVCPUHardwareReg reg) \<lbrace>P\<rbrace>"
+  by (wpsimp simp: readVCPUHardwareReg_def)
+
+lemma vcpu_save_reg_equiv_but_for_labels[wp]:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag vr \<in> L)\<rbrace>
+   vcpu_save_reg vr reg
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vcpu_save_reg_def
+  by wpsimp
+
+lemma save_virt_timer_equiv_but_for_labels[wp]:
+   "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> pasObjectAbs aag vr \<in> L \<and> cur_vcpu_of s vr \<noteq> None\<rbrace>
+   save_virt_timer vr
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding save_virt_timer_def
+  apply wpsimp
+  apply (clarsimp simp: cur_vcpu_for_def cur_vcpu_of_def split: option.splits if_splits)
+  done
+
+lemma dmo_enableFpuEL01_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+   do_machine_op enableFpuEL01
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_vcpu)
+
+lemma dmo_isb_equiv_but_for_labels[wp]:
+  "do_machine_op isb \<lbrace>equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_lift)
+
+lemma dmo_dsb_equiv_but_for_labels[wp]:
+  "do_machine_op dsb \<lbrace>equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_lift)
+
+lemma vcpu_disable_Some_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_of s vr \<noteq> None \<and> pasObjectAbs aag vr \<in> L\<rbrace>
+   vcpu_disable (Some vr) \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vcpu_disable_def
+  apply (clarsimp simp: dmo_distr)
+  apply wpsimp
+  apply (clarsimp simp: cur_vcpu_for_def cur_vcpu_of_def split: option.splits if_splits)
+  done
+
+lemma vcpu_save_reg_range_equiv_but_for_labels[wp]:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag vr \<in> L)\<rbrace>
+   vcpu_save_reg_range vr from to
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vcpu_save_reg_range_def
+  apply (rule hoare_gen_asm)
+  apply (wpsimp wp: mapM_x_wp_inv)
+  done
+
+lemma dmo_get_lr_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+   do_machine_op (get_gic_vcpu_ctrl_lr reg)
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_vcpu)
+
+lemma dmo_set_lr_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+   do_machine_op (set_gic_vcpu_ctrl_lr reg val)
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_vcpu)
+
+lemma dmo_get_apr_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s\<rbrace>
+   do_machine_op get_gic_vcpu_ctrl_apr
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_lift)
+
+lemma dmo_set_apr_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+   do_machine_op (set_gic_vcpu_ctrl_apr val)
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_vcpu)
+
+lemma dmo_get_vmcr_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s\<rbrace>
+   do_machine_op get_gic_vcpu_ctrl_vmcr
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_lift)
+
+lemma dmo_set_vmcr_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+   do_machine_op (set_gic_vcpu_ctrl_vmcr val)
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_vcpu)
+
+lemma vcpu_save_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> current_vcpu s = vopt \<and>
+        (\<exists>vr b. vopt = Some (vr,b) \<and> pasObjectAbs aag vr \<in> L)\<rbrace>
+   vcpu_save vopt \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vcpu_save_def
+  apply (case_tac vopt; clarsimp)
+  apply (wpsimp split_del: if_split simp: crunch_simps)
+          apply (rule_tac Q'="\<lambda>_ s. equiv_but_for_labels aag L st s \<and> pasObjectAbs aag a \<in> L \<and>
+                                    cur_vcpu_of s a \<noteq> None" in hoare_strengthen_post)
+           apply (wpsimp wp: mapM_wp_inv)
+           apply (clarsimp simp: cur_vcpu_for_def cur_vcpu_of_def split: option.splits if_splits)
+          apply clarsimp
+         apply (wpsimp simp: crunch_simps)+
+  apply (clarsimp simp: cur_vcpu_for_def cur_vcpu_of_def split: option.splits if_splits)
+  done
+
+lemma vcpu_restore_reg_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+  vcpu_restore_reg vr reg
+  \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vcpu_restore_reg_def
+  by wp
+
+lemma vcpu_restore_reg_range_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+  vcpu_restore_reg_range vr from to
+  \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vcpu_restore_reg_range_def
+  apply (rule hoare_strengthen_post, rule mapM_x_wp_inv)
+   apply (wpsimp wp: mapM_x_wp_inv)+
+  done
+
+lemma restore_virt_timer_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+  restore_virt_timer vr
+  \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding restore_virt_timer_def
+  by wpsimp
+
+lemma vcpu_enable_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+  vcpu_enable vr
+  \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp simp: vcpu_enable_def dmo_distr)
+
+crunch vcpu_restore_reg_range
+  for current_vcpu[wp]: "\<lambda>s. P (current_vcpu s)"
+  (wp: crunch_wps)
+
+lemma vcpu_restore_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+  vcpu_restore vr
+  \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: mapM_wp_inv simp: vcpu_restore_def dmo_distr dom_mapM)
+
+lemma modify_current_vcpu_equiv_but_for_labels:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> pasObjectAbs aag vr \<in> L \<and>
+        (\<forall>ptr b. current_vcpu s = Some (ptr,b) \<longrightarrow> pasObjectAbs aag ptr \<in> L)\<rbrace>
+   modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_current_vcpu := Some (vr,a)\<rparr>\<rparr>)
+   \<lbrace>\<lambda>_ s. equiv_but_for_labels aag L st s\<rbrace>"
+  apply wp
+  apply simp
+  apply (clarsimp simp: equiv_but_for_labels_def states_equiv_for_def equiv_for_def)
+  apply (intro conjI)
+    apply (clarsimp simp: equiv_asids_def equiv_asid_def)
+   defer
+   apply (clarsimp simp: equiv_fpu_def equiv_for_def cur_fpu_for_def get_tcb_def)
+  apply (clarsimp simp: equiv_hyp_def equiv_for_def)
+  apply (intro context_conjI; clarsimp)
+  apply (erule_tac x=x in allE)+
+  apply clarsimp
+  apply (case_tac "\<exists>b. current_vcpu s = Some (x, b)")
+   apply clarsimp
+  apply (fastforce simp: cur_vcpu_of_def split: option.splits if_splits)
+  done
+
+lemma vcpu_enable_2_equiv_but_for_labels:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> pasObjectAbs aag vr \<in> L \<and>
+        (\<forall>ptr b. current_vcpu s = Some (ptr,b) \<longrightarrow> pasObjectAbs aag ptr \<in> L)\<rbrace>
+   vcpu_enable_2 vr
+   \<lbrace>\<lambda>_ s. equiv_but_for_labels aag L st s\<rbrace>"
+  unfolding vcpu_enable_2_def
+  apply (wp modify_current_vcpu_equiv_but_for_labels)
+  apply (fastforce simp: cur_vcpu_for_def split: option.splits)
+  done
+
+lemma vcpu_restore_2_equiv_but_for_labels:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> pasObjectAbs aag vr \<in> L \<and>
+        (\<forall>ptr b. current_vcpu s = Some (ptr,b) \<longrightarrow> pasObjectAbs aag ptr \<in> L)\<rbrace>
+   vcpu_restore_2 vr
+   \<lbrace>\<lambda>_ s. equiv_but_for_labels aag L st s\<rbrace>"
+  unfolding vcpu_restore_2_def
+  apply (wp modify_current_vcpu_equiv_but_for_labels)
+  apply (fastforce simp: cur_vcpu_for_def split: option.splits)
+  done
+
+lemma vcpu_disable_2_equiv_but_for_labels:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> current_vcpu s = Some (vr, True) \<and> pasObjectAbs aag vr \<in> L\<rbrace>
+   vcpu_disable_2 vr
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vcpu_disable_2_def
+  apply (wp modify_current_vcpu_equiv_but_for_labels)
+  apply (clarsimp simp: cur_vcpu_of_def)
+  done
+
+
+lemma vcpu_update_reads_respects_l[wp]:
+  "reads_respects_l aag l \<top> (vcpu_update vr f)"
+  unfolding vcpu_update_def
+  apply (rule wp_pre)
+   apply (rule_tac ptr=vr in reads_respects_l_unit_cases)
+     apply wpsimp+
+  done
+
+lemma cur_vcpu_for_eq_Some[simp]:
+  "(cur_vcpu_for_2 P cv = Some b) = (\<exists>ptr. cv = Some (ptr,b) \<and> P ptr)"
+  by (clarsimp simp: cur_vcpu_for_def split: option.splits)
+
+lemma cur_vcpu_for_equiv_l:
+  "\<lbrakk> equiv_for P cur_vcpu_of st s \<rbrakk>
+     \<Longrightarrow> cur_vcpu_for P st = cur_vcpu_for P s"
+  apply (case_tac "current_vcpu st"; case_tac "current_vcpu s")
+  by (auto simp: cur_vcpu_for_None cur_vcpu_for_Some equiv_for_def cur_vcpu_of_def split: if_splits)
+
+lemma numlistregs_for_equiv_l:
+  "\<lbrakk> equiv_for P (K \<circ> numlistregs) st s \<rbrakk>
+     \<Longrightarrow> numlistregs_for P st = numlistregs_for P s"
+  by (auto simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def
+                 equiv_hyp_def equiv_for_def numlistregs_for_def)
+
+lemma do_machine_op_reads_respects_l':
+  assumes equiv_dmo:
+    "\<And>n cv cf. equiv_valid_inv (equiv_machine_state (l o pasObjectAbs aag)
+                                             and equiv_hyp_state n cv
+                                             and equiv_fpu_state cf)
+                             (equiv_machine_state (l o pasObjectAbs aag)) (Q n cv cf) f"
+  assumes guard:
+    "\<And>s. P s \<Longrightarrow> Q (numlistregs_for (l o pasObjectAbs aag) s) (cur_vcpu_for (l o pasObjectAbs aag) s)
+                    (cur_fpu_for (l o pasObjectAbs aag) s)
+                    (machine_state s)"
+  shows
+    "reads_respects_l aag l P (do_machine_op f)"
+  apply (rule use_spec_ev)
+  apply (rule spec_equiv_valid_add_A[OF _ states_equiv_for_refl])
+  apply (simp add: do_machine_op_def spec_equiv_valid_def)
+  apply (rule equiv_valid_2_guard_imp)
+    apply (rule_tac R'="\<lambda>rv rv'. equiv_machine_state (l o pasObjectAbs aag) rv rv' \<and>
+                                 equiv_hyp_state (numlistregs_for (l o pasObjectAbs aag) st)
+                                                 (cur_vcpu_for (l o pasObjectAbs aag) st) rv rv' \<and>
+                                 equiv_fpu_state (cur_fpu_for (l o pasObjectAbs aag) st) rv rv'"
+                and Q="\<lambda>r s. st = s \<and> Q (numlistregs_for (l o pasObjectAbs aag) st)
+                                        (cur_vcpu_for (l o pasObjectAbs aag) st)
+                                        (cur_fpu_for (l o pasObjectAbs aag) st) r"
+                and Q'="\<lambda>r s. Q (numlistregs_for (l o pasObjectAbs aag) st)
+                                (cur_vcpu_for (l o pasObjectAbs aag) st)
+                                (cur_fpu_for (l o pasObjectAbs aag) st) r"
+                and P="(=) st" and P'="\<top>" in equiv_valid_2_bind)
+       apply (rule gen_asm_ev2_l[simplified K_def pred_conj_def])
+       apply (rule gen_asm_ev2_r')
+       apply (rule_tac R'="\<lambda>(r, ms') (r', ms''). r = r' \<and>
+                             equiv_machine_state (l o pasObjectAbs aag) ms' ms'' \<and>
+                             equiv_hyp_state (numlistregs_for (l o pasObjectAbs aag) st)
+                                             (cur_vcpu_for (l o pasObjectAbs aag) st) ms' ms'' \<and>
+                             equiv_fpu_state (cur_fpu_for (l o pasObjectAbs aag) st) ms' ms''"
+                   and Q="\<lambda>r s. s = st" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
+            apply (clarsimp simp: modify_def get_def put_def bind_def return_def equiv_valid_2_def)
+            apply (rule states_equiv_for_machine_state_update)
+               apply clarsimp
+              apply (clarsimp simp: equiv_for_def)
+             apply (rule equiv_hyp_state_identical_hyp_state_updates)
+              apply (clarsimp simp: equiv_hyp_state_def cur_vcpu_for_def numlistregs_for_def
+                             split: option.splits if_splits)
+             apply (clarsimp simp: states_equiv_for_def)
+            apply (rule equiv_fpu_state_identical_fpu_state_updates)
+             apply (fastforce simp: equiv_fpu_state_def cur_fpu_for_def hw_fpu_def
+                             split: option.splits if_splits)
+            apply (clarsimp simp: states_equiv_for_def)
+           apply (insert equiv_dmo)[1]
+           apply (clarsimp simp: select_f_def equiv_valid_2_def equiv_valid_def2 split_def equiv_for_def)
+           apply (erule_tac x="numlistregs_for (l o pasObjectAbs aag) st" in meta_allE)
+           apply (erule_tac x="cur_vcpu_for (l o pasObjectAbs aag) st" in meta_allE)
+           apply (erule_tac x="cur_fpu_for (l o pasObjectAbs aag) st" in meta_allE)
+           apply (drule_tac x=rv in spec, drule_tac x=rv' in spec, fastforce)
+          apply wp
+         apply wp
+        apply clarsimp
+       apply clarsimp
+      apply (clarsimp simp: equiv_valid_2_def in_monad states_equiv_for_def equiv_hyp_def equiv_hyp_state_def comp_def)
+      apply (rule conjI)
+       apply (frule cur_vcpu_for_equiv_l)
+       apply (case_tac "cur_vcpu_for (l o pasObjectAbs aag) t"; clarsimp)
+        apply (clarsimp simp: cur_vcpu_for_def split: option.splits if_splits)
+       apply (clarsimp simp: equiv_for_def)
+       apply (erule_tac x=ptr in allE)+
+       apply (fastforce simp: cur_vcpu_for_Some cur_vcpu_of_def hw_vcpu_def numlistregs_for_def
+                       split: if_splits option.splits)
+      apply (fastforce simp: equiv_fpu_def equiv_fpu_state_def equiv_for_def hw_fpu_def cur_fpu_for_def
+                      split: if_splits)
+     apply (wpsimp wp: guard)+
+  apply (drule guard)
+  apply (clarsimp simp: states_equiv_for_def equiv_fpu_cur_fpu_for equiv_hyp_def
+                        cur_vcpu_for_equiv_l numlistregs_for_equiv_l comp_def)
+  done
+
+lemma do_machine_op_reads_respects_l:
+  assumes equiv_dmo:
+   "equiv_valid_inv (equiv_machine_state (l o pasObjectAbs aag)) (equiv_machine_state (l o pasObjectAbs aag)) \<top> f"
+  assumes hyp_state_inv:
+    "\<And>n cv ms. \<lbrace>equiv_hyp_state n cv ms\<rbrace> f \<lbrace>\<lambda>_. equiv_hyp_state n cv ms\<rbrace>"
+   assumes fpu_state_inv:
+    "\<And>cf ms. \<lbrace>equiv_fpu_state cf ms\<rbrace> f \<lbrace>\<lambda>_. equiv_fpu_state cf ms\<rbrace>"
+  shows
+    "reads_respects_l aag l \<top> (do_machine_op f)"
+ apply (rule do_machine_op_reads_respects_l'[where Q="\<lambda>_ _ _. \<top>"])
+   apply (insert equiv_dmo)
+  apply (clarsimp simp: equiv_valid_2_def equiv_valid_def2 equiv_for_or
+                  simp: split_def split: prod.splits simp: equiv_for_def)[1]
+   apply (rename_tac rv st rv' st')
+   apply (drule_tac x=s in spec, drule_tac x=t in spec)
+   apply clarsimp
+   apply (drule (1) bspec)+
+   apply clarsimp
+   apply (rule conjI)
+    apply (erule use_valid[OF _ hyp_state_inv])
+    apply (rule equiv_hyp_state_sym)
+    apply (erule use_valid[OF _ hyp_state_inv])
+    apply (erule equiv_hyp_state_sym)
+   apply (erule use_valid[OF _ fpu_state_inv])
+   apply (rule equiv_fpu_state_sym)
+   apply (erule use_valid[OF _ fpu_state_inv])
+   apply (erule equiv_fpu_state_sym)
+  apply simp
+  done
+
+lemma readVCPUHardwareReg_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. \<exists>b. cur_vcpu_for (l o pasObjectAbs aag) s = Some b \<and>
+                                   (vcpuRegSavedWhenDisabled reg \<longrightarrow> b))
+                          (do_machine_op (readVCPUHardwareReg reg))"
+  unfolding readVCPUHardwareReg_def
+  apply (wpsimp wp: do_machine_op_reads_respects_l')
+  apply (clarsimp simp: equiv_for_def equiv_hyp_state_def cur_vcpu_for_Some)
+  apply (case_tac b; clarsimp simp: hw_vcpu_def)
+  apply (drule_tac x=reg in fun_cong, clarsimp)
+  done
+
+lemma dmo_mol_reads_respects_l:
+  "reads_respects_l aag l \<top> (do_machine_op (machine_op_lift mop))"
+  apply (rule do_machine_op_reads_respects_l)
+    apply (rule equiv_valid_guard_imp[OF machine_op_lift_ev])
+    apply simp
+   apply wp+
+  done
+
+lemma writeVCPUHardwareReg_reads_respects_l[wp]:
+  "reads_respects_l aag l \<top> (do_machine_op (writeVCPUHardwareReg reg val))"
+  unfolding writeVCPUHardwareReg_def dmo_distr
+  apply (wpsimp wp: dmo_mol_reads_respects_l)
+    apply (wpsimp wp: do_machine_op_reads_respects_l' modify_ev)
+   apply wpsimp
+  apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def)
+  apply (case_tac "cur_vcpu_for (l \<circ> pasObjectAbs aag) s"; clarsimp simp: cur_vcpu_for_Some)
+  apply (clarsimp simp: hw_vcpu_def split: if_splits)
+   apply (intro conjI ext; drule_tac x=r in fun_cong; clarsimp)+
+  done
+
+lemma vcpu_save_reg_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. \<exists>b. current_vcpu s = Some (vr,b) \<and> (vcpuRegSavedWhenDisabled reg \<longrightarrow> b))
+                          (vcpu_save_reg vr reg)"
+  (is "reads_respects_l _ _ ?P _")
+  unfolding vcpu_save_reg_def
+  apply (rule wp_pre)
+   apply (rule_tac P="?P" and ptr=vr in reads_respects_l_unit_cases)
+     apply wpsimp+
+  done
+
+lemma vcpu_save_reg_range_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. \<exists>b. current_vcpu s = Some (vr,b))
+                          (vcpu_save_reg_range vr VCPURegTTBR0 VCPURegSPSR_EL1)"
+  (is "reads_respects_l _ _ ?P _")
+  unfolding vcpu_save_reg_range_def
+  apply (wpsimp wp: mapM_x_ev[where I="\<lambda>s. \<exists>b. current_vcpu s = Some (vr,b)"])
+    apply (auto simp: upto_enum_def fromEnum_def enum_vcpureg toEnum_def vcpuRegSavedWhenDisabled_def)[1]
+   apply wpsimp+
+  done
+
+lemma get_gic_vcpu_ctrl_hcr_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. \<exists>b. cur_vcpu_for (l o pasObjectAbs aag) s = Some True)
+                          (do_machine_op (get_gic_vcpu_ctrl_hcr))"
+  unfolding get_gic_vcpu_ctrl_hcr_def dmo_distr
+  apply (rule use_spec_ev)
+  apply (wpsimp wp: do_machine_op_reads_respects_l')
+  apply (clarsimp simp: equiv_for_def equiv_hyp_state_def cur_vcpu_for_Some hw_vcpu_def)
+  done
+
+lemma get_gic_vcpu_ctrl_vmcr_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. \<exists>b. cur_vcpu_for (l o pasObjectAbs aag) s = Some b)
+                          (do_machine_op (get_gic_vcpu_ctrl_vmcr))"
+  unfolding get_gic_vcpu_ctrl_vmcr_def dmo_distr
+  apply (rule use_spec_ev)
+  apply (wpsimp wp: do_machine_op_reads_respects_l')
+  apply (clarsimp simp: equiv_for_def equiv_hyp_state_def cur_vcpu_for_Some hw_vcpu_def)
+  done
+
+lemma get_gic_vcpu_ctrl_apr_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. \<exists>b. cur_vcpu_for (l o pasObjectAbs aag) s = Some b)
+                          (do_machine_op (get_gic_vcpu_ctrl_apr))"
+  unfolding get_gic_vcpu_ctrl_apr_def dmo_distr
+  apply (rule use_spec_ev)
+  apply (wpsimp wp: do_machine_op_reads_respects_l')
+  apply (clarsimp simp: equiv_for_def equiv_hyp_state_def cur_vcpu_for_Some hw_vcpu_def)
+  done
+
+lemma cur_fpu_for_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (arch_state s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (cur_fpu_for Q s)\<rbrace>"
+  unfolding cur_fpu_for_def
+  by (wp assms)
+
+lemma numlistregs_for_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (numlistregs s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. P (numlistregs_for Q s)\<rbrace>"
+  unfolding numlistregs_for_def
+  by (wp assms)
+
+lemma get_gic_vcpu_ctrl_lr_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. (\<exists>b. cur_vcpu_for (l o pasObjectAbs aag) s = Some b) \<and>
+                               unat reg < numlistregs s)
+                          (do_machine_op (get_gic_vcpu_ctrl_lr reg))"
+  unfolding get_gic_vcpu_ctrl_lr_def dmo_distr
+  apply wp
+     apply (rule use_spec_ev)
+     apply (wpsimp wp: do_machine_op_reads_respects_l')
+    apply (wpsimp wp: dmo_mol_reads_respects_l)
+   apply (rule hoare_lift_Pf[where f="numlistregs_for _"])
+    apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift cur_fpu_for_lift)
+   apply (wpsimp wp: numlistregs_for_lift)
+  apply (clarsimp simp: equiv_for_def equiv_hyp_state_def cur_vcpu_for_Some hw_vcpu_def)
+  apply (drule_tac x="unat reg" in fun_cong)+
+  apply (clarsimp simp: numlistregs_for_def split: if_splits)
+  done
+
+lemma vgic_update_reads_respects_l[wp]:
+  "reads_respects_l aag l \<top> (vgic_update vr f)"
+  unfolding vgic_update_def by wp
+
+lemma vgic_lr_update_reads_respects_l[wp]:
+  "reads_respects_l aag l \<top> (vgic_update_lr vr reg irq)"
+  unfolding vgic_update_lr_def by wp
+
+lemma vcpu_save_hcr_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. current_vcpu s = Some (vr,True))
+                          (vcpu_save_hcr vr)"
+  (is "reads_respects_l _ _ ?P _")
+  unfolding vcpu_save_hcr_def
+  apply (rule wp_pre)
+   apply (rule_tac P="?P" and ptr=vr in reads_respects_l_unit_cases)
+     apply (wpsimp simp: get_gic_vcpu_ctrl_hcr_def)+
+  done
+
+lemma vcpu_save_vmcr_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. \<exists>b. current_vcpu s = Some (vr,b))
+                        (vcpu_save_vmcr vr)"
+  (is "reads_respects_l _ _ ?P _")
+  unfolding vcpu_save_vmcr_def
+  apply (rule wp_pre)
+   apply (rule_tac P="?P" and ptr=vr in reads_respects_l_unit_cases)
+     apply (wpsimp simp: get_gic_vcpu_ctrl_vmcr_def)+
+  done
+
+lemma vcpu_save_apr_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. \<exists>b. current_vcpu s = Some (vr,b))
+                        (vcpu_save_apr vr)"
+  (is "reads_respects_l _ _ ?P _")
+  unfolding vcpu_save_apr_def
+  apply (rule wp_pre)
+   apply (rule_tac P="?P" and ptr=vr in reads_respects_l_unit_cases)
+     apply wpsimp+
+  done
+
+lemma vcpu_save_lr_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. (\<exists>b. current_vcpu s = Some (vr,b)) \<and> valid_numlistregs s \<and> reg < numlistregs s)
+                          (vcpu_save_lr vr reg)"
+  (is "reads_respects_l _ _ ?P _")
+  unfolding vcpu_save_lr_def
+  apply (rule wp_pre)
+   apply (rule_tac P="?P" and ptr=vr in reads_respects_l_unit_cases)
+     apply wpsimp
+     apply (clarsimp simp: valid_numlistregs_def)
+     apply (simp add: unat_of_nat64)
+    apply wpsimp
+    apply assumption
+   apply wpsimp
+  apply (clarsimp simp: cur_vcpu_for_def)
+  done
+
+crunch vcpu_save_hcr, vcpu_save_vmcr, vcpu_save_apr, vcpu_save_lr, vcpu_save_lrs
+  for arch_state[wp]: "\<lambda>s. P (arch_state s)"
+  (wp: mapM_wp_inv)
+
+lemma vcpu_save_lrs_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. (\<exists>b. current_vcpu s = Some (vr,b)) \<and> valid_numlistregs s)
+                          (vcpu_save_lrs vr)"
+  (is "reads_respects_l _ _ ?P _")
+  unfolding vcpu_save_lrs_def
+  apply (rule wp_pre)
+   apply (rule_tac P="?P" and ptr=vr in reads_respects_l_unit_cases)
+     apply (wpsimp wp: mapM_ev)
+            apply (rule wp_pre)
+             apply wpsimp
+            apply (prop_tac "\<forall>x \<in> set rva. x < numlistregs s")
+             apply (erule conjunct1)
+            apply clarsimp
+            apply assumption
+           apply wpsimp+
+     apply (fastforce simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_hyp_def equiv_for_def)
+    apply (wpsimp wp: mapM_wp_inv simp: vcpu_save_lr_def get_gic_vcpu_ctrl_lr_def dmo_distr)+
+  done
+
+lemma equiv_valid_cases'':
+  "\<lbrakk> \<And>s t. \<lbrakk> A s t; I s t; R s; R t \<rbrakk> \<Longrightarrow> P s = P t;
+     equiv_valid I A B (R and P) f; equiv_valid I A B ((\<lambda>s. \<not>P s) and R) f \<rbrakk>
+     \<Longrightarrow> equiv_valid I A B R f"
+  by (fastforce simp: equiv_valid_def2 equiv_valid_2_def)
+
+lemma hw_vcpu_Some_True[simp]:
+  "hw_vcpu n (Some True) vst = Some (vcpu_mask n vst)"
+  apply (clarsimp simp: hw_vcpu_def)
+  apply (rule vcpu_state.equality; clarsimp)
+  apply (rule gic_vcpu_interface.equality; clarsimp)
+  apply (rule ext; clarsimp)
+  done
+
+lemma vcpu_mask_regs_update[simp]:
+  "vcpu_mask n (vcpu_regs_update f vst) = vcpu_regs_update f (vcpu_mask n vst)"
+  by (rule vcpu_state.equality; clarsimp)
+
+lemma check_export_arch_timer_reads_respects_l'':
+  "reads_respects_l aag l (\<lambda>s. cur_vcpu_for (l o pasObjectAbs aag) s = None)
+                          (do_machine_op check_export_arch_timer)"
+  (is "reads_respects_l _ _ ?P _")
+   unfolding check_export_arch_timer_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects_l)
+     apply (rule do_machine_op_reads_respects_l')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_def)
+    apply wpsimp+
+   done
+
+lemma check_export_arch_timer_reads_respects_l':
+  "reads_respects_l aag l (\<lambda>s. \<exists>vr. cur_vcpu_for (l o pasObjectAbs aag) s = Some True)
+                          (do_machine_op check_export_arch_timer)"
+  (is "reads_respects_l _ _ ?P _")
+   unfolding check_export_arch_timer_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects_l)
+     apply (rule do_machine_op_reads_respects_l')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_Some)
+    apply wpsimp+
+   done
+
+lemma cur_vcpu_for_None':
+  "(cur_vcpu_for P s = None) = (\<forall>vr. P vr \<longrightarrow> cur_vcpu_of s vr = None)"
+  by (auto simp: cur_vcpu_for_def cur_vcpu_of_def split: option.splits)
+
+lemma check_export_arch_timer_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. \<exists>vr. current_vcpu s = Some (vr,True))
+                          (do_machine_op check_export_arch_timer)"
+  (is "reads_respects_l _ _ ?P _")
+  apply (rule_tac P="\<lambda>s. cur_vcpu_for (l o pasObjectAbs aag) s = None" in equiv_valid_cases'')
+    apply (prop_tac "equiv_hyp (l o pasObjectAbs aag) s t")
+     apply (auto simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_hyp_def equiv_for_def)[1]
+    apply (auto simp: cur_vcpu_for_None' equiv_hyp_def equiv_for_def)[1]
+   apply (wpsimp wp: check_export_arch_timer_reads_respects_l'')
+  apply (wpsimp wp: check_export_arch_timer_reads_respects_l')
+  done
+
+lemma save_virt_timer_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. current_vcpu s = Some (vr,True))
+                          (save_virt_timer vr)"
+  (is "reads_respects_l _ _ ?P _")
+  unfolding save_virt_timer_def
+  apply (wpsimp wp: vcpu_save_reg_reads_respects_l)
+  apply auto
+  done
+
+lemma dmo_dsb_reads_respects_l[wp]:
+  "reads_respects_l aag l \<top> (do_machine_op dsb)"
+  unfolding dsb_def
+  by (wpsimp wp: dmo_mol_reads_respects_l)
+
+lemma dmo_isb_reads_respects_l[wp]:
+  "reads_respects_l aag l \<top> (do_machine_op isb)"
+  unfolding isb_def
+  by (wpsimp wp: dmo_mol_reads_respects_l)
+
+lemma dmo_setHCR_reads_respects_l[wp]:
+  "reads_respects_l aag l \<top> (do_machine_op (setHCR val))"
+  unfolding setHCR_def
+  by (wpsimp wp: dmo_mol_reads_respects_l)
+
+lemma vcpu_save_lrs_helper:
+  "do (do num_list_regs <- gets (arm_gicvcpu_numlistregs \<circ> arch_state);
+                        return [0..<num_list_regs] >>= mapM (vcpu_save_lr vr)
+       od);
+      m
+   od = do vcpu_save_lrs vr; m od"
+  by (simp add: vcpu_save_lrs_def bind_assoc)
+
+lemma bind_assoc_helper:
+  "(do x <- f;
+       y <- g x;
+       (z y :: ('s,unit) nondet_monad)
+    od) =
+   (do y <- (f >>= g);
+       z y od)"
+  by (simp add: bind_assoc)
+
+lemma vcpu_save_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. current_vcpu s = cv \<and> valid_numlistregs s) (vcpu_save cv)"
+  apply (simp only: vcpu_save_def fun_app_def bind_assoc_helper vcpu_save_vgic_defs[symmetric] vcpu_save_lrs_helper)
+  apply (wpsimp wp: when_ev mapM_ev mapM_wp_inv)+
+  apply auto
+  done
+
+lemma dmo_maskInterrupt_reads_respects_l[wp]:
+  "reads_respects_l aag l \<top> (do_machine_op (maskInterrupt m irq))"
+  unfolding maskInterrupt_def
+  apply (rule use_spec_ev)
+  apply (wpsimp wp: do_machine_op_reads_respects_l' modify_ev)
+  apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def)
+  done
+
+lemma enableFpuEL01_reads_respects_l'':
+  "reads_respects_l aag l (\<lambda>s. cur_vcpu_for (l o pasObjectAbs aag) s = None)
+                          (do_machine_op enableFpuEL01)"
+  (is "reads_respects_l _ _ ?P _")
+   unfolding enableFpuEL01_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects_l)
+     apply (rule do_machine_op_reads_respects_l')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_def)
+    apply wpsimp+
+   done
+
+lemma enableFpuEL01_reads_respects_l':
+  "reads_respects_l aag l (\<lambda>s. \<exists>vr. cur_vcpu_for (l o pasObjectAbs aag) s = Some True)
+                          (do_machine_op enableFpuEL01)"
+  (is "reads_respects_l _ _ ?P _")
+   unfolding enableFpuEL01_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects_l)
+     apply (rule do_machine_op_reads_respects_l')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_Some)
+    apply wpsimp+
+   done
+
+lemma enableFpuEL01_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. \<forall>vr b. current_vcpu s = Some (vr,b) \<longrightarrow> b)
+                          (do_machine_op enableFpuEL01)"
+  (is "reads_respects_l _ _ ?P _")
+  apply (rule_tac P="\<lambda>s. cur_vcpu_for (l o pasObjectAbs aag) s = None" in equiv_valid_cases'')
+    apply (prop_tac "equiv_hyp (l o pasObjectAbs aag) s t")
+     apply (auto simp: states_equiv_for_def equiv_hyp_def equiv_for_def)[1]
+    apply (auto simp: cur_vcpu_for_None' equiv_hyp_def equiv_for_def)[1]
+   apply (wpsimp wp: enableFpuEL01_reads_respects_l'')
+  apply (wpsimp wp: enableFpuEL01_reads_respects_l')
+  done
+
+lemma setSCTLR_reads_respects_l'':
+  "reads_respects_l aag l (\<lambda>s. cur_vcpu_for (l o pasObjectAbs aag) s = None)
+                          (do_machine_op (setSCTLR val))"
+  (is "reads_respects_l _ _ ?P _")
+   unfolding setSCTLR_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects_l)
+     apply (rule do_machine_op_reads_respects_l')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_def)
+    apply wpsimp+
+   done
+
+lemma setSCTLR_reads_respects_l':
+  "reads_respects_l aag l (\<lambda>s. \<exists>vr. cur_vcpu_for (l o pasObjectAbs aag) s = Some True)
+                          (do_machine_op (setSCTLR val))"
+  (is "reads_respects_l _ _ ?P _")
+   unfolding setSCTLR_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects_l)
+     apply (rule do_machine_op_reads_respects_l')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_Some)
+    apply wpsimp+
+   done
+
+lemma setSCTLR_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. \<forall>vr b. current_vcpu s = Some (vr,b) \<longrightarrow> b)
+                          (do_machine_op (setSCTLR val))"
+  (is "reads_respects_l _ _ ?P _")
+  apply (rule_tac P="\<lambda>s. cur_vcpu_for (l o pasObjectAbs aag) s = None" in equiv_valid_cases'')
+    apply (prop_tac "equiv_hyp (l o pasObjectAbs aag) s t")
+     apply (auto simp: states_equiv_for_def equiv_hyp_def equiv_for_def)[1]
+    apply (auto simp: cur_vcpu_for_None' equiv_hyp_def equiv_for_def)[1]
+   apply (wpsimp wp: setSCTLR_reads_respects_l'')
+  apply (wpsimp wp: setSCTLR_reads_respects_l')
+  done
+
+lemma set_gic_vcpu_ctrl_hcr_reads_respects_l'':
+  "reads_respects_l aag l (\<lambda>s. cur_vcpu_for (l o pasObjectAbs aag) s = None)
+                          (do_machine_op (set_gic_vcpu_ctrl_hcr val))"
+  (is "reads_respects_l _ _ ?P _")
+   unfolding set_gic_vcpu_ctrl_hcr_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects_l)
+     apply (rule do_machine_op_reads_respects_l')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_def)
+    apply wpsimp+
+   done
+
+lemma vcpu_mask_hcr_update[simp]:
+  "vcpu_mask n (vcpu_vgic_update (vgic_hcr_update f) vst) = vcpu_vgic_update (vgic_hcr_update f) (vcpu_mask n vst)"
+  by (rule vcpu_state.equality; clarsimp)
+
+lemma set_gic_vcpu_ctrl_hcr_reads_respects_l':
+  "reads_respects_l aag l (\<lambda>s. \<exists>vr. cur_vcpu_for (l o pasObjectAbs aag) s = Some True)
+                          (do_machine_op (set_gic_vcpu_ctrl_hcr val))"
+  (is "reads_respects_l _ _ ?P _")
+   unfolding set_gic_vcpu_ctrl_hcr_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects_l)
+     apply (rule do_machine_op_reads_respects_l')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_Some)
+    apply wpsimp+
+   done
+
+lemma set_gic_vcpu_ctrl_hcr_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. \<forall>vr b. current_vcpu s = Some (vr,b) \<longrightarrow> b)
+                          (do_machine_op (set_gic_vcpu_ctrl_hcr val))"
+  (is "reads_respects_l _ _ ?P _")
+  apply (rule_tac P="\<lambda>s. cur_vcpu_for (l o pasObjectAbs aag) s = None" in equiv_valid_cases'')
+    apply (prop_tac "equiv_hyp (l o pasObjectAbs aag) s t")
+     apply (auto simp: states_equiv_for_def equiv_hyp_def equiv_for_def)[1]
+    apply (auto simp: cur_vcpu_for_None' equiv_hyp_def equiv_for_def)[1]
+   apply (wpsimp wp: set_gic_vcpu_ctrl_hcr_reads_respects_l'')
+  apply (wpsimp wp: set_gic_vcpu_ctrl_hcr_reads_respects_l')
+  done
+
+lemma vcpu_disable_Some_reads_respects_l[wp]:
+  "reads_respects_l aag l (\<lambda>s. current_vcpu s = Some (vr,True)) (vcpu_disable (Some vr))"
+  apply (simp only: vcpu_disable_def fun_app_def bind_assoc_helper vcpu_save_vgic_defs[symmetric] vcpu_save_lrs_helper)
+  apply (clarsimp simp: dmo_distr)
+  apply (wpsimp wp: when_ev mapM_ev mapM_wp_inv)+
+  apply auto
+  done
+
+definition states_equiv_for_non_hyp ::
+  "(obj_ref \<Rightarrow> bool) \<Rightarrow> (irq \<Rightarrow> bool) \<Rightarrow> (asid \<Rightarrow> bool) \<Rightarrow>
+   (domain \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "states_equiv_for_non_hyp P Q R S s s' \<equiv>
+     equiv_for P kheap s s' \<and>
+     equiv_machine_state P (machine_state s) (machine_state s') \<and>
+     equiv_for (P \<circ> fst) cdt s s' \<and>
+     equiv_for (P \<circ> fst) cdt_list s s' \<and>
+     equiv_for (P \<circ> fst) is_original_cap s s' \<and>
+     equiv_for Q interrupt_states s s' \<and>
+     equiv_for Q interrupt_irq_node s s' \<and>
+     equiv_for S  ready_queues s s' \<and>
+     equiv_asids R s s' \<and>
+     equiv_fpu P s s'"
+
+lemma states_equiv_for_non_hyp_refl:
+  "states_equiv_for_non_hyp P Q R S s s"
+  by (auto simp: states_equiv_for_non_hyp_def intro: equiv_for_refl equiv_asids_refl equiv_hyp_refl equiv_fpu_refl)
+
+lemma states_equiv_for_non_hyp_sym:
+  "states_equiv_for_non_hyp P Q R S s t \<Longrightarrow> states_equiv_for_non_hyp P Q R S t s"
+  by (auto simp: states_equiv_for_non_hyp_def intro: equiv_for_sym equiv_asids_sym equiv_hyp_sym equiv_fpu_sym)
+
+lemma states_equiv_for_non_hyp_trans:
+  "\<lbrakk> states_equiv_for_non_hyp P Q R S s t; states_equiv_for_non_hyp P Q R S t u \<rbrakk>
+     \<Longrightarrow> states_equiv_for_non_hyp P Q R S s u"
+  by (auto simp: states_equiv_for_non_hyp_def
+          intro: equiv_for_trans equiv_asids_trans equiv_hyp_trans equiv_fpu_trans equiv_forI
+           elim: equiv_forE)
+
+lemma states_equiv_for_non_hyp_lift:
+  assumes "\<And>st. f \<lbrace>\<lambda>s. equiv_for P kheap st s\<rbrace>"
+  assumes "\<And>ms. f \<lbrace>\<lambda>s. equiv_machine_state P ms (machine_state s)\<rbrace>"
+  assumes "\<And>st. f \<lbrace>\<lambda>s. equiv_for (P \<circ> fst) cdt st s\<rbrace>"
+  assumes "\<And>st. f \<lbrace>\<lambda>s. equiv_for (P \<circ> fst) cdt_list st s\<rbrace>"
+  assumes "\<And>st. f \<lbrace>\<lambda>s. equiv_for (P \<circ> fst) is_original_cap st s\<rbrace>"
+  assumes "\<And>st. f \<lbrace>\<lambda>s. equiv_for Q interrupt_states st s\<rbrace>"
+  assumes "\<And>st. f \<lbrace>\<lambda>s. equiv_for Q interrupt_irq_node st s\<rbrace>"
+  assumes "\<And>st. f \<lbrace>\<lambda>s. equiv_for S  ready_queues st s\<rbrace>"
+  assumes "\<And>st. f \<lbrace>\<lambda>s. equiv_asids R st s\<rbrace>"
+  assumes "\<And>st. f \<lbrace>\<lambda>s. equiv_fpu P st s\<rbrace>"
+  shows "f \<lbrace>states_equiv_for_non_hyp P Q R S st\<rbrace>"
+  unfolding states_equiv_for_non_hyp_def
+  apply (rule hoare_weaken_pre)
+   apply (rule hoare_vcg_conj_lift, rule assms)+
+   apply (rule assms)
+  apply simp
+  done
+
+crunch vcpu_switch
+  for is_original_cap[wp]: "\<lambda>s. P (is_original_cap s)"
+  and interrupt_states[wp]: "\<lambda>s. P (interrupt_states s)"
+  (wp: crunch_wps)
+
+lemma equiv_asids_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_pools_of s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (asid_table s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. equiv_asids R st s\<rbrace>"
+  unfolding equiv_asids_def equiv_asid_def asid_pools_at_eq
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift assms)
+  apply auto
+  done
+
+crunch vcpu_switch
+  for asid_pools[wp]: "\<lambda>s. P (asid_pools_of s)"
+  (wp: crunch_wps)
+
+lemma equiv_fpu_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (fpu_state (machine_state s))\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (current_fpu s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. equiv_fpu P st s\<rbrace>"
+  apply (clarsimp simp: valid_def equiv_fpu_def equiv_for_def)
+  apply (erule_tac x=x in allE, clarsimp)
+  apply (frule_tac P="\<lambda>s'. fpu_state (machine_state s') = fpu_state (machine_state s)" in use_valid)
+    apply (rule assms(1))
+   apply simp
+  apply (drule_tac P="\<lambda>s'. current_fpu s' = current_fpu s" in use_valid)
+    apply (rule assms(2))
+   apply simp
+  apply (clarsimp simp: equiv_fpu_def opt_map_def fpu_of_state_def cur_fpu_for_def get_tcb_def
+                 split: option.splits kernel_object.splits if_splits)
+  done
+
+crunch vcpu_restore
+  for kheap[wp]: "\<lambda>s. P (kheap s)"
+  and fpu_state[wp]: "\<lambda>s. P (fpu_state (machine_state s))"
+  and underlying_memory[wp]: "\<lambda>s. P (underlying_memory (machine_state s))"
+  and device_state[wp]: "\<lambda>s. P (device_state (machine_state s))"
+  (wp: crunch_wps dmo_wp simp: crunch_simps)
+
+lemma equiv_machine_state_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (underlying_memory (machine_state s))\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P  (device_state (machine_state s))\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. equiv_machine_state P ms (machine_state s)\<rbrace>"
+  by (wpsimp wp: assms equiv_for_lift2)
+
+lemma vcpu_restore_states_equiv_for_non_hyp[wp]:
+  "vcpu_restore vopt \<lbrace>states_equiv_for_non_hyp P Q R S st\<rbrace>"
+  apply (rule states_equiv_for_non_hyp_lift)
+           defer
+           defer
+           apply (rule equiv_for_lift, (wpsimp; fail))+
+     apply (rule equiv_asids_lift)
+      apply wpsimp
+     apply wpsimp
+    apply (rule equiv_fpu_lift)
+     apply (wpsimp simp: get_tcb_def wp: equiv_for_lift)+
+  apply (wpsimp wp: equiv_machine_state_lift)
+  done
+
+lemma equiv_valid_split:
+  assumes "equiv_valid I A B P f"
+  assumes "equiv_valid I' A' B' P' f"
+  shows "equiv_valid (\<lambda>s s'. I s s' \<and> I' s s') (\<lambda>s s'. A s s' \<and> A' s s')
+                     (\<lambda>s s'. B s s' \<and> B' s s') (\<lambda>s. P s \<and> P' s) f"
+  using assms by (fastforce simp: equiv_valid_def2 equiv_valid_2_def)
+
+definition vmask where
+  "vmask \<equiv> vcpu_mask"
+
+lemma vcpus_of_vcpu_proj:
+  "vcpus_of s vr = Some vcpu
+   \<Longrightarrow> vcpu_proj UNIV UNIV True True True vr s = Some (vmask (numlistregs s) vcpu)"
+  by (clarsimp simp: vcpu_proj_def vmask_def cong: if_cong)
+
+lemma vmask_truncate_helper:
+  "vmask (numlistregs s) (vcpu_state.truncate vcpu) =
+   vcpu_state.truncate (vmask (numlistregs s) vcpu)"
+  by (clarsimp simp: vmask_def vcpu_state.defs)
+
+lemma vcpu_restore_vcpu_proj':
+  "\<lbrace>\<lambda>s. vopt = vcpu_proj UNIV UNIV True True True vr s \<and> valid_arch_state s\<rbrace>
+    vcpu_restore vr
+    \<lbrace>\<lambda>_ s. vopt = vcpu_proj {} {} False False False vr s\<rbrace>"
+  by (wpsimp wp: vcpu_restore_vcpu_proj)
+
+lemma vcpu_restore_helper:
+  "\<lbrace>\<lambda>s. vcpus_of s vr = Some vcpu \<and> valid_arch_state s\<rbrace>
+   vcpu_restore vr
+   \<lbrace>\<lambda>_ s. vmask (numlistregs s) (vcpu_state.truncate vcpu) = vmask (numlistregs s) (vcpu_state (machine_state s))\<rbrace>"
+  apply (rule_tac Q'="\<lambda>_ s. vcpus_of s vr = Some vcpu \<and> Some (vmask (numlistregs s) vcpu) = vcpu_proj {} {} False False False vr s" in hoare_strengthen_post)
+   apply (rule_tac P'="\<lambda>s. vcpus_of s vr = Some vcpu \<and> Some (vmask (numlistregs s) vcpu) = vcpu_proj UNIV UNIV True True True vr s \<and> valid_arch_state s" in hoare_weaken_pre)
+    apply (rule hoare_weaken_pre)
+     apply (rule hoare_vcg_conj_lift)
+      apply wpsimp
+     apply wps
+     apply (wp vcpu_restore_vcpu_proj')
+    apply clarsimp
+   apply clarsimp
+   apply (drule vcpus_of_vcpu_proj)
+   apply simp
+  apply clarsimp
+  apply (clarsimp simp: vmask_truncate_helper)
+  apply (clarsimp simp: vcpu_proj_def vcpu_state.defs vmask_def cong: if_cong)
+  done
+
+
+lemma vcpu_restore_2_helper:
+  "\<lbrace>\<lambda>s. vcpus_of s vr = Some vcpu \<and> valid_arch_state s\<rbrace>
+   vcpu_restore_2 vr
+   \<lbrace>\<lambda>_ s. hw_vcpu_of s vr = Some (vcpu_mask (numlistregs s) (vcpu_state.truncate vcpu))\<rbrace>"
+  unfolding vcpu_restore_2_def
+apply (rule_tac Q'="\<lambda>_ s. vcpu_mask (numlistregs s) (vcpu_state.truncate vcpu) = vcpu_mask (numlistregs s) (vcpu_state (machine_state s)) \<and>
+     current_vcpu s = Some (vr,True)" in hoare_strengthen_post)
+   apply wp
+    apply (rule hoare_vcg_conj_lift)
+     apply simp
+     apply (wp vcpu_restore_helper[simplified vmask_def])
+    apply simp
+    apply wpsimp+
+  apply (clarsimp simp: cur_vcpu_of_def)
+  done
+
+lemma get_vcpu_vcpu_at:
+  "\<lbrace>\<lambda>s. vcpu_at vr s \<longrightarrow> P s\<rbrace> get_vcpu vr \<lbrace>\<lambda>_. P\<rbrace>"
+  unfolding get_vcpu_def gets_map_def
+  by (wpsimp simp: obj_at_def opt_map_def split: option.splits)
+
+crunch vcpu_restore_2
+  for kheap[wp]: "\<lambda>s. P (kheap s)"
+  and numlistregs[wp]: "\<lambda>s. P (numlistregs s)"
+
+(* This the main use of states_equiv_for : P is use to restrict the labels we want to consider *)
+abbreviation states_equiv_for_labels_non_hyp ::
+  "'a PAS \<Rightarrow> ('a \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "states_equiv_for_labels_non_hyp aag P \<equiv>
+      states_equiv_for_non_hyp (\<lambda>x. P (pasObjectAbs aag x)) (\<lambda>x. P (pasIRQAbs aag x))
+                       (\<lambda>x. P (pasASIDAbs aag x)) (\<lambda>x. \<exists>l\<in>pasDomainAbs aag x. P l)"
+
+abbreviation reads_respects_l_non_hyp where
+  "reads_respects_l_non_hyp aag L P f \<equiv> equiv_valid_inv \<top>\<top> (states_equiv_for_labels_non_hyp aag L) P f"
+
+lemma states_equiv_for_non_hyp_symmetric:
+  "states_equiv_for_non_hyp P Q R S s t = states_equiv_for_non_hyp P Q R S t s"
+  by (auto simp: states_equiv_for_non_hyp_sym)
+
+(* for things that only modify parts of the state not in the state relations,
+   we don't care what they read since these reads are unobservable anyway;
+   however, we cannot assert anything about their return-values *)
+lemma reads_respects_l_non_hyp_unobservable:
+  assumes f:
+    "\<And>P Q R S st. \<lbrace>states_equiv_for_non_hyp P Q R S st\<rbrace> f \<lbrace>\<lambda>_. states_equiv_for_non_hyp P Q R S st\<rbrace>"
+  shows
+    "reads_respects_l_non_hyp aag l \<top> (f :: (det_state,unit) nondet_monad)"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+   apply (subst states_equiv_for_non_hyp_symmetric)
+   apply (erule use_valid)
+    apply (wp assms)
+   apply (subst states_equiv_for_non_hyp_symmetric)
+   apply (erule use_valid)
+    apply (wp assms)
+  apply simp
+  done
+
+lemma states_equiv_for_non_hyp_current_vcpu_update[simp]:
+  " states_equiv_for_non_hyp P Q R S st
+            (s\<lparr>arch_state := arch_state s\<lparr>arm_current_vcpu := cv\<rparr>\<rparr>) = states_equiv_for_non_hyp P Q R S st s"
+  by (clarsimp simp: states_equiv_for_non_hyp_def equiv_for_def equiv_asids_def equiv_asid_def equiv_fpu_def cur_fpu_for_def get_tcb_def)
+
+lemma vcpu_restore_2_reads_respects_hyp_l:
+  "equiv_valid (\<lambda>s s'. equiv_for P kheap s s' \<and>
+                       equiv_for P (K \<circ> numlistregs) s s')
+               \<top>\<top> (\<lambda>s s'. equiv_for P cur_vcpu_of s s' \<and>
+                           equiv_for P hw_vcpu_of s s') (valid_arch_state)
+               (vcpu_restore_2 vr)"
+  apply (rule_tac P'="\<lambda>s. vcpus_of s vr \<noteq> None" in equiv_valid_guard_necessary)
+   apply (unfold vcpu_restore_2_def vcpu_restore_def)[1]
+   apply (clarsimp simp: bind_assoc)
+   apply (wpsimp wp: get_vcpu_vcpu_at simp: obj_at_def opt_map_def)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (rule context_conjI)
+   apply (erule use_valid, rule equiv_for_lift, wp)+
+   apply simp
+  apply (rename_tac s' t' vcpu vcpu')
+  apply (rule context_conjI, clarsimp simp: comp_def)
+   apply (erule use_valid, rule equiv_for_lift, wp)+
+   apply simp
+  apply (prop_tac "current_vcpu s' = Some (vr,True)")
+   apply (erule use_valid, wpsimp simp: vcpu_restore_2_def, simp)
+  apply (prop_tac "current_vcpu t' = Some (vr,True)")
+   apply (erule use_valid, wpsimp simp: vcpu_restore_2_def, simp)
+  apply (rule conjI)
+   apply (clarsimp simp: equiv_for_def)
+  apply (case_tac "P vr")
+   apply (prop_tac "vcpu = vcpu'")
+    apply (clarsimp simp: equiv_for_def opt_map_def)
+   apply (drule use_valid[OF _ vcpu_restore_2_helper], simp)+
+   apply (subgoal_tac " Some
+            (vcpu_vgic_update
+              (vgic_lr_update (\<lambda>f r. if numlistregs s' \<le> r then undefined else f r))
+              (vcpu_state.truncate vcpu)) =
+           Some
+            (vcpu_vgic_update
+              (vgic_lr_update (\<lambda>f r. if numlistregs t' \<le> r then undefined else f r))
+              (vcpu_state.truncate vcpu'))")
+    apply (clarsimp simp: equiv_for_def cur_vcpu_of_def)
+   apply (clarsimp simp: equiv_for_def)
+   apply (drule mp, fastforce)+
+   apply clarsimp
+  apply (clarsimp simp: equiv_for_def cur_vcpu_of_def)
+  done
+
+lemma vcpu_restore_2_reads_respects_l:
+  "reads_respects_l aag l (valid_arch_state) (vcpu_restore_2 vr)"
+  apply (rule equiv_valid_conseq)
+    apply (rule equiv_valid_split)
+     apply (subst vcpu_restore_2_def)[1]
+     apply (rule reads_respects_l_non_hyp_unobservable[of _ l aag])
+     apply (wpsimp)+
+    apply (rule vcpu_restore_2_reads_respects_hyp_l[of "l o pasObjectAbs aag"])
+   apply (auto simp: states_equiv_for_def comp_def
+                     states_equiv_for_non_hyp_def equiv_hyp_def)
+  done
+
+lemma vcpu_enable_2_vcpu_proj:
+  "\<lbrace>\<lambda>s. vopt = vcpu_proj savedWhenDisabledRegs {} True False False vr s \<and> valid_arch_state s\<rbrace>
+    vcpu_enable_2 vr
+    \<lbrace>\<lambda>_ s. vopt = vcpu_proj {} {} False False False vr s\<rbrace>"
+  by (wpsimp wp: vcpu_enable_vcpu_proj simp: vcpu_enable_2_def)
+
+crunch vcpu_enable_2
+  for kheap[wp]: "\<lambda>s. P (kheap s)"
+  and numlistregs[wp]: "\<lambda>s. P (numlistregs s)"
+
+lemma vcpu_enable_2_reads_respects_hyp_l:
+  "equiv_valid (\<lambda>s s'. equiv_for P kheap s s' \<and>
+                       equiv_for P (K \<circ> numlistregs) s s')
+               (equiv_for P hw_vcpu_of)
+               (\<lambda>s s'. equiv_for P cur_vcpu_of s s' \<and>
+                           equiv_for P hw_vcpu_of s s') (\<lambda>s. current_vcpu s = Some (vr,False) \<and> valid_arch_state s)
+               (vcpu_enable_2 vr)"
+  apply (rule_tac P'="\<lambda>s. vcpus_of s vr \<noteq> None" in equiv_valid_guard_necessary)
+   apply (unfold vcpu_enable_2_def vcpu_enable_def)[1]
+   apply (clarsimp simp: bind_assoc)
+   apply (wpsimp wp: get_vcpu_vcpu_at simp: obj_at_def opt_map_def)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (rule context_conjI)
+   apply (erule use_valid, rule equiv_for_lift, wp)+
+   apply simp
+  apply (rename_tac s' t' vcpu vcpu')
+  apply (rule context_conjI, clarsimp simp: comp_def)
+   apply (erule use_valid, rule equiv_for_lift, wp)+
+   apply simp
+  apply (prop_tac "current_vcpu s' = Some (vr,True)")
+   apply (erule use_valid, wpsimp simp: vcpu_enable_2_def, simp)
+  apply (prop_tac "current_vcpu t' = Some (vr,True)")
+   apply (erule use_valid, wpsimp simp: vcpu_enable_2_def, simp)
+  apply (rule conjI)
+   apply (clarsimp simp: equiv_for_def)
+  apply (case_tac "P vr")
+   apply (clarsimp simp: equiv_for_def)
+   apply (erule_tac x=x in allE)+
+   apply (drule mp, fastforce)+
+   apply clarsimp
+   apply (clarsimp simp: cur_vcpu_of_def)
+   apply (prop_tac "vcpu' = vcpu")
+    apply (clarsimp simp: opt_map_def)
+   apply clarsimp
+   apply (prop_tac "vcpu_proj savedWhenDisabledRegs {} True False False vr s =
+                    vcpu_proj savedWhenDisabledRegs {} True False False vr t")
+    apply (clarsimp simp: vcpu_proj_def hw_vcpu_def)
+    apply (case_tac vcpu; clarsimp)
+    apply (case_tac vcpu_vgic; clarsimp)
+    apply (intro conjI ext)
+     apply (drule_tac x=r in fun_cong, clarsimp)
+    apply (drule_tac x=reg in fun_cong, clarsimp simp: vcpuRegSavedWhenDisabled_def split: if_splits vcpureg.splits)
+   apply (prop_tac "vcpus_of s' vr = Some vcpu")
+    apply (erule use_valid, wpsimp, simp)
+   apply (prop_tac "vcpus_of t' vr = Some vcpu")
+    apply (erule use_valid, wpsimp, clarsimp simp: opt_map_def)
+   apply (drule use_valid, rule vcpu_enable_2_vcpu_proj, solves simp)
+   apply simp
+   apply (thin_tac "vcpu_proj _ _ _ _ _ _ _ = vcpu_proj _ _ _ _ _ _ _")
+   apply (drule use_valid, rule vcpu_enable_2_vcpu_proj, solves simp)
+   apply (thin_tac "vcpu_proj _ _ _ _ _ _ _ = vcpu_proj _ _ _ _ _ _ _")
+   apply (clarsimp simp: vcpu_proj_def)
+   apply (case_tac vcpu; clarsimp)
+   apply (case_tac vcpu_vgic; clarsimp cong: if_cong)
+  apply (clarsimp simp: equiv_for_def cur_vcpu_of_def)
+  done
+
+lemma vcpu_enable_states_equiv_for_non_hyp[wp]:
+  "vcpu_enable vopt \<lbrace>states_equiv_for_non_hyp P Q R S st\<rbrace>"
+  apply (rule states_equiv_for_non_hyp_lift)
+           defer
+           defer
+           apply (rule equiv_for_lift, (wpsimp; fail))+
+     apply (rule equiv_asids_lift)
+      apply wpsimp
+     apply wpsimp
+    apply (rule equiv_fpu_lift)
+     apply (wpsimp simp: get_tcb_def wp: equiv_for_lift)+
+  apply (wpsimp wp: equiv_machine_state_lift)
+  done
+
+lemma vcpu_enable_2_reads_respects_l:
+  "reads_respects_l aag l (\<lambda>s. current_vcpu s = Some (vr,False) \<and> valid_arch_state s) (vcpu_enable_2 vr)"
+  apply (rule equiv_valid_conseq)
+      apply (rule equiv_valid_split)
+      apply (subst vcpu_enable_2_def)[1]
+     apply (rule reads_respects_l_non_hyp_unobservable[of _ l aag])
+            apply (wpsimp)+
+    apply (rule vcpu_enable_2_reads_respects_hyp_l[of "l o pasObjectAbs aag"])
+     apply (auto simp: states_equiv_for_def equiv_for_def
+                       states_equiv_for_non_hyp_def  equiv_hyp_def)
+  done
+
+lemma reads_respects_l_modify_disable:
+  "reads_respects_l aag l (\<lambda>s. current_vcpu s = Some (vr,True) \<and> l (pasObjectAbs aag vr))
+                          (modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_current_vcpu := Some (vr, False)\<rparr>\<rparr>))"
+  apply (wpsimp wp: modify_ev')
+  apply (clarsimp simp: states_equiv_for_def equiv_for_def)
+  apply (intro conjI)
+     apply (clarsimp simp: equiv_asids_def equiv_asid_def)
+    apply (clarsimp simp: equiv_hyp_def equiv_for_def)
+     apply (erule_tac x=vr in allE)+
+     apply clarsimp
+     apply (drule mp, fastforce)
+     apply (clarsimp simp: cur_vcpu_of_def split: option.splits if_splits)
+     apply (clarsimp simp: hw_vcpu_def)
+     apply (case_tac "vcpu_state (machine_state s)"; case_tac "vcpu_state (machine_state t)"; clarsimp)
+     apply (case_tac "vcpu_vgic"; case_tac "vcpu_vgica"; clarsimp)
+     apply (intro conjI ext)
+      apply (drule_tac x=r in fun_cong, clarsimp)
+     apply (clarsimp split: if_splits)
+   apply (clarsimp simp: equiv_fpu_def equiv_for_def cur_fpu_for_def get_tcb_def)
+  done
+
+lemma vcpu_disable_2_reads_respects_l:
+  "reads_respects_l aag l (\<lambda>s. current_vcpu s = Some (vr,True) \<and> valid_arch_state s) (vcpu_disable_2 vr)"
+  unfolding vcpu_disable_2_def
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_l_unit_cases)
+     apply clarsimp
+     apply (wp vcpu_disable_Some_reads_respects_l reads_respects_l_modify_disable)
+     apply simp
+    apply (wp modify_current_vcpu_equiv_but_for_labels)
+    apply clarsimp
+    apply assumption
+   apply wpsimp
+  apply (auto simp: cur_vcpu_of_def)
+  done
+
+crunch vcpu_disable_2, vcpu_enable_2, vcpu_restore_2
+  for ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
+
+lemma ev_evrv:
+  "equiv_valid I A B P f \<Longrightarrow> equiv_valid_rv I A B (=) P f"
+  by (unfold equiv_valid_def2)
+
+lemma ev2_case_option:
+  assumes "\<lbrakk>x = None; y = None\<rbrakk> \<Longrightarrow> equiv_valid_2 I A B R P1 Q1 f g"
+  and "\<And>b. \<lbrakk>x = None; y = Some b\<rbrakk> \<Longrightarrow> equiv_valid_2 I A B R P2 (Q2 b) f (g' b)"
+  and "\<And>a. \<lbrakk>x = Some a; y = None\<rbrakk> \<Longrightarrow> equiv_valid_2 I A B R (P3 a) Q3 (f' a) g"
+  and "\<And>a b. \<lbrakk>x = Some a; y = Some b\<rbrakk> \<Longrightarrow> equiv_valid_2 I A B R (P4 a) (Q4 b) (f' a) (g' b)"
+  shows "equiv_valid_2 I A B R (case_option (P1 and P2) (P3 and P4) x)
+                               (case_option (Q1 and Q3) (Q2 and Q4) y)
+                               (case_option f f' x) (case_option g g' y)"
+  apply (case_tac x; case_tac y; clarsimp)
+  by (rule equiv_valid_2_guard_imp, rule assms; fastforce)+
+
+lemma vcpu_switch_reads_respects_l:
+  notes ev2l_bind = equiv_valid_2_bind_pre[where P=\<top> and P'=\<top> and R'="\<top>\<top>", rotated, simplified]
+  shows "reads_respects_l aag l (\<lambda>s. valid_arch_state s) (vcpu_switch vopt)"
+  apply (unfold vcpu_switch_def)
+  apply (fold vcpu_restore_2_def vcpu_enable_2_def vcpu_disable_2_def)
+  apply (rule_tac P="\<lambda>s. cur_vcpu_for (l o pasObjectAbs aag) s = None" in equiv_valid_cases'')
+    apply (simp add: cur_vcpu_for_None')
+    apply (clarsimp simp: states_equiv_for_def equiv_hyp_def equiv_for_def)
+   prefer 2
+   apply (wpsimp wp: when_ev vcpu_disable_2_reads_respects_l
+                     vcpu_restore_2_reads_respects_l vcpu_enable_2_reads_respects_l gets_ev')
+   apply (subgoal_tac "\<forall>t. states_equiv_for_labels aag l s t \<longrightarrow> current_vcpu s = current_vcpu t")
+    apply (clarsimp simp: valid_arch_state_def)
+   apply (clarsimp simp: states_equiv_for_def equiv_hyp_def equiv_for_def)
+   apply (erule_tac x=ptr in allE)+
+   apply (clarsimp simp: cur_vcpu_of_def split: option.splits if_splits)
+  apply (rule_tac P="\<lambda>_. none_bot (l o pasObjectAbs aag) vopt" in equiv_valid_cases'')
+    apply simp
+   prefer 2
+   apply (rule reads_respects_l_invisible[where P="\<top>", simplified])
+     apply (rule modifies_at_mostI)
+     apply (wpsimp wp: vcpu_enable_2_equiv_but_for_labels
+                       vcpu_disable_2_equiv_but_for_labels
+                       vcpu_restore_2_equiv_but_for_labels)
+     apply (fastforce simp: cur_vcpu_for_def)
+    apply wpsimp
+   apply clarsimp
+  apply (case_tac vopt; clarsimp simp: equiv_valid_def2)
+   apply (clarsimp simp: equiv_valid_2_def)
+  apply (rule equiv_valid_2_bind_pre[OF _ gets_any_evrv])
+      apply (rule_tac P="\<forall>b. rv \<noteq> Some (a,b)" in gen_asm_ev2_l)
+      apply (rule_tac P'="\<forall>b. rv' \<noteq> Some (a,b)" in gen_asm_ev2_r)
+      apply (clarsimp simp: split_def)
+      apply (rule ev2_case_option)
+         apply (rule ev_evrv)
+         apply (rule vcpu_restore_2_reads_respects_l)
+        apply (subst if_P, clarsimp, blast)
+        apply (subst return_bind[where f="\<lambda>_. vcpu_restore_2 _", symmetric],
+               rule_tac R'=dc in equiv_valid_2_bind_pre)
+             apply (simp only: K_bind_def)
+             apply (rule ev_evrv)
+             apply (rule vcpu_restore_2_reads_respects_l)
+            apply (rule_tac P=\<top> and P'=\<top>
+                         in reads_respects_l_2_invisible[OF modifies_at_mostI modifies_at_mostI])
+                apply (assumption | wpsimp simp: split_def split_del: if_split)+
+       apply (subst if_P, clarsimp, blast)
+       apply (subst return_bind[where f="\<lambda>_. vcpu_restore_2 _", symmetric],
+              rule_tac R'=dc in equiv_valid_2_bind_pre)
+            apply (simp only: K_bind_def)
+            apply (rule ev_evrv)
+            apply (rule vcpu_restore_2_reads_respects_l)
+           apply (rule_tac P=\<top> and P'=\<top>
+                        in reads_respects_l_2_invisible[OF modifies_at_mostI modifies_at_mostI])
+               apply (assumption | wpsimp simp: split_def split_del: if_split)+
+      apply (subst if_P, clarsimp, blast)+
+      apply (rule_tac R'=dc in equiv_valid_2_bind_pre)
+           apply (simp only: K_bind_def)
+           apply (rule ev_evrv)
+           apply (rule vcpu_restore_2_reads_respects_l)
+          apply (rule_tac P=\<top> and P'=\<top>
+                       in reads_respects_l_2_invisible[OF modifies_at_mostI modifies_at_mostI])
+              apply (assumption | wpsimp simp: split_def split_del: if_split)+
+   apply (auto simp: cur_vcpu_for_def split: option.splits if_splits)
+  done
+
+lemma vcpu_switch_reads_respects:
+  "reads_respects aag l valid_arch_state (vcpu_switch vopt)"
+  apply (rule reads_respects_from_labels)
+       apply (rule vcpu_switch_reads_respects_l)
+      apply wpsimp+
+  done
+
+lemma set_vcpu_reads_respects[wp]:
+  "reads_respects aag l \<top> (set_vcpu vr vcpu)"
+  unfolding set_vcpu_def
+  apply (rule_tac P'="vcpu_at vr" in equiv_valid_guard_necessary)
+   apply (rule wp_pre)
+    apply (rule hoare_set_object_weaken_pre)
+    apply wp
+   apply (clarsimp simp: obj_at_def)
+  apply (wpsimp wp: set_object_reads_respects)
+  done
+
+lemma get_vcpu_reads_respects[wp]:
+  "reads_respects aag l (K (aag_can_read aag vr \<or> aag_can_affect aag l vr)) (get_vcpu vr)"
+  unfolding get_vcpu_def gets_map_def
+  apply (subst gets_apply)
+  apply (wpsimp wp: gets_apply_ev)
+  apply (auto simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_for_def opt_map_def)
+  done
+
+lemma vcpu_update_reads_respects[wp]:
+  "reads_respects aag l \<top> (vcpu_update vr f)"
+  unfolding vcpu_update_def
+  apply (rule wp_pre)
+   apply (rule_tac ptr=vr in reads_respects_unit_cases)
+     apply wpsimp+
+  done
+
+lemma vcpu_read_reg_reads_respects[wp]:
+  "reads_respects aag l (K (aag_can_read aag v)) (vcpu_read_reg v reg)"
+  unfolding vcpu_read_reg_def
+  by wpsimp
+
+lemma vcpu_write_reg_reads_respects[wp]:
+  "reads_respects aag l \<top> (vcpu_write_reg v reg val)"
+  unfolding vcpu_write_reg_def
+  by wpsimp
+
+lemma gets_apply_evrv:
+  "equiv_valid_rv_inv I A R (K (\<forall>s t. I s t \<and> A s t \<longrightarrow> R (f s x) (f t x))) (gets_apply f x)"
+  apply (simp add: gets_apply_def get_def bind_def return_def)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  done
+
+lemma gets_apply_evrv':
+  "\<forall>s t. I s t \<and> A s t \<and> P s \<and> P t \<longrightarrow> R (f s x) (f t x)
+   \<Longrightarrow> equiv_valid_rv_inv I A R P (gets_apply f x)"
+  apply (simp add: gets_apply_def get_def bind_def return_def)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  done
+
+lemma readVCPUHardwareReg_reads_respects[wp]:
+  "reads_respects aag l (\<lambda>s. \<exists>b. cur_vcpu_for (aag_can_read_or_affect aag l) s = Some b \<and> (vcpuRegSavedWhenDisabled reg \<longrightarrow> b))
+                        (do_machine_op (readVCPUHardwareReg reg))"
+  unfolding readVCPUHardwareReg_def
+  apply (rule do_machine_op_reads_respects'')
+   apply wp
+  apply clarsimp
+  apply (clarsimp simp: equiv_for_def equiv_hyp_state_def cur_vcpu_for_Some)
+  apply (case_tac b; clarsimp simp: hw_vcpu_def)
+  apply (drule_tac x=reg in fun_cong, clarsimp)
+  done
+
+lemma writeVCPUHardwareReg_reads_respects[wp]:
+  "reads_respects aag l \<top> (do_machine_op (writeVCPUHardwareReg reg val))"
+  unfolding writeVCPUHardwareReg_def dmo_distr
+  apply (wpsimp wp: dmo_mol_reads_respects)
+    apply (rule use_spec_ev)
+    apply (wpsimp wp: do_machine_op_reads_respects'' modify_ev)
+   apply wpsimp
+  apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def)
+  apply (case_tac "cur_vcpu_for (aag_can_read aag or aag_can_affect aag l) s"; clarsimp simp: cur_vcpu_for_Some)
+  apply (clarsimp simp: hw_vcpu_def split: if_splits)
+   apply (intro conjI ext; drule_tac x=r in fun_cong; clarsimp)+
+  done
+
+lemma invoke_vcpu_read_register_reads_respects:
+  "reads_respects aag l (K (aag_can_read aag v)) (invoke_vcpu_read_register v reg)"
+  unfolding invoke_vcpu_read_register_def read_vcpu_register_def gets_def
+  apply (subst bind_assoc)
+  apply (subst return_bind)
+  apply (subst bind_assoc[symmetric])
+  apply (subst gets_apply_def[symmetric])
+  apply simp
+  apply (rule gen_asm_ev)
+  apply (rule wp_pre)
+   apply (unfold equiv_valid_def2)
+   apply (clarsimp simp: bind_assoc)
+   apply (rule_tac A=A and B=A and P=\<top> and W="\<lambda>x y. fst x = fst y \<and> (fst x \<longrightarrow> x = y)"
+               and Q="\<lambda>rv s. (fst rv \<longrightarrow> Q rv s) \<and> (\<not>fst rv \<longrightarrow> Q' rv s)"
+               for A Q Q' in equiv_valid_rv_bind_general)
+     apply (wpsimp wp: gets_apply_evrv')
+     apply (prop_tac "equiv_for (aag_can_read aag) cur_vcpu_of s t")
+      apply (clarsimp simp: reads_equiv_def2 states_equiv_for_def equiv_hyp_def)
+     apply (clarsimp simp: equiv_for_def)
+     apply (erule_tac x=v in allE)
+     apply (auto simp: equiv_for_def cur_vcpu_of_def split: option.splits if_splits)[1]
+    apply (case_tac "fst rv"; clarsimp split del: if_split; wpfix)
+     apply (subst equiv_valid_def2[symmetric])
+     apply wpsimp
+    apply (subst equiv_valid_def2[symmetric])
+    apply wpsimp
+     apply (rule equiv_valid_guard_imp)
+      apply wpsimp
+     apply clarsimp
+    apply wpsimp
+   apply wpsimp+
+   apply (clarsimp split: option.splits)
+  apply simp
+  done
+
+lemma invoke_vcpu_write_register_reads_respects:
+  "reads_respects aag l (K (aag_can_read aag v)) (invoke_vcpu_write_register v reg val)"
+  unfolding invoke_vcpu_write_register_def write_vcpu_register_def gets_def
+  apply (subst bind_assoc)
+  apply (subst return_bind)
+  apply (subst bind_assoc[symmetric])
+  apply (subst gets_apply_def[symmetric])
+  apply simp
+  apply (rule gen_asm_ev)
+  apply (rule wp_pre)
+   apply (unfold equiv_valid_def2)
+   apply (clarsimp simp: bind_assoc)
+   apply (rule_tac A=A and B=A and P=\<top> and W="\<lambda>x y. fst x = fst y \<and> (fst x \<longrightarrow> x = y)"
+               and Q="\<lambda>rv s. (fst rv \<longrightarrow> Q rv s) \<and> (\<not>fst rv \<longrightarrow> Q' rv s)"
+               for A Q Q' in equiv_valid_rv_bind_general)
+     apply (wpsimp wp: gets_apply_evrv')
+     apply (prop_tac "equiv_for (aag_can_read aag) cur_vcpu_of s t")
+      apply (clarsimp simp: reads_equiv_def2 states_equiv_for_def equiv_hyp_def)
+     apply (clarsimp simp: equiv_for_def)
+     apply (erule_tac x=v in allE)
+     apply (auto simp: equiv_for_def cur_vcpu_of_def split: option.splits if_splits)[1]
+    apply (case_tac "fst rv"; clarsimp split del: if_split; wpfix)
+     apply (subst equiv_valid_def2[symmetric])
+     apply wpsimp
+    apply (subst equiv_valid_def2[symmetric])
+    apply wpsimp+
+  done
+
+lemma set_gic_vcpu_ctrl_lr_reads_respects'':
+  "reads_respects aag l (\<lambda>s. cur_vcpu_for (aag_can_read_or_affect aag l) s = None)
+                        (do_machine_op (set_gic_vcpu_ctrl_lr reg val))"
+  (is "reads_respects _ _ ?P _")
+   unfolding set_gic_vcpu_ctrl_lr_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects)
+     apply (rule do_machine_op_reads_respects'')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_def)
+    apply wpsimp+
+   done
+
+lemma hw_vcpu_lr_update[simp]:
+  "hw_vcpu n cv (vcpu_vgic_update (vgic_lr_update (\<lambda>f. f(reg := val))) vst) =
+   (if reg < n then map_option (vcpu_vgic_update (vgic_lr_update (\<lambda>f. f(reg := val)))) (hw_vcpu n cv vst)
+               else hw_vcpu n cv vst)"
+  by (auto split: if_splits option.splits simp: hw_vcpu_def)
+
+lemma set_gic_vcpu_ctrl_lr_reads_respects':
+  "reads_respects aag l (\<lambda>s. \<exists>vr b. cur_vcpu_for (aag_can_read_or_affect aag l) s = Some b)
+                        (do_machine_op (set_gic_vcpu_ctrl_lr reg val))"
+  (is "reads_respects _ _ ?P _")
+  unfolding set_gic_vcpu_ctrl_lr_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects)
+     apply (rule do_machine_op_reads_respects'')
+      apply (wpsimp wp: modify_ev')
+    apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_Some)
+    apply wpsimp+
+   done
+
+lemma set_gic_vcpu_ctrl_lr_reads_respects[wp]:
+  "reads_respects aag l \<top>
+                        (do_machine_op (set_gic_vcpu_ctrl_lr reg val))"
+  (is "reads_respects _ _ ?P _")
+  apply (rule_tac P="\<lambda>s. cur_vcpu_for (aag_can_read_or_affect aag l) s = None" in equiv_valid_cases'')
+    apply (prop_tac "equiv_hyp (aag_can_read_or_affect aag l) s t")
+     apply (auto simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_hyp_def equiv_for_def)[1]
+    apply (auto simp: cur_vcpu_for_None' equiv_hyp_def equiv_for_def)[1]
+   apply (wpsimp wp: set_gic_vcpu_ctrl_lr_reads_respects'')
+  apply (wpsimp wp: set_gic_vcpu_ctrl_lr_reads_respects')
+  done
+
+lemma vgic_update_reads_respects[wp]:
+  "reads_respects aag l \<top> (vgic_update vr f)"
+  unfolding vgic_update_def by wp
+
+lemma vgic_lr_update_reads_respects[wp]:
+  "reads_respects aag l \<top> (vgic_update_lr vr reg irq)"
+  unfolding vgic_update_lr_def by wp
+
+lemma invoke_vcpu_inject_irq_reads_respects:
+  "reads_respects aag l (\<lambda>s. aag_can_read aag v) (invoke_vcpu_inject_irq v n irq)"
+  unfolding invoke_vcpu_inject_irq_def
+  apply (subst equiv_valid_def2)
+  apply (rule_tac W="\<lambda>cv cv'. (cv \<noteq> None \<and> fst (the cv) = v) = (cv' \<noteq> None \<and> fst (the cv') = v)" in equiv_valid_rv_bind)
+    apply (wpsimp wp: gets_evrv'')
+    apply (prop_tac "equiv_for (aag_can_read aag) cur_vcpu_of s t")
+     apply (clarsimp simp: reads_equiv_def2 states_equiv_for_def equiv_hyp_def)
+    apply (clarsimp simp: equiv_for_def)
+    apply (erule_tac x=v in allE)
+    apply (auto simp: equiv_for_def cur_vcpu_of_def split: option.splits if_splits)[1]
+   apply (clarsimp split del: if_split)
+   apply (subst equiv_valid_def2[symmetric])
+   apply wpsimp+
+  done
+
+lemma invoke_vcpu_ack_vppi_reads_respects:
+  "reads_respects aag l (K (aag_can_read aag v)) (invoke_vcpu_ack_vppi v vppi)"
+  unfolding invoke_vcpu_ack_vppi_def
+  by wpsimp
+
+lemma as_user_getRegister_reads_respects:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows "reads_respects aag l (K (aag_can_read aag thread \<or> aag_can_affect aag l thread)) (as_user thread (getRegister reg))"
+   apply (simp add: as_user_def split_def)
+   apply (rule gen_asm_ev)
+   apply (wp set_object_reads_respects select_f_ev gets_the_ev)
+   apply (auto intro: reads_affects_equiv_get_tcb_eq det_getRegister)[1]
+  done
+
+lemma arch_thread_set_vcpu_reads_respects[wp]:
+  "reads_respects aag l (K (aag_can_read_or_affect aag l t))
+                        (arch_thread_set (tcb_vcpu_update f) t)"
+  unfolding arch_thread_set_def
+  apply (wpsimp wp: set_object_reads_respects)
+   apply fastforce
+  done
+
+lemma gets_arm_current_vcpu_reads_respects:
+  "reads_respects aag l (\<lambda>s. cur_vcpu_for (aag_can_read_or_affect aag l) s \<noteq> None)
+                        (gets (arm_current_vcpu \<circ> arch_state))"
+  apply (wpsimp wp: gets_ev')
+  apply (erule disjE)
+  apply (prop_tac "equiv_hyp (aag_can_read aag) s t")
+   apply (clarsimp simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_hyp_def equiv_for_def)
+   apply (fastforce simp: equiv_hyp_def equiv_for_def cur_vcpu_of_def split: if_splits option.splits)
+  apply (prop_tac "equiv_hyp (aag_can_affect aag l) s t")
+   apply (clarsimp simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_hyp_def equiv_for_def)
+   apply (fastforce simp: equiv_hyp_def equiv_for_def cur_vcpu_of_def split: if_splits option.splits)
+  done
+
+lemma modify_current_vcpu_None_reads_respects[wp]:
+  "reads_respects aag l \<top>
+     (modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_current_vcpu := None\<rparr>\<rparr>))"
+  apply (wpsimp wp: modify_ev)
+  apply (clarsimp simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_for_def)
+  apply (intro conjI)
+  prefer 4
+       apply (auto simp: equiv_asids_def equiv_asid_def)[2]
+     prefer 2
+     prefer 4
+     apply (auto simp: equiv_fpu_def equiv_for_def cur_fpu_for_def get_tcb_def)[2]
+   apply (clarsimp simp: equiv_hyp_def equiv_for_def cur_vcpu_of_def split: option.split)
+   apply (clarsimp simp: equiv_hyp_def equiv_for_def cur_vcpu_of_def split: option.split)
+  done
+
+lemma dmo_dsb_reads_respects[wp]:
+  "reads_respects aag l \<top> (do_machine_op dsb)"
+  unfolding dsb_def
+  by (wpsimp wp: dmo_mol_reads_respects)
+
+lemma dmo_isb_reads_respects[wp]:
+  "reads_respects aag l \<top> (do_machine_op isb)"
+  unfolding isb_def
+  by (wpsimp wp: dmo_mol_reads_respects)
+
+lemma dmo_setHCR_reads_respects[wp]:
+  "reads_respects aag l \<top> (do_machine_op (setHCR val))"
+  unfolding setHCR_def
+  by (wpsimp wp: dmo_mol_reads_respects)
+
+lemma dmo_maskInterrupt_reads_respects[wp]:
+  "reads_respects aag l \<top> (do_machine_op (maskInterrupt m irq))"
+  unfolding maskInterrupt_def
+  apply (rule use_spec_ev)
+  apply (wpsimp wp: do_machine_op_reads_respects'' modify_ev)
+  apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def)
+  done
+
+lemma enableFpuEL01_reads_respects'':
+  "reads_respects aag l (\<lambda>s. cur_vcpu_for (aag_can_read_or_affect aag l) s = None)
+                        (do_machine_op enableFpuEL01)"
+  (is "reads_respects _ _ ?P _")
+   unfolding enableFpuEL01_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects)
+     apply (rule do_machine_op_reads_respects'')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_def)
+    apply wpsimp+
+   done
+
+lemma enableFpuEL01_reads_respects':
+  "reads_respects aag l (\<lambda>s. \<exists>vr. cur_vcpu_for (aag_can_read_or_affect aag l) s = Some True)
+                        (do_machine_op enableFpuEL01)"
+  (is "reads_respects _ _ ?P _")
+   unfolding enableFpuEL01_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects)
+     apply (rule do_machine_op_reads_respects'')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_Some)
+    apply wpsimp+
+   done
+
+lemma enableFpuEL01_reads_respects[wp]:
+  "reads_respects aag l (\<lambda>s. \<forall>vr b. current_vcpu s = Some (vr,b) \<longrightarrow> b)
+                        (do_machine_op enableFpuEL01)"
+  (is "reads_respects _ _ ?P _")
+  apply (rule_tac P="\<lambda>s. cur_vcpu_for (aag_can_read_or_affect aag l) s = None" in equiv_valid_cases'')
+    apply (prop_tac "equiv_hyp (aag_can_read_or_affect aag l) s t")
+     apply (auto simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_hyp_def equiv_for_def)[1]
+    apply (auto simp: cur_vcpu_for_None' equiv_hyp_def equiv_for_def)[1]
+   apply (wpsimp wp: enableFpuEL01_reads_respects'')
+  apply (wpsimp wp: enableFpuEL01_reads_respects')
+  done
+
+lemma setSCTLR_reads_respects'':
+  "reads_respects aag l (\<lambda>s. cur_vcpu_for (aag_can_read_or_affect aag l) s = None)
+                        (do_machine_op (setSCTLR val))"
+  (is "reads_respects _ _ ?P _")
+   unfolding setSCTLR_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects)
+     apply (rule do_machine_op_reads_respects'')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_def)
+    apply wpsimp+
+   done
+
+lemma setSCTLR_reads_respects':
+  "reads_respects aag l (\<lambda>s. \<exists>vr. cur_vcpu_for (aag_can_read_or_affect aag l) s = Some True)
+                        (do_machine_op (setSCTLR val))"
+  (is "reads_respects _ _ ?P _")
+   unfolding setSCTLR_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects)
+     apply (rule do_machine_op_reads_respects'')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_Some)
+    apply wpsimp+
+   done
+
+lemma setSCTLR_reads_respects[wp]:
+  "reads_respects aag l (\<lambda>s. \<forall>vr b. current_vcpu s = Some (vr,b) \<longrightarrow> b)
+                        (do_machine_op (setSCTLR val))"
+  (is "reads_respects _ _ ?P _")
+  apply (rule_tac P="\<lambda>s. cur_vcpu_for (aag_can_read_or_affect aag l) s = None" in equiv_valid_cases'')
+    apply (prop_tac "equiv_hyp (aag_can_read_or_affect aag l) s t")
+     apply (auto simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_hyp_def equiv_for_def)[1]
+    apply (auto simp: cur_vcpu_for_None' equiv_hyp_def equiv_for_def)[1]
+   apply (wpsimp wp: setSCTLR_reads_respects'')
+  apply (wpsimp wp: setSCTLR_reads_respects')
+  done
+
+lemma set_gic_vcpu_ctrl_hcr_reads_respects'':
+  "reads_respects aag l (\<lambda>s. cur_vcpu_for (aag_can_read_or_affect aag l) s = None)
+                        (do_machine_op (set_gic_vcpu_ctrl_hcr val))"
+  (is "reads_respects _ _ ?P _")
+   unfolding set_gic_vcpu_ctrl_hcr_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects)
+     apply (rule do_machine_op_reads_respects'')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_def)
+    apply wpsimp+
+   done
+
+lemma set_gic_vcpu_ctrl_hcr_reads_respects':
+  "reads_respects aag l (\<lambda>s. \<exists>vr. cur_vcpu_for (aag_can_read_or_affect aag l) s = Some True)
+                        (do_machine_op (set_gic_vcpu_ctrl_hcr val))"
+  (is "reads_respects _ _ ?P _")
+   unfolding set_gic_vcpu_ctrl_hcr_def dmo_distr
+   apply (rule_tac P'="?P" in bind_ev_pre)
+      apply (wpsimp wp: dmo_mol_reads_respects)
+     apply (rule do_machine_op_reads_respects'')
+      apply (wpsimp wp: modify_ev')
+     apply (clarsimp simp: equiv_for_def equiv_hyp_state_def equiv_fpu_state_def cur_vcpu_for_Some)
+    apply wpsimp+
+   done
+
+lemma set_gic_vcpu_ctrl_hcr_reads_respects[wp]:
+  "reads_respects aag l (\<lambda>s. \<forall>vr b. current_vcpu s = Some (vr,b) \<longrightarrow> b)
+                        (do_machine_op (set_gic_vcpu_ctrl_hcr val))"
+  (is "reads_respects _ _ ?P _")
+  apply (rule_tac P="\<lambda>s. cur_vcpu_for (aag_can_read_or_affect aag l) s = None" in equiv_valid_cases'')
+    apply (prop_tac "equiv_hyp (aag_can_read_or_affect aag l) s t")
+     apply (auto simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_hyp_def equiv_for_def)[1]
+    apply (auto simp: cur_vcpu_for_None' equiv_hyp_def equiv_for_def)[1]
+   apply (wpsimp wp: set_gic_vcpu_ctrl_hcr_reads_respects'')
+  apply (wpsimp wp: set_gic_vcpu_ctrl_hcr_reads_respects')
+  done
+
+lemma vcpu_disable_None_reads_respects[wp]:
+  "reads_respects aag l (\<lambda>s. \<exists>vr. current_vcpu s = Some (vr,True)) (vcpu_disable None)"
+  apply (simp only: vcpu_disable_def fun_app_def bind_assoc_helper vcpu_save_vgic_defs[symmetric] vcpu_save_lrs_helper)
+  apply (clarsimp simp: dmo_distr)
+  apply wpsimp
+  done
+
+lemma vcpu_invalidate_active_reads_respects:
+  "reads_respects aag l (\<lambda>s. cur_vcpu_for (aag_can_read_or_affect aag l) s \<noteq> None) vcpu_invalidate_active"
+  unfolding vcpu_invalidate_active_def
+  apply wp
+      apply wpsimp
+     apply wpsimp
+    apply (wp gets_arm_current_vcpu_reads_respects)
+   apply wpsimp
+  apply clarsimp
+  done
+
+lemma arch_thread_get_tcb_vcpu_reads_respects[wp]:
+  "reads_respects aag l (K (aag_can_read aag t)) (arch_thread_get tcb_vcpu t)"
+  unfolding arch_thread_get_def
+  apply wpsimp
+  apply fastforce
+  done
+
+lemma gets_comp:
+  "do x <- gets f;
+      m (g x)
+   od =
+   do x <- gets (g \<circ> f);
+      m x
+    od"
+  by (simp add: gets_def)
+
+lemma dissociate_vcpu_tcb_reads_respects:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects aag l (K (aag_can_read aag t \<and> aag_can_read aag vr))
+                              (dissociate_vcpu_tcb vr t)"
+  apply (clarsimp simp: dissociate_vcpu_tcb_def as_user_bind)
+  apply (subst gets_comp)
+  apply (wpsimp wp: as_user_set_register_reads_respects' as_user_getRegister_reads_respects when_ev
+                    vcpu_invalidate_active_reads_respects get_vcpu_wp arch_thread_get_wp)
+  apply (rule conjI; clarsimp)
+  apply (prop_tac "equiv_hyp (aag_can_read aag) sa ta")
+   apply (clarsimp simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_hyp_def equiv_for_def)
+  apply (fastforce simp: equiv_hyp_def equiv_for_def cur_vcpu_of_def split: if_splits option.splits)
+  done
+
+lemma dissociate_vcpu_tcb_helper:
+  "\<lbrace>\<lambda>s. \<exists>vcpu'. vcpus_of s vr = Some vcpu' \<and> P (Some (if v = vr then vcpu'\<lparr>vcpu_tcb := None\<rparr> else vcpu'))\<rbrace>
+   dissociate_vcpu_tcb v t
+   \<lbrace>\<lambda>_ s. P (vcpus_of s vr)\<rbrace>"
+  unfolding dissociate_vcpu_tcb_def
+  apply (wpsimp wp: get_vcpu_wp hoare_vcg_all_lift arch_thread_get_wp)
+  apply (auto elim!: rsubst[where P=P] intro!: ext split: if_splits)
+  done
+
+lemma associate_vcpu_tcb_reads_respects:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects aag l (pas_refined aag and valid_arch_state and K (is_subject aag vr \<and> is_subject aag t)) (associate_vcpu_tcb vr t)"
+  unfolding associate_vcpu_tcb_def
+  apply (rule_tac P'="\<lambda>s. vcpus_of s vr \<noteq> None" in equiv_valid_guard_necessary)
+   apply (clarsimp simp: bind_assoc)
+   apply (wpsimp wp: get_vcpu_vcpu_at simp: obj_at_def opt_map_def)
+  apply (subst gets_comp)
+  apply (wpsimp wp: when_ev vcpu_switch_reads_respects dissociate_vcpu_tcb_reads_respects
+                    arch_thread_get_wp get_vcpu_wp dissociate_vcpu_tcb_helper
+                    hoare_vcg_imp_lift' hoare_vcg_all_lift)
+  apply (intro conjI impI allI; clarsimp?)
+      apply (fastforce simp: get_tcb_ko_at dest: associated_vcpu_is_subject)
+     apply (fastforce dest: associated_tcb_is_subject)
+    apply (clarsimp simp: reads_equiv_def)
+   apply (fastforce dest: associated_tcb_is_subject)
+  apply (clarsimp simp: reads_equiv_def)
+  done
+
+lemma perform_vcpu_invocation_reads_respects:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows
+  "reads_respects aag l (pas_refined aag and valid_arch_state and valid_vcpu_invocation iv and K (authorised_vcpu_inv aag iv))
+                        (perform_vcpu_invocation iv)"
+  unfolding perform_vcpu_invocation_def authorised_vcpu_inv_def
+  apply (rule gen_asm_ev)
+  apply (cases iv; simp)
+      apply (wpsimp wp: associate_vcpu_tcb_reads_respects)
+     apply (wpsimp wp: invoke_vcpu_inject_irq_reads_respects)
+    apply (wpsimp wp: invoke_vcpu_read_register_reads_respects)
+   apply (wpsimp wp: invoke_vcpu_write_register_reads_respects)
+  apply (wpsimp wp: invoke_vcpu_ack_vppi_reads_respects)
+  done
+
+lemma set_vcpu_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
+   set_vcpu ptr vcpu
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding set_vcpu_def
+  apply (wpsimp wp: set_object_globals_equiv[THEN hoare_set_object_weaken_pre] get_object_wp
+              simp: partial_inv_def)+
+  apply (fastforce simp: obj_at_def valid_arch_state_def dest: valid_global_arch_objs_pt_at)
+  done
+
+lemma vcpu_update_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
+   vcpu_update vr f
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding vcpu_update_def
+  by wpsimp
+
+lemma thread_set_globals_equiv:
+  "(\<And>tcb. arch_tcb_context_get (tcb_arch (f tcb)) = arch_tcb_context_get (tcb_arch tcb))
+   \<Longrightarrow> \<lbrace>globals_equiv s and valid_arch_state\<rbrace> thread_set f tptr \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding thread_set_def
+  apply (wp set_object_globals_equiv)
+  apply simp
+  apply (intro impI conjI allI)
+    apply (fastforce simp: valid_arch_state_def obj_at_def get_tcb_def dest: valid_global_arch_objs_pt_at)+
+  done
+
+lemma arch_thread_set_vcpu_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
+   arch_thread_set (tcb_vcpu_update f) t
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding arch_thread_set_is_thread_set
+  by (wpsimp wp: thread_set_globals_equiv simp: arch_tcb_context_get_def)
+
+crunch vcpu_save_reg
+  for globals_equiv[wp]: "globals_equiv st"
+  (simp: readVCPUHardwareReg_def)
+
+crunch vgic_update_lr
+  for globals_equiv[wp]: "globals_equiv st"
+
+lemma vcpu_save_reg_range_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
+   vcpu_save_reg_range vr from to
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding vcpu_save_reg_range_def
+  apply (rule hoare_strengthen_post)
+   apply (rule mapM_x_wp_inv)
+   apply wpsimp+
+  done
+
+lemma dmo_globals_equiv:
+  "\<lbrakk> \<And>P. f \<lbrace>\<lambda>ms. P (device_state ms)\<rbrace> \<rbrakk>
+     \<Longrightarrow> do_machine_op f \<lbrace>globals_equiv st\<rbrace>"
+  apply (simp add: do_machine_op_def)
+  apply (wp modify_wp | simp add: split_def)+
+  apply (clarsimp simp: globals_equiv_def idle_equiv_def)
+  apply (erule use_valid, fastforce+)
+  done
+
+crunch vcpu_save
+  for globals_equiv[wp]: "globals_equiv st"
+  (wp: mapM_wp_inv dmo_globals_equiv simp: crunch_simps )
+
+crunch vcpu_restore
+  for globals_equiv[wp]: "globals_equiv st"
+  (wp: mapM_x_wp_inv mapM_wp_inv dmo_globals_equiv simp: crunch_simps )
+
+crunch vcpu_disable
+  for globals_equiv[wp]: "globals_equiv st"
+  (wp: mapM_x_wp_inv mapM_wp_inv dmo_globals_equiv simp: crunch_simps )
+
+lemma globals_equiv_arm_current_vcpu_update[simp]:
+  "globals_equiv st (s\<lparr>arch_state := arch_state s\<lparr>arm_current_vcpu := vcpu'\<rparr>\<rparr>) = globals_equiv st s"
+  by (auto simp: globals_equiv_def idle_equiv_def)
+
+crunch vcpu_switch
+  for globals_equiv[wp]: "globals_equiv st"
+  (wp: mapM_x_wp_inv mapM_wp_inv dmo_globals_equiv simp: crunch_simps )
+
+lemma vcpu_invalidate_active_valid_arch_state[wp]:
+  "vcpu_invalidate_active \<lbrace>valid_arch_state\<rbrace>"
+  unfolding vcpu_invalidate_active_def
+  apply wp
+    apply (rule_tac Q'="\<lambda>_. valid_arch_state" in hoare_strengthen_post[rotated])
+     apply (clarsimp simp: valid_arch_state_def cur_vcpu_def valid_global_arch_objs_def)
+    apply wpsimp+
+  done
+
+crunch vcpu_invalidate_active
+  for globals_equiv[wp]: "globals_equiv st"
+
+lemma dissociate_vcpu_tcb_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and valid_arch_state and (\<lambda>s. t \<noteq> idle_thread s)\<rbrace>
+   dissociate_vcpu_tcb vr t
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding dissociate_vcpu_tcb_def
+  apply (wpsimp wp: as_user_globals_equiv simp: arch_tcb_context_get_def as_user_bind)
+       apply (rule_tac Q'="\<lambda>_ s. arm_current_vcpu (arch_state s) = None" in hoare_post_add)
+       apply (clarsimp cong: conj_cong)
+       apply (wpsimp wp: get_vcpu_wp arch_thread_get_wp)+
+  done
+
+lemma associate_vcpu_tcb_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and invs and ex_nonz_cap_to t\<rbrace>
+   associate_vcpu_tcb vr t
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding associate_vcpu_tcb_def
+  apply (wpsimp)
+  apply (wp hoare_drop_imps)
+  apply clarsimp
+       apply wpsimp
+      apply clarsimp
+      apply wpsimp
+     apply (wp get_vcpu_wp)
+       apply (rule_tac Q'="\<lambda>_. globals_equiv s and valid_arch_state" in hoare_post_add)
+    apply (clarsimp cong: conj_cong)
+    apply (wpsimp wp: hoare_vcg_all_lift hoare_vcg_imp_lift dissociate_vcpu_tcb_vcpus_of)
+   apply (wp arch_thread_get_wp)
+  apply clarsimp
+  apply (case_tac "t = idle_thread sa", clarsimp)
+  using idle_no_ex_cap apply fastforce
+  apply clarsimp
+  apply (case_tac "vcpus_of sa vr"; clarsimp)
+  apply (case_tac "vcpu_tcb a"; clarsimp)
+  apply (case_tac "aa = idle_thread sa"; clarsimp)
+  apply (subgoal_tac "False", clarsimp)
+  apply (rename_tac s' tcb vcpu)
+  apply (prop_tac "(idle_thread s', HypTCBRef) \<in> state_hyp_refs_of s' vr")
+   apply (clarsimp simp: state_hyp_refs_of_def opt_map_def split: option.splits)
+  apply (drule sym_refsD)
+   apply (erule invs_hyp_sym_refs)
+    apply (clarsimp simp: obj_at_vcpu_hyp_live_of_s[symmetric] is_vcpu_def
+                       state_hyp_refs_of_def obj_at_def hyp_live_def hyp_refs_of_def
+                       tcb_vcpu_refs_def refs_of_ao_def arch_live_def vcpu_tcb_refs_def
+                split: option.splits kernel_object.splits arch_kernel_obj.splits)
+     apply (frule invs_valid_idle)
+     apply (clarsimp simp: valid_idle_def pred_tcb_at_def)
+     apply (frule invs_iflive)
+     apply (frule invs_valid_global_refs)
+     apply (frule invs_valid_objs)
+     apply (drule (1) idle_no_ex_cap)
+     apply (erule swap, erule if_live_then_nonz_capD)
+      apply simp
+     apply clarsimp
+   apply (clarsimp simp: live_def hyp_live_def)
+  done
+
+crunch invoke_vcpu_inject_irq, invoke_vcpu_read_register, invoke_vcpu_write_register, invoke_vcpu_ack_vppi, perform_smc_invocation
+  for globals_equiv[wp]: "globals_equiv s"
+  (wp: dmo_globals_equiv)
+
+lemma perform_vcpu_invocation_globals_equiv:
+  "\<lbrace>globals_equiv s and invs and valid_vcpu_invocation iv\<rbrace>
+   perform_vcpu_invocation iv
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding perform_vcpu_invocation_def valid_vcpu_invocation_def
+  by (cases iv; wpsimp)
+
+lemma perform_sgi_invocation_reads_respects:
+  "reads_respects aag l \<top>
+                  (perform_sgi_invocation api)"
+  unfolding perform_sgi_invocation_def sendSGI_def
+  by (case_tac api; wpsimp wp: dmo_mol_reads_respects)
+
+lemma perform_smc_invocation_reads_respects:
+  "reads_respects aag l \<top> (perform_smc_invocation api)"
+  unfolding perform_smc_invocation_def
+  by (case_tac api; wpsimp wp: dmo_doSMC_mop_reads_respects)
 
 
 definition authorised_for_globals_arch_inv ::
@@ -1170,7 +3443,6 @@ definition authorised_for_globals_arch_inv ::
              | InvokePage oper \<Rightarrow> authorised_for_globals_page_inv oper
              | _ \<Rightarrow> \<top>"
 
-
 lemma arch_perform_invocation_reads_respects_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows "reads_respects_g aag l (ct_active and authorised_arch_inv aag ai and valid_arch_inv ai
@@ -1178,16 +3450,22 @@ lemma arch_perform_invocation_reads_respects_g:
                                            and pas_refined aag and is_subject aag \<circ> cur_thread)
                           (arch_perform_invocation ai)"
   unfolding arch_perform_invocation_def fun_app_def
-  apply (case_tac ai; rule equiv_valid_guard_imp)
+  apply (case_tac ai; clarsimp)
   by (wpsimp wp: doesnt_touch_globalsI
                  reads_respects_g[OF perform_page_table_invocation_reads_respects]
                  reads_respects_g[OF perform_page_invocation_reads_respects]
                  reads_respects_g[OF perform_asid_control_invocation_reads_respects]
+                 reads_respects_g[OF perform_vspace_invocation_reads_respects]
+                 reads_respects_g[OF perform_vcpu_invocation_reads_respects]
+                 reads_respects_g[OF perform_sgi_invocation_reads_respects]
+                 reads_respects_g[OF perform_smc_invocation_reads_respects]
                  perform_asid_pool_invocation_reads_respects_g
                  perform_page_table_invocation_globals_equiv
                  perform_page_invocation_globals_equiv
                  perform_asid_control_invocation_globals_equiv
                  perform_asid_pool_invocation_globals_equiv
+                 perform_vcpu_invocation_globals_equiv
+                 perform_sgi_invocation_globals_equiv
            simp: authorised_arch_inv_def valid_arch_inv_def authorised_for_globals_arch_inv_def
                  invs_psp_aligned invs_valid_objs invs_vspace_objs invs_valid_asid_table | simp)+
 
@@ -1200,16 +3478,13 @@ lemma arch_perform_invocation_globals_equiv:
   apply (wpsimp wp: perform_page_table_invocation_globals_equiv
                     perform_page_invocation_globals_equiv
                     perform_asid_control_invocation_globals_equiv
-                    perform_asid_pool_invocation_globals_equiv)+
+                    perform_asid_pool_invocation_globals_equiv
+                    perform_vcpu_invocation_globals_equiv)+
   apply (auto simp: authorised_for_globals_arch_inv_def invs_def valid_state_def valid_arch_inv_def)
   done
 
 crunch arch_post_cap_deletion
   for valid_global_objs[wp]: "valid_global_objs"
-
-lemma get_thread_state_globals_equiv[wp]:
-  "get_thread_state ref \<lbrace>globals_equiv s\<rbrace>"
-  by wp
 
 (* generalises auth_ipc_buffers_mem_Write *)
 lemma auth_ipc_buffers_mem_Write':
@@ -1224,16 +3499,6 @@ lemma auth_ipc_buffers_mem_Write':
    apply (auto dest: ipcframe_subset_page)
   done
 
-lemma thread_set_globals_equiv:
-  "(\<And>tcb. arch_tcb_context_get (tcb_arch (f tcb)) = arch_tcb_context_get (tcb_arch tcb))
-   \<Longrightarrow> \<lbrace>globals_equiv s and valid_arch_state\<rbrace> thread_set f tptr \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding thread_set_def
-  apply (wp set_object_globals_equiv)
-  apply simp
-  apply (intro impI conjI allI)
-    apply (fastforce simp: valid_arch_state_def obj_at_def get_tcb_def dest: valid_global_arch_objs_pt_at)+
-  done
-
 end
 
 hide_fact as_user_globals_equiv
@@ -1245,7 +3510,6 @@ requalify_consts
 
 requalify_facts
   arch_post_cap_deletion_valid_global_objs
-  get_thread_state_globals_equiv
   auth_ipc_buffers_mem_Write'
   thread_set_globals_equiv
   arch_post_modify_registers_cur_domain
@@ -1262,7 +3526,6 @@ requalify_facts
 
 declare
   arch_post_cap_deletion_valid_global_objs[wp]
-  get_thread_state_globals_equiv[wp]
   arch_post_modify_registers_cur_domain[wp]
   arch_post_modify_registers_cur_thread[wp]
   prepare_thread_delete_st_tcb_at_halted[wp]
@@ -1270,8 +3533,5 @@ declare
 end
 
 declare as_user_globals_equiv[wp]
-
-axiomatization dmo_reads_respects where
-  dmo_read_stval_reads_respects: "reads_respects aag l \<top> (do_machine_op read_stval)"
 
 end

--- a/proof/infoflow/AARCH64/ArchCNode_IF.thy
+++ b/proof/infoflow/AARCH64/ArchCNode_IF.thy
@@ -28,48 +28,19 @@ lemma set_object_globals_equiv:
   apply (clarsimp simp: globals_equiv_def idle_equiv_def tcb_at_def2)
   done
 
-lemma set_object_globals_equiv'':
-  "\<lbrace>globals_equiv s and (\<lambda> s. ptr \<noteq> arm_us_global_vspace (arch_state s)) and (\<lambda>t. ptr \<noteq> idle_thread t)\<rbrace>
-   set_object ptr obj
-   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  by (wpsimp wp: set_object_globals_equiv)
-
-lemma set_cap_globals_equiv':
-  "\<lbrace>globals_equiv s and (\<lambda> s. fst p \<noteq> arm_us_global_vspace (arch_state s))\<rbrace>
-   set_cap cap p
-   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_cap_def
-  apply (simp only: split_def)
-  apply (wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
-  apply (fastforce simp: obj_at_def is_tcb_def)
-  done
-
 lemma set_cap_globals_equiv[CNode_IF_assms]:
-  "\<lbrace>globals_equiv s and valid_global_objs and valid_arch_state\<rbrace>
+  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
    set_cap cap p
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding set_cap_def
   apply (simp only: split_def)
   apply (wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
-  apply (fastforce simp: is_tcb_def obj_at_def valid_arch_state_def
-                   dest: valid_global_arch_objs_pt_at)
+  apply (fastforce simp: valid_arch_state_def obj_at_def is_tcb_def
+                   dest: valid_global_arch_objs_pt_at)+
   done
 
 definition irq_at :: "nat \<Rightarrow> (irq \<Rightarrow> bool) \<Rightarrow> irq option" where
-  "irq_at pos masks \<equiv> let i = irq_oracle pos in (if i = 0x3F \<or> masks i then None else Some i)"
-
-lemma dmo_getActiveIRQ_wp[CNode_IF_assms]:
-  "\<lbrace>\<lambda>s. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
-          (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>)\<rbrace>
-   do_machine_op (getActiveIRQ in_kernel)
-   \<lbrace>P\<rbrace>"
-  apply (simp add: do_machine_op_def getActiveIRQ_def non_kernel_IRQs_def)
-  apply (wp modify_wp | wpc)+
-  apply clarsimp
-  apply (erule use_valid)
-   apply (wp modify_wp)
-  apply (auto simp: irq_at_def Let_def split: if_splits)
-  done
+  "irq_at pos masks \<equiv> let i = irq_oracle pos in (if masks i then None else Some i)"
 
 lemma arch_globals_equiv_irq_state_update[CNode_IF_assms, simp]:
   "arch_globals_equiv ct it kh kh' as as' ms (irq_state_update f ms') =
@@ -124,14 +95,23 @@ lemma dmo_getActiveIRQ_reads_respects[CNode_IF_assms]:
   notes gets_ev[wp del]
   shows "reads_respects aag l (invs and only_timer_irq_inv irq st)
                        (do_machine_op (getActiveIRQ in_kernel))"
-  apply (rule use_spec_ev)
-  apply (rule do_machine_op_spec_reads_respects')
+  apply (rule do_machine_op_reads_respects')
    apply (simp add: getActiveIRQ_def)
    apply (wp irq_state_increment_reads_respects_memory irq_state_increment_reads_respects_device
              gets_ev[where f="irq_oracle \<circ> irq_state"] equiv_valid_inv_conj_lift
              gets_irq_masks_equiv_valid modify_wp
           | simp add: no_irq_def)+
   apply (rule only_timer_irq_inv_determines_irq_masks, blast+)
+   apply (wpsimp simp: irq_state_independent_def)+
+  done
+
+lemma dmo_getActiveIRQ_globals_equiv[CNode_IF_assms]:
+  "do_machine_op (getActiveIRQ in_kernel) \<lbrace>globals_equiv st\<rbrace>"
+  unfolding globals_equiv_def arch_globals_equiv_def idle_equiv_def
+  apply (rule hoare_weaken_pre)
+   apply wps
+   apply wpsimp
+  apply clarsimp
   done
 
 end

--- a/proof/infoflow/AARCH64/ArchDecode_IF.thy
+++ b/proof/infoflow/AARCH64/ArchDecode_IF.thy
@@ -46,19 +46,21 @@ lemma arch_decode_irq_control_invocation_rev[Decode_IF_assms]:
      (arch_decode_irq_control_invocation label args slot caps)"
   unfolding arch_decode_irq_control_invocation_def arch_check_irq_def
   apply (wp ensure_empty_rev lookup_slot_for_cnode_op_rev
-            is_irq_active_rev whenE_inv
+            is_irq_active_rev whenE_inv range_check_ev
          | wp (once) hoare_drop_imps
-         | simp add: Let_def)+
+         | simp add: Let_def unlessE_def split del: if_split)+
   apply safe
-       apply simp+
-    apply (blast intro: aag_Control_into_owns_irq )
+           apply simp+
+      apply (blast intro: aag_Control_into_owns_irq)
+     apply (drule_tac x="caps ! 0" in bspec)
+      apply (fastforce intro: bang_0_in_set)
+     apply (drule (1) is_cnode_into_is_subject; blast dest: prop_of_obj_ref_of_cnode_cap)
+    apply (fastforce dest: is_cnode_into_is_subject intro: bang_0_in_set)
    apply (drule_tac x="caps ! 0" in bspec)
     apply (fastforce intro: bang_0_in_set)
    apply (drule (1) is_cnode_into_is_subject; blast dest: prop_of_obj_ref_of_cnode_cap)
   apply (fastforce dest: is_cnode_into_is_subject intro: bang_0_in_set)
   done
-
-requalify_facts check_valid_ipc_buffer_inv
 
 end
 
@@ -77,6 +79,7 @@ lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq'':
   "\<lbrakk> \<forall>asid. is_subject_asid aag asid; reads_equiv aag s t; pas_refined aag x \<rbrakk>
      \<Longrightarrow> arm_asid_table (arch_state s) (asid_high_bits_of base) =
          arm_asid_table (arch_state t) (asid_high_bits_of base)"
+  supply asid_high_bits_of_0[simp del]
   apply (subgoal_tac "asid_high_bits_of 0 = asid_high_bits_of 1")
    apply (case_tac "base = 0")
     apply (subgoal_tac "is_subject_asid aag 1")
@@ -172,6 +175,13 @@ lemma decode_asid_control_invocation_reads_respects_f:
   apply fastforce
   done
 
+lemma reads_respects_f_check_vspace_root[wp]:
+  notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
+  notes whenE_wps[wp_split del]
+  shows "reads_respects_f aag l \<top> (check_vspace_root cap arg)"
+  unfolding check_vspace_root_def
+  by (rule equiv_valid_guard_imp, wpsimp+)
+
 lemma decode_frame_invocation_reads_respects_f:
   notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
   notes whenE_wps[wp_split del]
@@ -179,15 +189,15 @@ lemma decode_frame_invocation_reads_respects_f:
     "reads_respects_f aag l
        (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
                         and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)
-                        and K (cap = FrameCap p R sz dev m)
+                        and valid_arch_cap cap and K (cap = FrameCap p R sz dev m)
                         and K (\<forall>(cap, slot) \<in> {(cap.ArchObjectCap cap, slot)} \<union> set excaps.
                                  aag_cap_auth aag (pasObjectAbs aag (fst slot)) cap \<and>
                                  is_subject aag (fst slot) \<and>
                                  (\<forall>v \<in> cap_asid' cap. is_subject_asid aag v)))
         (decode_frame_invocation label args slot cap excaps)"
-  unfolding decode_frame_invocation_def decode_fr_inv_map_def
-            check_slot_def check_vp_alignment_def gets_the_def
-  supply gets_the_ev[wp del]
+  unfolding decode_frame_invocation_def decode_fr_inv_map_def decode_fr_inv_flush_def
+            check_vp_alignment_def gets_the_def
+  apply (rule gen_asm_ev)+
   apply (rule equiv_valid_guard_imp)
    apply ((wp gets_ev' check_vp_wpR  reads_respects_f_inv'[OF get_asid_pool_rev]
               reads_respects_f_inv'[OF ensure_empty_rev]
@@ -202,37 +212,31 @@ lemma decode_frame_invocation_reads_respects_f:
            | wpc
            | simp add: Let_def unlessE_whenE
            | wp (once) whenE_throwError_wp)+)[1]
-  apply clarsimp
+  apply (case_tac "invocation_type label = ArchInvocationLabel ARMPageMap"; clarsimp)
   apply (drule_tac x="excaps ! 0" in bspec, fastforce intro: bang_0_in_set)+
-  apply (intro conjI; clarsimp)
-   apply (fastforce dest: cte_wp_valid_cap simp: valid_cap_def wellformed_mapdata_def)
-  apply (prop_tac "args ! 0 \<in> user_region")
-   apply (drule not_le_imp_less)
-   apply (frule order.strict_implies_order[where b=user_vtop])
-   apply (drule order.strict_trans[OF _ user_vtop_pptr_base])
-   apply (drule canonical_below_pptr_base_user)
-    apply (erule below_user_vtop_canonical)
-   apply (clarsimp simp: user_region_def)
-   apply (drule is_aligned_no_overflow_mask)
-   apply (erule (1) dual_order.trans)
-  apply (rule conjI; clarsimp)
-   apply (clarsimp simp: reads_equiv_f_def)
-   apply (frule vspace_for_asid_vs_lookup)
-   apply (frule_tac pt=xa and level=max_pt_level and bot_level=0 in pt_walk_reads_equiv,
-          (fastforce dest: aag_has_Control_iff_owns
-                     elim: vs_lookup_table_vref_independent
-                     simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def
-                           pt_lookup_slot_def pt_lookup_slot_from_level_def obind_def
-                    split: option.splits)+)[1]
-  apply (subgoal_tac "is_subject aag (table_base bb)", clarsimp)
-  apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def vspace_for_asid_def)
-  apply (frule pt_walk_is_aligned)
-   apply (erule (1) vspace_for_pool_is_aligned[OF _ _ user_region0]; clarsimp)
   apply clarsimp
-  apply (erule_tac asid=a in pt_walk_is_subject[rotated 4]; clarsimp?)
-   apply (clarsimp simp: vs_lookup_table_def in_omonad)
-  apply (fastforce intro: vspace_for_asid_is_subject simp: vspace_for_asid_def in_omonad)
-  done
+  apply (case_tac "m = None \<and> \<not> user_vtop < args ! 0 + mask (pageBitsForSize sz) \<or> (m = Some (asid, args ! 0))")
+   prefer 2
+   apply clarsimp
+  apply (prop_tac "\<not> user_vtop < args ! 0 + mask (pageBitsForSize sz) \<longrightarrow> args ! 0 \<in> user_region")
+   apply (clarsimp simp: user_region_def not_le)
+   apply (rule user_vtop_leq_canonical_user)
+   apply (simp add: vmsz_aligned_def not_less)
+   apply (drule is_aligned_no_overflow_mask)
+   apply simp
+  apply (prop_tac "args ! 0 \<in> user_region")
+   apply (fastforce simp: valid_arch_cap_def wellformed_mapdata_def)
+  apply (subgoal_tac "(\<forall>t. reads_equiv_f aag s t \<and> affects_equiv aag l s t \<longrightarrow>
+                           pt_lookup_slot pt (args ! 0) (ptes_of s) = pt_lookup_slot pt (args ! 0) (ptes_of t))")
+   apply clarsimp
+  apply (clarsimp simp: reads_equiv_f_def)
+  apply (frule vspace_for_asid_vs_lookup)
+  apply (frule_tac pt=pt and level=max_pt_level and bot_level=0 in pt_walk_reads_equiv)
+  by (fastforce dest: aag_has_Control_iff_owns
+                elim: vs_lookup_table_vref_independent
+                simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def
+                      pt_lookup_slot_def pt_lookup_slot_from_level_def obind_def
+               split: option.splits)+
 
 lemma decode_page_table_invocation_reads_respects_f:
   notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
@@ -241,65 +245,156 @@ lemma decode_page_table_invocation_reads_respects_f:
     "reads_respects_f aag l
        (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
                         and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)
-                        and K (cap = PageTableCap p m)
+                        and valid_arch_cap cap and K (cap = PageTableCap p pt_t m)
                         and K (\<forall>(cap, slot) \<in> {(cap.ArchObjectCap cap, slot)} \<union> set excaps.
                                  aag_cap_auth aag (pasObjectAbs aag (fst slot)) cap \<and>
                                  is_subject aag (fst slot) \<and>
                                  (\<forall>v \<in> cap_asid' cap. is_subject_asid aag v)))
         (decode_page_table_invocation label args slot cap excaps)"
   unfolding decode_page_table_invocation_def decode_pt_inv_map_def gets_the_def
-  supply gets_the_ev[wp del]
-  apply (rule equiv_valid_guard_imp)
-   apply ((wp gets_ev' check_vp_wpR reads_respects_f_inv'[OF get_asid_pool_rev]
-              reads_respects_f_inv'[OF ensure_empty_rev]
-              reads_respects_f_inv'[OF get_pte_rev]
-              reads_respects_f_inv'[OF lookup_slot_for_cnode_op_rev]
-              reads_respects_f_inv'[OF ensure_no_children_rev]
-              reads_respects_f_inv'[OF lookup_error_on_failure_rev]
-              find_vspace_for_asid_reads_respects
-              is_final_cap_reads_respects
-              select_ext_ev_bind_lift
-              select_ext_ev_bind_lift[simplified]
-           | simp add: Let_def unlessE_whenE if_fun_split
-           | wpc
-           | wp (once) whenE_throwError_wp hoare_drop_imps)+)[1]
+  apply (wp gets_ev' check_vp_wpR reads_respects_f_inv'[OF get_asid_pool_rev]
+            reads_respects_f_inv'[OF ensure_empty_rev]
+            reads_respects_f_inv'[OF get_pte_rev]
+            reads_respects_f_inv'[OF lookup_slot_for_cnode_op_rev]
+            reads_respects_f_inv'[OF ensure_no_children_rev]
+            reads_respects_f_inv'[OF lookup_error_on_failure_rev]
+            find_vspace_for_asid_reads_respects
+            is_final_cap_reads_respects
+            select_ext_ev_bind_lift
+            select_ext_ev_bind_lift[simplified]
+         | wpc
+         | simp add: Let_def unlessE_whenE if_fun_split
+         | wp (once) whenE_throwError_wp hoare_drop_imps)+
   apply clarsimp
   apply (rule conjI; clarsimp)
    apply (drule_tac x="excaps ! 0" in bspec, fastforce intro: bang_0_in_set)+
    apply (prop_tac "args ! 0 \<in> user_region")
-    apply (drule not_le_imp_less)
-    apply (frule order.strict_implies_order[where b=user_vtop])
-    apply (drule order.strict_trans[OF _ user_vtop_pptr_base])
-    apply (drule canonical_below_pptr_base_user)
-     apply (erule below_user_vtop_canonical)
-    apply (clarsimp simp: user_region_def)
-   apply clarsimp
-   apply (intro conjI impI allI; clarsimp)
-     apply (fastforce dest: cte_wp_valid_cap simp: valid_cap_def wellformed_mapdata_def)
+    apply (clarsimp simp: user_region_def not_le)
+    apply (rule user_vtop_leq_canonical_user)
+    apply (simp add: vmsz_aligned_def not_less)
+   apply (clarsimp cong: conj_cong imp_cong)
+   apply (rule context_conjI; clarsimp)
     apply (clarsimp simp: reads_equiv_f_def)
     apply (frule vspace_for_asid_vs_lookup)
-    apply (frule_tac pt=xa and level=max_pt_level and bot_level=0 in pt_walk_reads_equiv,
+    apply (frule_tac pt=pt and level=max_pt_level and bot_level=0 in pt_walk_reads_equiv,
            (fastforce dest: aag_has_Control_iff_owns
                       elim: vs_lookup_table_vref_independent
                       simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def
                             pt_lookup_slot_def pt_lookup_slot_from_level_def obind_def
                      split: option.splits)+)[1]
-   apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def vspace_for_asid_def)
-   apply (frule pt_walk_is_aligned)
-    apply (erule (1) vspace_for_pool_is_aligned[OF _ _ user_region0]; clarsimp)
-   apply clarsimp
-   apply (erule_tac asid=a in pt_walk_is_subject[rotated 4]; clarsimp?)
-    apply (clarsimp simp: vs_lookup_table_def in_omonad)
-   apply (fastforce intro: vspace_for_asid_is_subject simp: vspace_for_asid_def in_omonad)
-  apply (rule conjI, fastforce elim!: is_subject_not_silc_inv)+
-  apply (clarsimp simp: reads_equiv_f_def)
-  apply (erule reads_equivE)
-  apply (clarsimp simp: equiv_asids_def equiv_asid_def)
-  apply (erule_tac x=a in allE)
-  apply (fastforce simp: vspace_for_asid_def pool_for_asid_def vspace_for_pool_def
-                         asid_pools_of_ko_at obj_at_def obind_def opt_map_def
-                  split: option.splits)
+   apply (frule (3) pt_lookup_slot_pte_at)
+   apply (clarsimp simp: pte_at_def2)
+   apply (frule vspace_for_asid_is_subject, fastforce+)
+   apply (clarsimp simp: pt_lookup_slot_def)
+   apply (erule pt_lookup_slot_from_level_is_subject)
+          apply fastforce+
+      apply (fastforce dest: vspace_for_asid_vs_lookup vs_lookup_table_vref_independent)
+     apply clarsimp+
+  apply (intro conjI)
+     apply fastforce
+    apply fastforce
+   apply fastforce
+  apply (fastforce dest: silc_inv_not_subject)
   done
+
+lemma reads_respects_gets_lookup_frame:
+  "reads_respects aag l
+     (pas_refined aag and pspace_aligned and valid_vspace_objs and valid_asid_table
+                      and (\<lambda>s. \<exists>asid. vspace_for_asid asid s = Some pt \<and>
+                               is_subject_asid aag asid \<and> vptr \<in> user_region))
+               (gets (lookup_frame pt vptr \<circ> ptes_of))"
+  apply (wp gets_ev')
+  apply (clarsimp simp: lookup_frame_def pt_lookup_slot_def)
+  apply (frule (3) vspace_for_asid_is_subject)
+  apply (frule vspace_for_asid_vs_lookup)
+  apply (rule obind_eqI_full)
+   apply (frule (6) pt_walk_reads_equiv[where bot_level=0])
+     apply (rule order_refl)
+    apply (erule vs_lookup_table_vref_independent[OF _ order_refl])
+   apply (clarsimp simp: pt_lookup_slot_from_level_def obind_def split: option.splits)
+  apply clarsimp
+  apply (rule obind_eqI; clarsimp simp: obind_def)
+  apply (rule_tac aag=aag in ptes_of_reads_equiv)
+  by (fastforce elim: vs_lookup_table_vref_independent pt_lookup_slot_from_level_is_subject)
+
+lemma decode_vspace_invocation_reads_respects_f:
+  notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
+  notes whenE_wps[wp_split del]
+  shows
+    "reads_respects_f aag l
+       (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (cap.ArchObjectCap cap)) slot
+                        and valid_arch_cap cap
+                        and K (aag_cap_auth aag (pasObjectAbs aag (fst slot)) (ArchObjectCap cap) \<and>
+                               is_subject aag (fst slot) \<and>
+                               (\<forall>v \<in> cap_asid' (ArchObjectCap cap). is_subject_asid aag v)))
+        (decode_vspace_invocation label args slot cap excaps)"
+  unfolding decode_vspace_invocation_def decode_vs_inv_flush_def
+  apply (wpsimp wp: reads_respects_f_inv'[OF reads_respects_gets_lookup_frame]
+                    reads_respects_f_inv'[OF lookup_error_on_failure_rev]
+                    find_vspace_for_asid_reads_respects whenE_throwError_wp hoare_vcg_all_lift
+              simp: Let_def)+
+  apply (fastforce intro: user_vtop_leq_canonical_user simp: user_region_def user_vtop_def)
+  done
+
+lemma aag_cap_auth_VCPUCap:
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (VCPUCap vcpu_ptr)); pas_refined aag s \<rbrakk>
+     \<Longrightarrow> is_subject aag vcpu_ptr"
+  unfolding aag_cap_auth_def
+  by (simp add: clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
+                cli_no_irqs pas_refined_all_auth_is_owns)
+
+lemma decode_vcpu_inject_irq_reads_respects_f:
+  "\<lbrakk> cap = VCPUCap vcpu_ptr; invocation_type label = ArchInvocationLabel ARMVCPUInjectIRQ\<rbrakk>
+     \<Longrightarrow> reads_respects_f aag l
+           (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (ArchObjectCap cap)) slot
+                            and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)
+                            and valid_arch_cap cap
+                            and K (\<forall>(cap, slot) \<in> {(cap.ArchObjectCap cap, slot)} \<union> set excaps.
+                                     aag_cap_auth aag (pasObjectAbs aag (fst slot)) cap \<and>
+                                     is_subject aag (fst slot) \<and>
+                                     (\<forall>v \<in> cap_asid' cap. is_subject_asid aag v)))
+            (decode_vcpu_inject_irq args (VCPUCap vcpu_ptr))"
+  unfolding decode_vcpu_inject_irq_def range_check_def unlessE_whenE
+  apply (wpsimp wp: reads_respects_f[OF get_vcpu_reads_respects, where st=st])
+  apply (prop_tac "valid_numlistregs x")
+   apply (frule invs_arch_state)
+   apply (clarsimp simp: valid_arch_state_def)
+  apply (clarsimp simp: valid_numlistregs_def)
+  apply (auto simp: aag_cap_auth_VCPUCap reads_equiv_f_def reads_equiv_def2
+                    states_equiv_for_def equiv_hyp_def equiv_for_def
+              dest: aag_can_read_self)
+  done
+
+lemma decode_vcpu_invocation_reads_respects_f:
+  notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
+  notes whenE_wps[wp_split del]
+  shows
+    "reads_respects_f aag l
+       (silc_inv aag st and invs and pas_refined aag and cte_wp_at ((=) (ArchObjectCap cap)) slot
+                        and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)
+                        and valid_arch_cap cap
+                        and K (\<forall>(cap, slot) \<in> {(cap.ArchObjectCap cap, slot)} \<union> set excaps.
+                                 aag_cap_auth aag (pasObjectAbs aag (fst slot)) cap \<and>
+                                 is_subject aag (fst slot) \<and>
+                                 (\<forall>v \<in> cap_asid' cap. is_subject_asid aag v)))
+        (decode_vcpu_invocation label args cap excaps)"
+  unfolding decode_vcpu_invocation_def
+  apply (cases cap; clarsimp; (solves wp)?)
+  apply (cases "invocation_type label"; clarsimp; (solves wp)?)
+  by (wpsimp wp: decode_vcpu_inject_irq_reads_respects_f
+           simp: decode_vcpu_read_register_def decode_vcpu_write_register_def
+                 decode_vcpu_set_tcb_def decode_vcpu_ack_vppi_def arch_check_irq_def
+      | fastforce)+
+
+lemma decode_sgi_signal_invocation_reads_respects_f[wp]:
+  "reads_respects_f aag l \<top> (decode_sgi_signal_invocation (SGISignalCap irq target))"
+  unfolding decode_sgi_signal_invocation_def
+  by wpsimp
+
+lemma decode_smc_invocation_reads_respects_f[wp]:
+  "reads_respects_f aag l \<top> (decode_smc_invocation label args cap)"
+  unfolding decode_smc_invocation_def
+  by (wpsimp simp: unlessE_whenE)
 
 lemma arch_decode_invocation_reads_respects_f[Decode_IF_assms]:
   notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
@@ -314,11 +409,15 @@ lemma arch_decode_invocation_reads_respects_f[Decode_IF_assms]:
                                  (\<forall>v \<in> cap_asid' cap. is_subject_asid aag v)))
         (arch_decode_invocation label args cap_index slot cap excaps)"
   unfolding arch_decode_invocation_def
-  apply (cases cap; rule equiv_valid_guard_imp)
+  apply (cases cap; clarsimp; rule equiv_valid_guard_imp)
   by (wpsimp wp: decode_asid_pool_invocation_reads_respects_f
                  decode_asid_control_invocation_reads_respects_f
                  decode_frame_invocation_reads_respects_f
-                 decode_page_table_invocation_reads_respects_f | fastforce)+
+                 decode_vspace_invocation_reads_respects_f
+                 decode_vcpu_invocation_reads_respects_f
+                 decode_page_table_invocation_reads_respects_f
+      | fastforce dest: caps_of_state_valid cte_wp_at_caps_of_state'
+                  simp: valid_cap_def valid_arch_cap_def)+
 
 end
 

--- a/proof/infoflow/AARCH64/ArchFinalCaps.thy
+++ b/proof/infoflow/AARCH64/ArchFinalCaps.thy
@@ -46,14 +46,41 @@ lemma set_asid_pool_silc_inv[wp]:
   apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
   done
 
-crunch arch_finalise_cap, prepare_thread_delete, init_arch_objects
+lemma set_vcpu_silc_inv:
+  "\<lbrace>silc_inv aag st\<rbrace>
+   set_vcpu ptr vcpu
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding set_vcpu_def
+  apply (rule silc_inv_pres)
+    apply (wpsimp wp: set_object_wp_strong get_object_wp simp: obj_at_def)
+    apply (drule (1) silc_inv_cnode_only)
+    apply (fastforce simp: silc_inv_def obj_at_def is_cap_table_def split: kernel_object.splits)
+   apply (wpsimp wp: set_object_wp get_object_wp)
+  apply (wpsimp wp: set_object_wp_strong get_object_wp simp: obj_at_def)
+  apply (case_tac "ptr = fst (a,b)")
+   apply (fastforce elim: cte_wp_atE simp: obj_at_def)
+  apply (fastforce elim: cte_wp_atE intro: cte_wp_at_cteI cte_wp_at_tcbI)
+  done
+
+crunch vcpu_switch
+  for silc_inv[wp]: "silc_inv aag st"
+  (wp: mapM_x_wp_inv mapM_wp_inv)
+
+crunch associate_vcpu_tcb
+  for silc_inv[wp]: "silc_inv aag st"
+  (wp: crunch_wps simp: arch_thread_set_is_thread_set)
+
+crunch arch_finalise_cap, prepare_thread_delete
   for silc_inv[FinalCaps_assms, wp]: "silc_inv aag st"
   (wp: crunch_wps modify_wp simp: crunch_simps ignore: set_object)
 
-crunch handle_reserved_irq, handle_vm_fault, handle_hypervisor_fault, handle_arch_fault_reply,
-         arch_invoke_irq_handler, arch_mask_irq_signal,
-         arch_post_cap_deletion, arch_post_modify_registers,
-         arch_activate_idle_thread, arch_switch_to_idle_thread, arch_switch_to_thread
+crunch init_arch_objects
+  for silc_inv[FinalCaps_assms, wp]: "silc_inv aag st"
+  (wp: crunch_wps modify_wp simp: crunch_simps ignore: set_object)
+
+crunch handle_vm_fault, handle_arch_fault_reply, arch_invoke_irq_handler, arch_mask_irq_signal,
+       arch_post_cap_deletion, arch_post_modify_registers, arch_activate_idle_thread,
+       arch_switch_to_idle_thread, arch_switch_to_thread
   for silc_inv[FinalCaps_assms, wp]: "silc_inv aag st"
 
 lemma arch_derive_cap_silc[FinalCaps_assms]:
@@ -69,7 +96,6 @@ lemma arch_derive_cap_silc[FinalCaps_assms]:
 declare init_arch_objects_cte_wp_at[FinalCaps_assms]
 declare handle_vm_fault_cur_thread[FinalCaps_assms]
 declare finalise_cap_makes_halted[FinalCaps_assms]
-declare init_arch_objects_inv[FinalCaps_assms]
 
 end
 
@@ -113,11 +139,11 @@ lemmas perform_page_table_invocation_silc_inv_get_cap_helper' =
   perform_page_table_invocation_silc_inv_get_cap_helper[simplified o_def fun_app_def]
 
 lemma mapM_x_swp_store_pte_silc_inv[wp]:
-  "mapM_x (swp store_pte A) slots \<lbrace>silc_inv aag st\<rbrace>"
+  "mapM_x (swp (store_pte pt_t) A) slots \<lbrace>silc_inv aag st\<rbrace>"
   by (wp mapM_x_wp[OF _ subset_refl] | simp add: swp_def)+
 
 lemma is_arch_eq_pt_is_pt_or_frame_cap:
-  "cte_wp_at ((=) (ArchObjectCap (PageTableCap xa xb))) slot s
+  "cte_wp_at ((=) (ArchObjectCap (PageTableCap pt_t xa xb))) slot s
    \<Longrightarrow> cte_wp_at (\<lambda>a. is_pt_cap a \<or> is_frame_cap a) slot s"
   apply (erule cte_wp_at_weakenE)
   by (clarsimp simp: is_frame_cap_def is_pt_cap_def)
@@ -151,6 +177,9 @@ lemma perform_page_table_invocation_silc_inv:
   apply fastforce
   done
 
+crunch invalidate_tlb_by_asid_va, perform_flush
+  for silc_inv[FinalCaps_assms, wp]: "silc_inv aag st"
+
 lemma perform_page_invocation_silc_inv:
   "\<lbrace>silc_inv aag st and valid_page_inv blah and authorised_page_inv aag blah\<rbrace>
    perform_page_invocation blah
@@ -167,10 +196,15 @@ lemma perform_page_invocation_silc_inv:
   apply (clarsimp simp: valid_page_inv_def authorised_page_inv_def
                   split: page_invocation.splits)
    apply (intro allI impI conjI)
-    apply (drule_tac slot="(ab,bc)" in overlapping_slots_have_labelled_overlapping_caps[rotated])
-      apply (fastforce)
+      apply (drule_tac slot="(ac,bb)" in overlapping_slots_have_labelled_overlapping_caps[rotated])
+        apply (fastforce)+
+       apply (fastforce elim: is_arch_update_overlaps[rotated] cte_wp_at_weakenE)
+      apply fastforce+
+     apply (fastforce simp: silc_inv_def)
+    apply (drule_tac slot="(ac,bb)" in overlapping_slots_have_labelled_overlapping_caps[rotated])
+      apply (fastforce)+
      apply (fastforce elim: is_arch_update_overlaps[rotated] cte_wp_at_weakenE)
-    apply fastforce
+    apply fastforce+
    apply (fastforce simp: silc_inv_def)
   apply (fastforce dest: is_arch_eq_pg_is_pt_or_pg_cap simp: silc_inv_def pred_disj_def)
   done
@@ -188,7 +222,7 @@ lemma perform_asid_control_invocation_silc_inv:
             set_cap_silc_inv get_cap_slots_holding_overlapping_caps[where st=st]
             delete_objects_silc_inv hoare_weak_lift_imp
          | wpc | simp )+
-  apply (clarsimp simp: authorised_asid_control_inv_def silc_inv_def valid_aci_def ptr_range_def page_bits_def)
+  apply (clarsimp simp: authorised_asid_control_inv_def silc_inv_def valid_aci_def ptr_range_def)
   apply (rule conjI)
    apply (clarsimp simp: range_cover_def obj_bits_api_def default_arch_object_def asid_bits_def pageBits_def)
    apply (rule of_nat_inverse)
@@ -206,10 +240,6 @@ lemma perform_asid_control_invocation_silc_inv:
 crunch store_asid_pool_entry, handle_spurious_irq
   for silc_inv[wp]: "silc_inv aag st"
 
-crunch copy_global_mappings
-  for silc_inv[wp]: "silc_inv aag st"
-  (wp: crunch_wps modify_wp simp: crunch_simps ignore: set_object)
-
 lemma perform_asid_pool_invocation_silc_inv:
   "\<lbrace>silc_inv aag st and K (authorised_asid_pool_inv aag blah)\<rbrace>
    perform_asid_pool_invocation blah
@@ -221,6 +251,9 @@ lemma perform_asid_pool_invocation_silc_inv:
                          slots_holding_overlapping_caps_def authorised_asid_pool_inv_def
                          is_ArchObjectCap_def is_PageTableCap_def update_map_data_def)+
   done
+
+crunch perform_vcpu_invocation, perform_vspace_invocation, perform_sgi_invocation, perform_smc_invocation
+  for silc_inv[wp]: "silc_inv aag st"
 
 declare handle_spurious_irq_silc_inv[wp, FinalCaps_assms]
 
@@ -234,8 +267,20 @@ lemma arch_perform_invocation_silc_inv[FinalCaps_assms]:
             perform_page_invocation_silc_inv
             perform_asid_control_invocation_silc_inv
             perform_asid_pool_invocation_silc_inv
+            perform_vcpu_invocation_silc_inv
          | wpc)+
   apply (clarsimp simp: authorised_arch_inv_def valid_arch_inv_def split: arch_invocation.splits)
+  done
+
+lemma new_irq_handler_caps_are_intra_label:
+  "\<lbrakk> cte_wp_at ((=) (IRQControlCap)) slot s; pas_refined aag s; is_subject aag (fst slot) \<rbrakk>
+     \<Longrightarrow> cap_points_to_label aag (IRQHandlerCap irq) (pasSubject aag)"
+  apply (clarsimp simp: cap_points_to_label_def)
+  apply (frule cap_cur_auth_caps_of_state[rotated])
+    apply assumption
+   apply (simp add: cte_wp_at_caps_of_state)
+  apply (clarsimp simp: aag_cap_auth_def cap_links_irq_def)
+  apply (blast intro: aag_Control_into_owns_irq)
   done
 
 lemma arch_invoke_irq_control_silc_inv[FinalCaps_assms]:
@@ -249,6 +294,7 @@ lemma arch_invoke_irq_control_silc_inv[FinalCaps_assms]:
   apply (wp cap_insert_silc_inv'' hoare_vcg_ex_lift slots_holding_overlapping_caps_lift
          | simp add: authorised_irq_ctl_inv_def arch_irq_control_inv_valid_def)+
   apply (fastforce dest: new_irq_handler_caps_are_intra_label)
+  apply (wpsimp wp: cap_insert_silc_inv'' simp: cap_points_to_label_def)
   done
 
 crunch set_priority, set_flags
@@ -256,7 +302,27 @@ crunch set_priority, set_flags
   (simp: tcb_cap_cases_def)
 
 crunch arch_prepare_set_domain, arch_prepare_next_domain, arch_post_set_flags
-  for inv[FinalCaps_assms,wp]: P
+  for silc_inv[FinalCaps_assms, wp]: "silc_inv aag st"
+  (wp: crunch_wps)
+
+lemma tcb_cap_cases_tcb_fault:
+  "\<forall>(getF, a, b)\<in>ran tcb_cap_cases.
+         getF (tcb_fault_update F tcb) = getF tcb"
+  by (rule ball_tcb_cap_casesI, simp+)
+
+lemma case_option_wp_returnOk:
+  assumes [wp]: "\<And>x. \<lbrace>P x\<rbrace> f x \<lbrace>\<lambda>_. Q\<rbrace>"
+  shows "\<lbrace>Q and (\<lambda>s. opt \<noteq> None \<longrightarrow> P (the opt) s)\<rbrace>
+         (case opt of None \<Rightarrow> returnOk rv | Some x \<Rightarrow> f x)
+         \<lbrace>\<lambda>_. Q\<rbrace>"
+  by (cases opt; wpsimp)
+
+lemma case_option_wp_return:
+  assumes [wp]: "\<And>x. \<lbrace>P x\<rbrace> f x \<lbrace>\<lambda>_. Q\<rbrace>"
+  shows "\<lbrace>Q and (\<lambda>s. opt \<noteq> None \<longrightarrow> P (the opt) s)\<rbrace>
+         (case opt of None \<Rightarrow> return rv | Some x \<Rightarrow> f x)
+         \<lbrace>\<lambda>_. Q\<rbrace>"
+  by (cases opt; wpsimp)
 
 lemma invoke_tcb_silc_inv[FinalCaps_assms]:
   notes hoare_weak_lift_imp [wp]
@@ -266,19 +332,21 @@ lemma invoke_tcb_silc_inv[FinalCaps_assms]:
          invoke_tcb tinv
          \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   apply (case_tac tinv)
-         apply ((wp restart_silc_inv hoare_vcg_if_lift suspend_silc_inv mapM_x_wp[OF _ subset_refl]
-                    hoare_weak_lift_imp
-                 | wpc
-                 | simp split del: if_split add: authorised_tcb_inv_def check_cap_at_def
-                 | clarsimp
-                 | strengthen invs_mdb
-                 | force intro: notE[rotated,OF idle_no_ex_cap,simplified])+)[3]
-      defer
-      apply ((wp suspend_silc_inv restart_silc_inv | simp add: authorised_tcb_inv_def | force)+)[2]
-    (* NotificationControl *)
-    apply (rename_tac option)
-    apply (case_tac option; (wp | simp)+)
-   (* SetTLSBase *)
+          apply ((wp restart_silc_inv hoare_vcg_if_lift suspend_silc_inv mapM_x_wp[OF _ subset_refl]
+                     hoare_weak_lift_imp
+                  | wpc
+                  | simp split del: if_split add: authorised_tcb_inv_def check_cap_at_def
+                  | clarsimp
+                  | strengthen invs_mdb
+                  | force intro: notE[rotated,OF idle_no_ex_cap,simplified])+)[3]
+       defer
+       apply ((wp suspend_silc_inv restart_silc_inv | simp add: authorised_tcb_inv_def | force)+)[2]
+     (* NotificationControl *)
+     apply (rename_tac option)
+     apply (case_tac option; (wp | simp)+)
+    (* SetTLSBase *)
+    apply (wpsimp split: option.splits)
+   (* SetFlags *)
    apply (wpsimp split: option.splits)
   (* just ThreadControl left *)
   apply (simp add: split_def cong: option.case_cong)
@@ -286,7 +354,8 @@ lemma invoke_tcb_silc_inv[FinalCaps_assms]:
   apply (strengthen use_no_cap_to_obj_asid_strg
          | clarsimp
          | simp only: conj_ac cong: conj_cong imp_cong
-         | wp checked_insert_pas_refined checked_cap_insert_silc_inv hoare_vcg_all_liftE_R
+         | wp case_option_wp_returnOk case_option_wp_return
+              checked_insert_pas_refined checked_cap_insert_silc_inv hoare_vcg_all_liftE_R
               hoare_vcg_all_lift hoare_vcg_const_imp_liftE_R
               cap_delete_silc_inv_not_transferable
               cap_delete_pas_refined' cap_delete_deletes
@@ -310,16 +379,73 @@ lemma invoke_tcb_silc_inv[FinalCaps_assms]:
          | wp (once) hoare_drop_imps
          | elim disjE; solves clarsimp)+
   (* also slow, ~30s *)
-  apply (intro impI conjI
-         | clarsimp simp: is_cap_simps is_cnode_or_valid_arch_def is_valid_vtable_root_def
-                          authorised_tcb_inv_def emptyable_def
-                   split: cap.splits option.splits)+
+  prefer 1
+  apply (clarsimp simp: is_cap_simps)
+  apply (clarsimp split: option.split_asm)
+  apply (clarsimp simp: is_cap_simps is_cnode_or_valid_arch_def is_valid_vtable_root_def
+                            authorised_tcb_inv_def emptyable_def
+                     split: cap.splits option.splits pt_type.splits arch_cap.splits)+
   done
 
 end
 
 
 global_interpretation FinalCaps_2?: FinalCaps_2
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact FinalCaps_assms)?)
+qed
+
+
+context Arch begin global_naming AARCH64
+
+lemma handle_hypervisor_fault_silc_inv[FinalCaps_assms]:
+  "\<lbrace>silc_inv aag st and invs and pas_refined aag and is_subject aag o cur_thread and K (is_subject aag t)\<rbrace>
+   handle_hypervisor_fault t ex
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  apply (case_tac ex; clarsimp split del: if_split)
+  apply (wpsimp wp: handle_fault_silc_inv simp: valid_fault_def)
+  done
+
+lemma vppi_event_silc_inv:
+  "\<lbrace>silc_inv aag st and invs and pas_refined aag and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))\<rbrace>
+   vppi_event irq
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding vppi_event_def
+  apply (wpsimp wp: gts_wp hoare_vcg_all_lift vcpu_update_trivial_invs maskInterrupt_invs
+                    hoare_vcg_imp_lift  | wps | wp dmo_wp)+
+  apply (clarsimp simp: valid_fault_def)
+  using ct_active_st_tcb_at_weaken runnable_eq by blast
+
+lemma vgic_maintenance_silc_inv:
+  "\<lbrace>silc_inv aag st and invs and pas_refined aag and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))\<rbrace>
+   vgic_maintenance
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding vgic_maintenance_def
+  apply (wpsimp wp: gts_wp hoare_vcg_all_lift hoare_weak_lift_imp dmo_invs_lift
+              simp: crunch_simps valid_fault_def split_del: if_split
+         | wps | wp (once) hoare_drop_imps)+
+  using ct_active_st_tcb_at_weaken runnable_eq by blast
+
+lemma handle_reserved_irq_silc_inv[FinalCaps_assms]:
+  "\<lbrace>silc_inv aag st and invs and pas_refined aag and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))\<rbrace>
+   handle_reserved_irq irq
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding handle_reserved_irq_def
+  by (cases "irq = irqVGICMaintenance"; wpsimp wp: vgic_maintenance_silc_inv vppi_event_silc_inv)
+
+lemma handle_reserved_irq_non_kernel_IRQs[FinalCaps_assms]:
+  "\<lbrace>P and K (irq \<notin> non_kernel_IRQs)\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_. P\<rbrace>"
+  unfolding handle_reserved_irq_def
+  apply (rule hoare_gen_asm)
+  apply (wpsimp wp: when_wp[where P'="\<bottom>"] simp: non_kernel_IRQs_def irq_vppi_event_index_def)
+  done
+
+end
+
+
+global_interpretation FinalCaps_3?: FinalCaps_3
 proof goal_cases
   interpret Arch .
   case 1 show ?case

--- a/proof/infoflow/AARCH64/ArchFinalise_IF.thy
+++ b/proof/infoflow/AARCH64/ArchFinalise_IF.thy
@@ -8,6 +8,8 @@ theory ArchFinalise_IF
 imports Finalise_IF
 begin
 
+(* FIXME AARCH64 IF: clean and refactor theory *)
+
 context Arch begin global_naming AARCH64
 
 named_theorems Finalise_IF_assms
@@ -18,14 +20,7 @@ crunch arch_post_cap_deletion
 
 lemma dmo_maskInterrupt_reads_respects[Finalise_IF_assms]:
   "reads_respects aag l \<top> (do_machine_op (maskInterrupt m irq))"
-  unfolding maskInterrupt_def
-  apply (rule use_spec_ev)
-  apply (rule do_machine_op_spec_reads_respects)
-   apply (simp add: equiv_valid_def2)
-   apply (rule modify_ev2)
-   apply (fastforce simp: equiv_for_def)
-  apply (wp modify_wp | simp)+
-  done
+  by wpsimp
 
 lemma arch_post_cap_deletion_read_respects[Finalise_IF_assms, wp]:
   "reads_respects aag l \<top> (arch_post_cap_deletion acap)"
@@ -69,8 +64,8 @@ lemma set_thread_state_reads_respects[Finalise_IF_assms]:
      apply (rule set_thread_state_act_reads_respects)
     apply (case_tac "aag_can_read aag ref \<or> aag_can_affect aag l ref")
      apply (wp set_object_reads_respects gets_the_ev)
-     apply (fastforce simp: get_tcb_def split: option.splits
-                     elim: reads_equivE affects_equivE equiv_forE)
+     apply fastforce
+    apply (clarsimp simp: equiv_for_def get_tcb_def)
     apply (simp add: equiv_valid_def2)
     apply (rule equiv_valid_rv_bind)
       apply (rule equiv_valid_rv_trivial)
@@ -96,7 +91,8 @@ lemma set_thread_state_runnable_reads_respects[Finalise_IF_assms]:
      apply (rule set_thread_state_act_runnable_reads_respects)
     apply (case_tac "aag_can_read aag ref \<or> aag_can_affect aag l ref")
      apply (wp set_object_reads_respects gets_the_ev)
-     apply (fastforce simp: get_tcb_def split: option.splits elim: reads_equivE affects_equivE equiv_forE)
+     apply fastforce
+    apply (clarsimp simp: equiv_for_def get_tcb_def)
     apply (simp add: equiv_valid_def2)
     apply (rule equiv_valid_rv_bind)
       apply (rule equiv_valid_rv_trivial)
@@ -110,7 +106,7 @@ lemma set_thread_state_runnable_reads_respects[Finalise_IF_assms]:
     apply (blast dest: get_tcb_not_asid_pool_at)
    apply (subst thread_set_def[symmetric, simplified fun_app_def])
    apply (wp thread_set_st_tcb_at | simp)+
-   done
+  done
 
 lemma set_bound_notification_none_reads_respects[Finalise_IF_assms]:
   assumes domains_distinct: "pas_domains_distinct aag"
@@ -119,7 +115,8 @@ lemma set_bound_notification_none_reads_respects[Finalise_IF_assms]:
   apply (rule pre_ev(5)[where Q=\<top>])
    apply (case_tac "aag_can_read aag ref \<or> aag_can_affect aag l ref")
     apply (wp set_object_reads_respects gets_the_ev)[1]
-    apply (fastforce simp: get_tcb_def split: option.splits elim: reads_equivE affects_equivE equiv_forE)
+    apply fastforce
+   apply (clarsimp simp: equiv_for_def get_tcb_def)
    apply (simp add: equiv_valid_def2)
    apply (rule equiv_valid_rv_bind)
      apply (rule equiv_valid_rv_trivial)
@@ -152,7 +149,8 @@ lemma set_tcb_queue_modifies_at_most:
   "modifies_at_most aag L (\<lambda>s. pasDomainAbs aag d \<inter> L \<noteq> {}) (set_tcb_queue d prio queue)"
   apply (rule modifies_at_mostI)
   apply (simp add: set_tcb_queue_def modify_def, wp)
-  apply (force simp: equiv_but_for_labels_def states_equiv_for_def equiv_for_def equiv_asids_def)
+  apply (force simp: equiv_but_for_labels_def states_equiv_for_def equiv_for_def equiv_asids_def
+                     equiv_hyp_def equiv_fpu_def cur_fpu_for_def get_tcb_def)
   done
 
 lemma set_notification_equiv_but_for_labels[Finalise_IF_assms]:
@@ -165,21 +163,16 @@ lemma set_notification_equiv_but_for_labels[Finalise_IF_assms]:
   done
 
 lemma thread_set_reads_respects[Finalise_IF_assms]:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "reads_respects aag l \<top> (thread_set x y)"
-  unfolding thread_set_def fun_app_def
-  apply (case_tac "aag_can_read aag y \<or> aag_can_affect aag l y")
-   apply (wp set_object_reads_respects)
-   apply (clarsimp, rule reads_affects_equiv_get_tcb_eq, simp+)[1]
-  apply (simp add: equiv_valid_def2)
-  apply (rule equiv_valid_rv_guard_imp)
-   apply (rule_tac L="{pasObjectAbs aag y}" and L'="{pasObjectAbs aag y}"
-                in ev2_invisible[OF domains_distinct])
-       apply (assumption | simp add: labels_are_invisible_def)+
-     apply (rule modifies_at_mostI[where P="\<top>"]
-            | wp set_object_equiv_but_for_labels
-            | simp
-            | (clarify, drule get_tcb_not_asid_pool_at))+
+  "reads_respects aag l \<top> (thread_set f thread)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule_tac ptr=thread in reads_respects_unit_cases)
+  unfolding thread_set_def
+     apply (rule gen_asm_ev)
+     apply (wpsimp wp: set_object_reads_respects)
+    apply (wpsimp wp: set_object_equiv_but_for_labels)
+    apply (clarsimp simp: get_tcb_def obj_at_def)
+   apply wpsimp+
+  apply auto
   done
 
 lemma aag_cap_auth_ASIDPoolCap:
@@ -190,7 +183,7 @@ lemma aag_cap_auth_ASIDPoolCap:
                 cli_no_irqs pas_refined_all_auth_is_owns)
 
 lemma aag_cap_auth_PageDirectory:
-  "pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word (Some a))) \<Longrightarrow>
+  "pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word pt_t (Some a))) \<Longrightarrow>
     pas_refined aag s \<Longrightarrow> is_subject aag word"
   unfolding aag_cap_auth_def
   by (simp add: clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
@@ -213,27 +206,27 @@ lemma aag_cap_auth_PageCap_asid:
           intro: pas_refined_Control_into_is_subject_asid)
 
 lemma aag_cap_auth_PageTableCap:
-  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word option)); pas_refined aag s \<rbrakk>
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word pt_t option)); pas_refined aag s \<rbrakk>
      \<Longrightarrow> is_subject aag word"
   unfolding aag_cap_auth_def
   by (simp add: clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
                 cli_no_irqs pas_refined_all_auth_is_owns)
 
 lemma aag_cap_auth_PageTableCap_asid:
-  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word (Some (a, b)))); pas_refined aag s \<rbrakk>
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word pt_t (Some (a, b)))); pas_refined aag s \<rbrakk>
      \<Longrightarrow> is_subject_asid aag a"
   by (auto simp: aag_cap_auth_def cap_links_asid_slot_def label_owns_asid_slot_def
           intro: pas_refined_Control_into_is_subject_asid)
 
 lemma aag_cap_auth_PageDirectoryCap:
-  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word option));  pas_refined aag s \<rbrakk>
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word pt_t option));  pas_refined aag s \<rbrakk>
      \<Longrightarrow> is_subject aag word"
   unfolding aag_cap_auth_def
   by (simp add: clas_no_asid cap_auth_conferred_def arch_cap_auth_conferred_def
                 cli_no_irqs pas_refined_all_auth_is_owns)
 
 lemma aag_cap_auth_PageDirectoryCap_asid:
-  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word (Some (a,vref)))); pas_refined aag s \<rbrakk>
+  "\<lbrakk> pas_cap_cur_auth aag (ArchObjectCap (PageTableCap word pt_t (Some (a,vref)))); pas_refined aag s \<rbrakk>
      \<Longrightarrow> is_subject_asid aag a"
   unfolding aag_cap_auth_def
   by (auto simp: cap_links_asid_slot_def label_owns_asid_slot_def
@@ -243,11 +236,766 @@ lemmas aag_cap_auth_subject = aag_cap_auth_ASIDPoolCap_asid
                               aag_cap_auth_PageCap_asid
                               aag_cap_auth_PageTableCap_asid
 
+(* Helpful groupings *)
+
+definition fpu_save where
+  "fpu_save \<equiv> do
+     cur_fpu_owner \<leftarrow> gets (arm_current_fpu_owner \<circ> arch_state);
+     do_machine_op enableFpu;
+     maybeM save_fpu_state cur_fpu_owner
+  od"
+
+definition fpu_restore where
+  "fpu_restore new_owner \<equiv> do
+     case new_owner of None \<Rightarrow> do_machine_op disableFpu
+        | Some tcb_ptr \<Rightarrow> load_fpu_state tcb_ptr;
+     set_arm_current_fpu_owner new_owner
+   od"
+
+lemma dmo_enableFpu_reads_respects[wp]:
+  "reads_respects_l aag l \<top> (do_machine_op enableFpu)"
+  unfolding enableFpu_def dmo_distr
+  apply wpsimp
+     apply (wpsimp wp: do_machine_op_reads_respects_l modify_ev)
+       apply (clarsimp simp: equiv_for_def)
+      apply (wpsimp wp: dmo_mol_reads_respects_l)+
+  done
+
+lemma dmo_disableFpu_reads_respects_l[wp]:
+  "reads_respects_l aag l \<top> (do_machine_op disableFpu)"
+  unfolding disableFpu_def dmo_distr
+  apply wpsimp
+     apply (wpsimp wp: do_machine_op_reads_respects_l modify_ev)
+       apply (clarsimp simp: equiv_for_def)
+      apply (wpsimp wp: dmo_mol_reads_respects_l)+
+  done
+
+lemma switch_local_fpu_owner_def2:
+  "switch_local_fpu_owner new_owner = do fpu_save; fpu_restore new_owner od"
+  unfolding switch_local_fpu_owner_def fpu_save_def fpu_restore_def
+  by (clarsimp simp: bind_assoc)
+
+lemma valid_cur_fpu_cur_fpu_for:
+  "valid_cur_fpu s \<Longrightarrow> cur_fpu_for P s = (\<exists>p. P p \<and> is_tcb_cur_fpu p s)"
+  apply (clarsimp simp: cur_fpu_for_def valid_cur_fpu_def)
+  apply (rule iffI; erule ex_forward)
+   apply (clarsimp simp: valid_cur_fpu_def is_tcb_cur_fpu_def obj_at_def get_tcb_def is_arch_cur_fpu_def
+                  split: option.splits kernel_object.splits)+
+  done
+
+lemma equiv_kheap_equiv_current_fpu:
+  "\<lbrakk> equiv_for P kheap s t; valid_cur_fpu s; valid_cur_fpu t; cur_fpu_for P s; cur_fpu_for P t\<rbrakk>
+     \<Longrightarrow> current_fpu s = current_fpu t"
+  apply (clarsimp simp: valid_cur_fpu_cur_fpu_for valid_cur_fpu_def
+                        equiv_for_def is_tcb_cur_fpu_def obj_at_def)
+  apply (drule_tac x=p in spec)+
+  apply auto
+  done
+
+lemma maybeM_when:
+  "maybeM f opt = when (opt \<noteq> None) (f (the opt))"
+  by (clarsimp simp: maybeM_def when_def)
+
+lemma maybeM_ev:
+  "\<lbrakk> \<And>v. opt = Some v \<Longrightarrow> equiv_valid_inv I A (P v) (f v) \<rbrakk>
+     \<Longrightarrow> equiv_valid_inv I A (\<lambda>s. \<forall>v. opt = Some v \<longrightarrow> P v s) (maybeM f opt)"
+  apply (subst maybeM_when)
+  apply (rule equiv_valid_guard_imp)
+   apply (rule_tac P="P (the opt)" in when_ev)
+   apply auto
+  done
+
+lemma as_user_reads_respects_l_roa:
+  "reads_respects_l aag l (K (det f \<and> (l (pasObjectAbs aag thread)))) (as_user thread f)"
+  apply (simp add: as_user_def split_def)
+  apply (rule gen_asm_ev)
+  apply (wp set_object_reads_respects_l select_f_ev gets_the_ev)
+  apply (auto simp: equiv_for_def get_tcb_def arch_tcb_context_set_def states_equiv_for_def)
+  done
+
+lemma reads_respects_l_unobservable_unit_return:
+  assumes f:
+    "\<And>P Q R S st. \<lbrace>states_equiv_for P Q R S st\<rbrace> f \<lbrace>\<lambda>_. states_equiv_for P Q R S st\<rbrace>"
+  shows
+    "reads_respects_l aag l \<top> (f::(unit,det_ext) s_monad)"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (erule use_valid[OF _ f])
+  apply (rule states_equiv_for_sym)
+  apply (erule use_valid[OF _ f])
+  apply (rule states_equiv_for_sym)
+  apply simp
+  done
+
+lemma dmo_readFpuState_reads_respects_l:
+  "reads_respects_l aag l (cur_fpu_for (l o pasObjectAbs aag)) (do_machine_op readFpuState)"
+  (is "reads_respects_l _ _ ?P _")
+  unfolding readFpuState_def dmo_distr
+  apply (rule_tac Q="\<lambda>_. ?P" in bind_ev_pre)
+     apply wpsimp
+     apply (rule do_machine_op_reads_respects_l')
+      apply (wpsimp wp: gets_ev')
+     apply (clarsimp simp: pred_disj_def equiv_fpu_state_def hw_fpu_def)
+    apply (rule reads_respects_l_unobservable_unit_return)
+    apply (wpsimp wp: dmo_wp)+
+  done
+
+lemma det_setFPUStat[simp]:
+  "det (setFPUState fpu)"
+  by (wpsimp simp: setFPUState_def)
+
+lemma thread_set_equiv_but_for_labels[wp]:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag ptr \<in> L)\<rbrace>
+   thread_set f ptr
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding thread_set_def
+  apply (wpsimp wp: set_object_equiv_but_for_labels)
+  apply (clarsimp simp: get_tcb_def obj_at_def split: option.splits kernel_object.splits)
+  done
+
+lemma as_user_equiv_but_for_labels[wp]:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag ptr \<in> L)\<rbrace>
+   as_user ptr f
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  apply (rule as_user_wp_thread_set_helper)
+  apply wpsimp
+  done
+
+lemma dmo_readFpuState_inv[wp]:
+  "do_machine_op readFpuState \<lbrace>P\<rbrace>"
+  by (wpsimp simp: readFpuState_def wp: dmo_wp)
+
+lemma save_fpu_state_reads_respects_l:
+  "reads_respects_l aag l (\<lambda>s. current_fpu s = Some ptr) (save_fpu_state ptr)"
+  (is "reads_respects_l _ _ ?P _")
+  unfolding save_fpu_state_def
+  apply (rule equiv_valid_guard_imp)
+   apply (rule_tac P="?P" and ptr=ptr in reads_respects_l_unit_cases)
+     apply (wpsimp wp: as_user_reads_respects_l_roa dmo_readFpuState_reads_respects_l)
+     apply (clarsimp simp: cur_fpu_for_def is_arch_cur_fpu_def)
+    apply wpsimp+
+  done
+
+(* FIXME AARCH64 IF: move *)
+locale_abbrev "cur_fpu_of s \<equiv> \<lambda>x. arm_current_fpu_owner (arch_state s) = Some x"
+
+lemma equiv_fpu_def2:
+  "equiv_fpu P s s' \<equiv> (\<forall>x. P x \<longrightarrow>
+     (current_fpu s = Some x \<longleftrightarrow> current_fpu s' = Some x) \<and>
+     (current_fpu s = Some x \<longrightarrow> machine_fpu s = machine_fpu s'))"
+  apply (rule eq_reflection)
+  apply (clarsimp simp: equiv_fpu_def equiv_for_def valid_cur_fpu_cur_fpu_for)
+  apply (clarsimp simp: hw_fpu_def is_arch_cur_fpu_def)
+  apply auto
+  done
+
+lemma dmo_disableFpu_machine_fpu[wp]:
+  "do_machine_op disableFpu \<lbrace>\<lambda>s. P (machine_fpu s)\<rbrace>"
+  by (wpsimp wp: dmo_wp)
+
+lemma dmo_enableFpu_machine_fpu[wp]:
+  "do_machine_op enableFpu \<lbrace>\<lambda>s. P (machine_fpu s)\<rbrace>"
+  by (wpsimp wp: dmo_wp)
+
+lemma tcb_at_typ_at':
+  "(\<And>P T p. \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace> f \<lbrace>\<lambda>rv s. P (typ_at T p s)\<rbrace>)
+    \<Longrightarrow> \<lbrace>\<lambda>s. P (tcb_at c s)\<rbrace> f \<lbrace>\<lambda>rv s. P (tcb_at c s)\<rbrace>"
+  by (simp add: tcb_at_typ)
+
+lemma as_user_not_tcb_at[wp]:
+  "as_user t m \<lbrace>\<lambda>s. \<not>tcb_at t' s\<rbrace>"
+  by (wpsimp wp: tcb_at_typ_at'[OF as_user_typ_at])
+
+crunch save_fpu_state
+  for not_tcb_at[wp]: "\<lambda>s. \<not>tcb_at t s"
+
+lemma fpu_of_Some_True[simp]:
+  "fpu_of (Some True) fopt fpu = Some fpu"
+  by (clarsimp simp: fpu_of_def)
+
+lemma fpu_of_Some_False[simp]:
+  "fpu_of (Some False) fopt fpu = fopt"
+  by (clarsimp simp: fpu_of_def)
+
+lemma fpu_of_None[simp]:
+  "fpu_of None fopt fpu = None"
+  by (clarsimp simp: fpu_of_def)
+
+lemma valid_cur_fpu_current_fpu_Some:
+  "\<lbrakk> valid_cur_fpu s; current_fpu s = Some t \<rbrakk>
+     \<Longrightarrow> tcb_cur_fpu_of s t = Some True"
+  apply (clarsimp simp: valid_cur_fpu_def)
+  apply (erule_tac x=t in allE)
+  apply (clarsimp simp: get_tcb_def is_tcb_cur_fpu_def obj_at_def)
+  done
+
+lemma save_fpu_state_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> pasObjectAbs aag ptr \<in> L\<rbrace>
+   save_fpu_state ptr
+  \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding save_fpu_state_def
+  by wpsimp
+
+lemma dmo_enableFpu_equiv_but_for_labels[wp]:
+  "do_machine_op enableFpu \<lbrace>equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_lift)
+
+lemma dmo_disableFpu_equiv_but_for_labels[wp]:
+  "do_machine_op disableFpu \<lbrace>equiv_but_for_labels aag L st\<rbrace>"
+  by (wpsimp wp: dmo_equiv_but_for_labels_lift)
+
+lemma fpu_save_reads_respects_l:
+  "reads_respects_l aag l valid_cur_fpu fpu_save"
+  unfolding fpu_save_def
+  apply (rule_tac P="cur_fpu_for (l o pasObjectAbs aag)" in equiv_valid_cases'')
+    apply (fastforce simp: states_equiv_for_def comp_def equiv_fpu_cur_fpu_for)
+   apply (wpsimp wp: maybeM_ev gets_ev'' save_fpu_state_reads_respects_l
+                     hoare_vcg_imp_lift' hoare_vcg_all_lift)
+     apply (rename_tac s t)
+     apply (prop_tac "valid_cur_fpu s \<and> cur_fpu_for (l o pasObjectAbs aag) s")
+      apply assumption
+     apply (prop_tac "valid_cur_fpu t \<and> cur_fpu_for (l o pasObjectAbs aag) t")
+      apply assumption
+     apply clarsimp
+     apply (prop_tac "equiv_for (l o pasObjectAbs aag) kheap s t")
+      apply (fastforce simp: states_equiv_for_def comp_def)
+     apply (clarsimp simp: equiv_kheap_equiv_current_fpu)
+    apply wpsimp
+   apply clarsimp
+  apply (rule wp_pre)
+   apply (simp add: equiv_valid_def2)
+   apply (rule_tac R'="\<top>\<top>"
+               and Q="\<lambda>rv. (\<lambda>s. current_fpu s = rv \<and> valid_cur_fpu s)
+                       and K (\<forall>vr. rv = Some vr \<longrightarrow> \<not> l (pasObjectAbs aag vr))"
+               and Q'="\<lambda>rv. (\<lambda>s. current_fpu s = rv \<and> valid_cur_fpu s)
+                        and K (\<forall>vr. rv = Some vr \<longrightarrow> \<not> l (pasObjectAbs aag vr))"
+                in equiv_valid_2_bind)
+      apply (rule EquivValid.gen_asm_ev2_l)
+      apply (rule EquivValid.gen_asm_ev2_r)
+      prefer 2
+      apply (rule gets_any_evrv)
+     apply (rule equiv_valid_2_guard_imp)
+       apply (rule reads_respects_l_2_invisible)
+           apply (rule modifies_at_mostI)
+           apply (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_all_lift)
+          apply (rule modifies_at_mostI)
+          apply (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_all_lift)
+         apply wpsimp
+        apply wpsimp
+       apply clarsimp
+      apply simp
+     apply simp
+    apply wpsimp+
+  apply (clarsimp simp: cur_fpu_for_def is_arch_cur_fpu_def)
+  done
+
+lemma equiv_valid_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (i s)\<rbrace>"
+  shows "equiv_valid (equiv_for P i) \<top>\<top> \<top>\<top> \<top> (f :: ('s state, unit) nondet_monad)"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+   apply (erule use_valid)
+    apply (wpsimp wp: assms equiv_for_lift)
+   apply (erule use_valid)
+    apply (wpsimp wp: assms equiv_for_lift)
+   apply clarsimp
+  done
+
+crunch getFPUState
+  for inv[wp]: P
+
+crunch load_fpu_state
+  for kheap[wp]: "\<lambda>s. P (kheap s)"
+  (wp: as_user_inv)
+
+lemma set_object_equiv_kheap:
+  "equiv_valid_inv (equiv_for P kheap) \<top>\<top> \<top> (set_object ptr obj)"
+  by (clarsimp simp: equiv_valid_def2 equiv_valid_2_def set_object_def get_object_def
+                     bind_def' get_def gets_def put_def return_def fail_def assert_def equiv_for_def)
+
+lemma thread_set_kheap_equiv:
+  "equiv_valid_inv (equiv_for P kheap) \<top>\<top> \<top> (thread_set f thread)"
+  unfolding thread_set_def
+  apply (case_tac "P thread")
+   apply (wpsimp wp: set_object_equiv_kheap)
+   apply (clarsimp simp: get_tcb_def equiv_for_def)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def set_object_def get_object_def
+                        gets_the_def assert_opt_def get_tcb_def bind_def' get_def gets_def
+                        put_def return_def fail_def assert_def equiv_for_def
+                 split: option.splits kernel_object.splits)
+  done
+
+lemma arch_thread_set_kheap_equiv:
+  "equiv_valid_inv (equiv_for P kheap) \<top>\<top> \<top> (arch_thread_set f thread)"
+  by (wpsimp simp: arch_thread_set_is_thread_set wp: thread_set_kheap_equiv)
+
+lemma gets_current_fpu_owner_equiv_kheap:
+  "equiv_valid (equiv_for P kheap) (equiv_for P cur_fpu_of) (\<lambda>_ _. True)
+               (valid_cur_fpu and cur_fpu_for P)
+               (gets (arm_current_fpu_owner \<circ> arch_state))"
+  (is "equiv_valid_inv _ _ ?P _")
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def gets_def get_def return_def bind_def)
+  apply (clarsimp simp: equiv_for_def cur_fpu_for_def is_arch_cur_fpu_def)
+  done
+
+lemma equiv_valid_make_inv:
+  assumes "equiv_valid_inv I A P f"
+  shows "equiv_valid I A \<top>\<top> P f"
+  using assms
+  by (fastforce simp: equiv_valid_def2 equiv_valid_2_def)
+
+lemma arch_thread_set_equiv_for_kheap:
+  "\<lbrace>equiv_for P kheap st and K (\<not>P thread)\<rbrace>
+   arch_thread_set f thread
+   \<lbrace>\<lambda>_. equiv_for P kheap st\<rbrace>"
+  apply (wpsimp wp: arch_thread_set_wp)
+  apply (clarsimp simp: equiv_for_def)
+  done
+
+lemma set_arm_current_fpu_owner_ev:
+  "equiv_valid (equiv_for P kheap) (equiv_for P cur_fpu_of) \<top>\<top> (valid_cur_fpu)
+    (do cur_fpu_owner <- gets (arm_current_fpu_owner \<circ> arch_state);
+        maybeM (arch_thread_set (tcb_cur_fpu_update (\<lambda>_. False))) cur_fpu_owner
+     od)"
+  apply (rule_tac P="cur_fpu_for P" in equiv_valid_cases'')
+    apply (fastforce simp: equiv_for_def cur_fpu_for_def is_arch_cur_fpu_def)
+   apply (rule wp_pre)
+    apply (rule bind_ev_general)
+      apply (wp maybeM_ev)
+      apply (wpsimp wp: maybeM_ev arch_thread_set_kheap_equiv)
+     apply (wp gets_current_fpu_owner_equiv_kheap)
+    apply wpsimp
+   apply clarsimp
+  apply (rule equiv_valid_make_inv)
+  apply (rule equiv_valid_inv_lift)
+    apply (wpsimp wp: arch_thread_set_equiv_for_kheap equiv_for_lift)
+    apply (clarsimp simp: equiv_for_def cur_fpu_for_def is_arch_cur_fpu_def)
+   apply (auto simp: equiv_for_sym)
+  done
+
+crunch load_fpu_state
+  for valid_cur_fpu[wp]: valid_cur_fpu
+
+lemma fpu_restore_equiv_kheap':
+  "equiv_valid (equiv_for P kheap) (equiv_for P cur_fpu_of) \<top>\<top> valid_cur_fpu (fpu_restore new_owner)"
+  unfolding fpu_restore_def set_arm_current_fpu_owner_def
+  apply (rule equiv_valid_guard_imp)
+   apply (rule_tac A=B and B=B for B in bind_ev_general)
+     prefer 2
+     apply (rule equiv_valid_inv_lift)
+       apply (wpsimp wp: equiv_for_lift)+
+      apply (fastforce simp: equiv_for_def)+
+    apply simp
+    apply (subst bind_assoc[symmetric])
+    apply (rule bind_ev_general)
+      prefer 2
+      apply (rule set_arm_current_fpu_owner_ev)
+     apply clarsimp
+     apply (rule bind_ev_general)
+       prefer 2
+       apply (rule equiv_valid_lift)
+       apply wpsimp
+      apply (rule maybeM_ev)
+      apply (rule arch_thread_set_kheap_equiv)
+     apply wpsimp+
+  done
+
+lemma fpu_restore_equiv_kheap:
+  "equiv_valid (equiv_for P kheap) (equiv_fpu P) \<top>\<top> valid_cur_fpu (fpu_restore new_owner)"
+  apply (rule equiv_valid_conseq)
+    apply (rule_tac P=P in fpu_restore_equiv_kheap')
+   apply (clarsimp simp: equiv_fpu_def2 equiv_for_def)
+  apply clarsimp
+  done
+
+crunch fpu_save
+  for valid_cur_fpu[wp]: "valid_cur_fpu"
+  (wp: crunch_wps)
+
+lemma switch_local_fpu_owner_equiv_kheap:
+  "equiv_valid \<top>\<top> (states_equiv_for_labels aag l) (equiv_for (l o pasObjectAbs aag) kheap)
+               valid_cur_fpu (switch_local_fpu_owner new_owner :: (det_state,unit) nondet_monad)"
+  unfolding switch_local_fpu_owner_def2
+  apply (rule equiv_valid_guard_imp)
+   apply (rule bind_ev_general)
+     apply clarsimp
+     apply (rule equiv_valid_conseq)
+       apply (rule_tac P="l o pasObjectAbs aag" in fpu_restore_equiv_kheap)
+      apply clarsimp
+      apply (subst conj_assoc[symmetric])
+      apply (rule conjI)
+       apply assumption
+      apply clarsimp
+      apply (rule conjI)
+       apply assumption
+      apply assumption
+     apply clarsimp
+    apply (rule equiv_valid_conseq)
+      apply (rule_tac aag=aag and l=l in fpu_save_reads_respects_l)
+     apply clarsimp
+     apply (rule conjI)
+      apply assumption+
+    apply clarsimp
+    apply (clarsimp simp: comp_def states_equiv_for_def equiv_for_disj equiv_fpu_def)
+   apply wpsimp
+  apply simp
+  done
+
+definition states_equiv_for_non_fpu ::
+  "(obj_ref \<Rightarrow> bool) \<Rightarrow> (irq \<Rightarrow> bool) \<Rightarrow> (asid \<Rightarrow> bool) \<Rightarrow>
+   (domain \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "states_equiv_for_non_fpu P Q R S s s' \<equiv>
+     equiv_machine_state P (machine_state s) (machine_state s') \<and>
+     equiv_for (P \<circ> fst) cdt s s' \<and>
+     equiv_for (P \<circ> fst) cdt_list s s' \<and>
+     equiv_for (P \<circ> fst) is_original_cap s s' \<and>
+     equiv_for Q interrupt_states s s' \<and>
+     equiv_for Q interrupt_irq_node s s' \<and>
+     equiv_for S ready_queues s s' \<and>
+     equiv_asids R s s' \<and>
+     equiv_hyp P s s'"
+
+lemma states_equiv_for_non_fpu_refl:
+  "states_equiv_for_non_fpu P Q R S s s"
+  by (auto simp: states_equiv_for_non_fpu_def intro: equiv_for_refl equiv_asids_refl equiv_hyp_refl)
+
+lemma states_equiv_for_non_fpu_sym:
+  "states_equiv_for_non_fpu P Q R S s t \<Longrightarrow> states_equiv_for_non_fpu P Q R S t s"
+  by (auto simp: states_equiv_for_non_fpu_def intro: equiv_for_sym equiv_asids_sym equiv_fpu_sym equiv_hyp_sym)
+
+lemma states_equiv_for_non_fpu_trans:
+  "\<lbrakk> states_equiv_for_non_fpu P Q R S s t; states_equiv_for_non_fpu P Q R S t u \<rbrakk>
+     \<Longrightarrow> states_equiv_for_non_fpu P Q R S s u"
+  by (auto simp: states_equiv_for_non_fpu_def
+          intro: equiv_for_trans equiv_asids_trans equiv_fpu_trans equiv_hyp_trans equiv_forI
+           elim: equiv_forE)
+
+abbreviation states_equiv_for_labels_non_fpu ::
+  "'a PAS \<Rightarrow> ('a \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "states_equiv_for_labels_non_fpu aag P \<equiv>
+      states_equiv_for_non_fpu (\<lambda>x. P (pasObjectAbs aag x)) (\<lambda>x. P (pasIRQAbs aag x))
+                               (\<lambda>x. P (pasASIDAbs aag x)) (\<lambda>x. \<exists>l\<in>pasDomainAbs aag x. P l)"
+
+abbreviation reads_respects_l_non_fpu where
+  "reads_respects_l_non_fpu aag L P f \<equiv> equiv_valid_inv \<top>\<top> (states_equiv_for_labels_non_fpu aag L) P f"
+
+lemma states_equiv_for_non_fpu_symmetric:
+  "states_equiv_for_non_fpu P Q R S s t \<Longrightarrow> states_equiv_for_non_fpu P Q R S t s"
+  by (auto simp: states_equiv_for_non_fpu_sym)
+
+lemma reads_respects_l_non_fpu_unobservable:
+  assumes f:
+    "\<And>P Q R S st. \<lbrace>states_equiv_for_non_fpu P Q R S st\<rbrace> f \<lbrace>\<lambda>_. states_equiv_for_non_fpu P Q R S st\<rbrace>"
+  assumes g:
+    "\<And>P. \<lbrace>\<lambda>s. P (cur_thread s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cur_thread s)\<rbrace>"
+  assumes h:
+    "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s)\<rbrace> f \<lbrace>\<lambda>rv s. P (cur_domain s)\<rbrace>"
+  assumes j:
+    "\<And>P. \<lbrace>\<lambda>s. P (scheduler_action s)\<rbrace> f \<lbrace>\<lambda>rv s. P (scheduler_action s)\<rbrace>"
+  assumes k:
+    "\<And>P. \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace> f \<lbrace>\<lambda>rv s. P (work_units_completed s)\<rbrace>"
+  assumes l:
+    "\<And>P. \<lbrace>\<lambda>s. P (irq_state (machine_state s))\<rbrace> f \<lbrace>\<lambda>rv s. P (irq_state (machine_state s))\<rbrace>"
+  shows
+    "reads_respects_l_non_fpu aag l \<top> (f :: (det_state,unit) nondet_monad)"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (rule states_equiv_for_non_fpu_symmetric)
+  apply (erule use_valid)
+   apply (wp assms)
+  apply (rule states_equiv_for_non_fpu_symmetric)
+  apply (erule use_valid)
+   apply (wp assms)
+  apply simp
+  done
+
+lemma equiv_hyp_lift:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (vcpu_state (machine_state s))\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (current_vcpu s)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (numlistregs s)\<rbrace>"
+  shows "f \<lbrace>\<lambda>s. equiv_hyp P st s\<rbrace>"
+  unfolding equiv_hyp_def
+  apply (wpsimp wp: equiv_for_lift assms)
+  apply (rule hoare_weaken_pre)
+   apply (wps assms)
+    apply wpsimp+
+  done
+
+lemma switch_local_fpu_owner_states_equiv_for_non_hyp[wp]:
+  "switch_local_fpu_owner vopt \<lbrace>states_equiv_for_non_fpu P Q R S st\<rbrace>"
+  unfolding states_equiv_for_non_fpu_def
+  by (wpsimp wp: equiv_machine_state_lift equiv_asids_lift equiv_hyp_lift equiv_for_lift dmo_wp)
+
+lemma valid_cur_fpu_hw_fpu_of:
+  "valid_cur_fpu s \<Longrightarrow>
+   hw_fpu_of s t = (if current_fpu s = Some t
+                    then fpu_of (tcb_cur_fpu_of s t) (tcb_fpu_of s t) (machine_fpu s)
+                    else None)"
+  supply if_split[split del]
+  apply (subst fpu_of_def)
+  apply (clarsimp simp: is_arch_cur_fpu_def hw_fpu_def)
+  apply (case_tac "current_fpu s = Some t"; clarsimp)
+  apply (frule (1) current_fpu_owner_Some_tcb_at)
+  apply (clarsimp simp: tcb_at_def get_tcb_def split: option.splits kernel_object.splits)
+  apply (clarsimp simp: valid_cur_fpu_def)
+  apply (erule_tac x=t in allE)
+  apply (clarsimp simp: is_tcb_cur_fpu_def obj_at_def)
+  done
+
+lemma set_arm_current_fpu_owner_current_fpu[wp]:
+  "\<lbrace>\<lambda>s. P (new_owner)\<rbrace>
+   set_arm_current_fpu_owner new_owner
+   \<lbrace>\<lambda>_ s. P (current_fpu s)\<rbrace>"
+  unfolding set_arm_current_fpu_owner_def
+  apply wpsimp
+  apply auto
+  done
+
+crunch switch_local_fpu_owner
+  for valid_cur_fpu[wp]: valid_cur_fpu
+  (wp: hoare_drop_imps)
+
+lemma switch_local_fpu_owner_current_fpu[wp]:
+  "\<lbrace>\<lambda>s. P (new_owner)\<rbrace>
+   switch_local_fpu_owner new_owner
+   \<lbrace>\<lambda>_ s. P (current_fpu s)\<rbrace>"
+  unfolding switch_local_fpu_owner_def
+  by wpsimp
+
+lemma switch_local_fpu_owner_hw_fpu_of:
+  "\<lbrace>\<lambda>s. valid_cur_fpu s \<and> fopt = (if new_owner \<noteq> Some ptr then None
+                                  else if hw_fpu_of s ptr = None then tcb_fpu_of s ptr
+                                  else hw_fpu_of s ptr)\<rbrace>
+   switch_local_fpu_owner new_owner
+   \<lbrace>\<lambda>_ s. fopt = hw_fpu_of s ptr\<rbrace>"
+  apply (rule_tac Q'="\<lambda>_ s. valid_cur_fpu s \<and>
+                            (current_fpu s = Some ptr \<longrightarrow> fopt = fpu_of (tcb_cur_fpu_of s ptr)
+                                                                        (tcb_fpu_of s ptr) (machine_fpu s)) \<and>
+                            (current_fpu s \<noteq> Some ptr \<longrightarrow> fopt = None)"
+               in hoare_strengthen_post[rotated])
+   apply (clarsimp simp: valid_cur_fpu_hw_fpu_of)
+  apply (rule wp_pre)
+   apply (rule hoare_vcg_conj_lift)
+    apply wpsimp
+   apply (rule hoare_vcg_conj_lift)
+    apply (rule hoare_vcg_imp_lift')
+     apply wp
+    apply (wp switch_local_fpu_owner_fpu_of)
+   apply wp
+  apply (clarsimp simp: valid_cur_fpu_hw_fpu_of split: if_splits)
+   apply (simp add: valid_cur_fpu_current_fpu_Some)
+  apply (clarsimp simp: fpu_of_def get_tcb_def split: option.splits bool.splits kernel_object.splits)
+  by (simp add: valid_cur_fpu_defs(1,2,3))
+
+lemma switch_local_fpu_owner_equiv_fpu:
+  "equiv_valid (equiv_fpu P) (equiv_for P kheap) \<top>\<top> valid_cur_fpu (switch_local_fpu_owner new_owner)"
+  apply (clarsimp simp: equiv_fpu_def equiv_valid_def2 equiv_valid_2_def)
+  apply (rename_tac s' t')
+  apply (clarsimp simp: equiv_for_def)
+  apply (erule_tac x=x in allE)+
+  apply clarsimp
+  apply (rule sym)
+  apply (erule use_valid)
+   apply (rule switch_local_fpu_owner_hw_fpu_of)
+  apply (rule conjI, simp)
+  apply (rule sym)
+  apply (erule use_valid)
+   apply (rule switch_local_fpu_owner_hw_fpu_of)
+  apply (rule conjI, simp)
+  apply (case_tac "new_owner \<noteq> Some x")
+   apply clarsimp
+  apply (case_tac "hw_fpu_of s x = None")
+   apply (clarsimp simp: get_tcb_def)
+  apply clarsimp
+  done
+
+lemma switch_local_fpu_owner_reads_respects_l[wp]:
+  "reads_respects_l aag l (valid_cur_fpu) (switch_local_fpu_owner new_owner)"
+  apply (rule equiv_valid_conseq)
+    apply (rule equiv_valid_split)
+     apply (rule reads_respects_l_non_fpu_unobservable[of _ l aag])
+          apply ((wpsimp simp: fpu_restore_def wp: dmo_wp)+)[6]
+    apply (rule equiv_valid_split)
+     apply (rule_tac aag=aag and l=l in switch_local_fpu_owner_equiv_kheap)
+    apply (rule_tac P="l o pasObjectAbs aag" in switch_local_fpu_owner_equiv_fpu)
+   apply (clarsimp simp: states_equiv_for_def states_equiv_for_non_fpu_def comp_def)+
+  done
+
+lemma switch_local_fpu_owner_reads_respects[wp]:
+  "reads_respects aag l (valid_cur_fpu) (switch_local_fpu_owner new_owner)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_from_labels)
+        apply (rule switch_local_fpu_owner_reads_respects_l)
+       apply wpsimp+
+  done
+
+lemma arch_thread_set_equiv_but_for_labels[wp]:
+  "\<lbrace>equiv_but_for_labels aag L st and K (pasObjectAbs aag t \<in> L)\<rbrace>
+   arch_thread_set f t
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding arch_thread_set_def
+  apply (wpsimp wp: set_object_equiv_but_for_labels)
+  apply (clarsimp simp: get_tcb_def obj_at_def split: option.splits kernel_object.splits)
+  done
+
+lemma modify_current_fpu_equiv_but_for_labels:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and>
+        (\<forall>t. current_fpu s = Some t \<longrightarrow> pasObjectAbs aag t \<in> L) \<and>
+        (\<forall>t. new_owner = Some t \<longrightarrow> pasObjectAbs aag t \<in> L)\<rbrace>
+   modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_current_fpu_owner := new_owner\<rparr>\<rparr>)
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  apply wp
+  apply (subst equiv_but_for_labels_def)
+  apply (subst states_equiv_for_def)
+  apply (intro conjI; (clarsimp simp: equiv_but_for_labels_def states_equiv_for_def equiv_for_def; fail)?)
+    apply (clarsimp simp: equiv_but_for_labels_def states_equiv_for_def equiv_for_def)
+    apply (clarsimp simp: equiv_asids_def equiv_asid_def)
+   apply (clarsimp simp: equiv_but_for_labels_def states_equiv_for_def equiv_for_def)
+   apply (clarsimp simp: equiv_hyp_def equiv_for_def)
+  apply (prop_tac "equiv_fpu (\<lambda>x. pasObjectAbs aag x \<notin> L) st s")
+   apply (clarsimp simp: equiv_but_for_labels_def states_equiv_for_def equiv_for_def)
+  apply (erule equiv_fpu_trans)
+  apply (clarsimp simp: equiv_fpu_def)
+  apply (clarsimp simp: equiv_for_def)
+  apply (clarsimp simp: is_arch_cur_fpu_def)
+  apply (clarsimp simp: hw_fpu_def)
+  apply auto
+  done
+
+lemma set_arm_current_fpu_owner_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> (\<forall>t. new_owner = Some t \<longrightarrow> pasObjectAbs aag t \<in> L) \<and>
+                                          (\<forall>t. current_fpu s = Some t \<longrightarrow> pasObjectAbs aag t \<in> L)\<rbrace>
+   set_arm_current_fpu_owner new_owner
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding set_arm_current_fpu_owner_def
+  by (wpsimp wp_del: modify_wp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift modify_current_fpu_equiv_but_for_labels)
+
+lemma dmo_equiv_but_for_labels_fpu:
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (underlying_memory ms)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (device_state ms)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (irq_state ms)\<rbrace>"
+  assumes "\<And>P. f \<lbrace>\<lambda>ms. P (vcpu_state ms)\<rbrace>"
+  shows "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> \<not>cur_fpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s\<rbrace>
+         do_machine_op f
+         \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding equiv_but_for_labels_def states_equiv_for_def equiv_asids_def cur_fpu_for_def
+  apply wp
+   apply clarsimp
+   apply (rule hoare_vcg_conj_lift, solves "wpsimp wp: equiv_for_lift equiv_hyp_lift assms dmo_wp")+
+   apply (rule hoare_vcg_conj_lift)
+    apply (clarsimp simp: equiv_fpu_def)
+    apply (rule_tac Q'="\<lambda>_ s. (\<forall>x. pasObjectAbs aag x \<notin> L \<longrightarrow> hw_fpu_of st x = None) \<and>
+                              \<not>cur_fpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s"
+                 in hoare_strengthen_post)
+     apply (wpsimp wp: equiv_for_lift2 assms dmo_wp simp: cur_fpu_for_def)
+    apply (clarsimp simp: equiv_for_def hw_fpu_def)
+    apply (erule_tac x=x in allE)
+    apply (clarsimp split: if_splits)
+    apply (fastforce simp: cur_fpu_for_def)
+   apply (wpsimp wp: equiv_for_lift equiv_hyp_lift assms dmo_wp)
+  apply clarsimp
+  apply (clarsimp simp: equiv_fpu_def)
+  apply (fastforce simp: equiv_for_def cur_fpu_for_def hw_fpu_def split: if_splits)
+  done
+
+lemma as_user_cur_fpu_for[wp]:
+  "as_user t f \<lbrace>\<lambda>s. P (cur_fpu_for R s)\<rbrace>"
+  apply (wpsimp wp: as_user_wp_thread_set_helper thread_set_wp)
+  apply (auto elim!: rsubst[where P=P]
+               simp: get_tcb_def cur_fpu_for_def arch_tcb_context_get_def arch_tcb_context_set_def)
+  done
+
+lemma dmo_cur_fpu_for[wp]:
+  "do_machine_op f \<lbrace>\<lambda>s. P (cur_fpu_for R s)\<rbrace>"
+  by (wpsimp wp: dmo_wp simp: cur_fpu_for_def)
+
+crunch save_fpu_state
+  for cur_fpu_for[wp]: "\<lambda>s. P (cur_fpu_for R s)"
+
+lemma load_fpu_state_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> \<not>cur_fpu_for (\<lambda>a. pasObjectAbs aag a \<notin> L) s\<rbrace>
+   load_fpu_state t
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding load_fpu_state_def
+  by (wpsimp wp: dmo_equiv_but_for_labels_fpu as_user_inv)
+
+lemma switch_local_fpu_owner_equiv_but_for_labels:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> (\<forall>t. cur_fpu_of s t \<longrightarrow> pasObjectAbs aag t \<in> L) \<and>
+                                          (\<forall>t. new_owner = Some t \<longrightarrow> pasObjectAbs aag t \<in> L)\<rbrace>
+   switch_local_fpu_owner new_owner
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding switch_local_fpu_owner_def
+  apply (wpsimp wp: hoare_vcg_imp_lift' hoare_vcg_all_lift)
+  apply (prop_tac "equiv_fpu (\<lambda>a. pasObjectAbs aag a \<notin> L) st s")
+   apply (clarsimp simp: equiv_but_for_labels_def states_equiv_for_def)
+  apply (clarsimp simp: cur_fpu_for_def is_arch_cur_fpu_def)
+  done
+
+lemma fpu_release_reads_respects:
+  "reads_respects aag l valid_cur_fpu (fpu_release t)"
+  unfolding fpu_release_def
+  apply (rule equiv_valid_guard_imp)
+   apply (subst gets_comp)
+   apply (rule_tac P=valid_cur_fpu and ptr=t in reads_respects_unit_cases)
+     apply (rule equiv_valid_guard_imp)
+      apply wp
+        apply (wpsimp wp: when_ev)
+       prefer 2
+       apply wpsimp
+      apply (wpsimp wp: gets_ev'')
+      apply (prop_tac "valid_cur_fpu x \<and>  aag_can_read_or_affect aag l t")
+       apply assumption
+      apply (prop_tac "valid_cur_fpu xa \<and>  aag_can_read_or_affect aag l t")
+       apply assumption
+      apply (prop_tac "equiv_fpu (aag_can_read_or_affect aag l) x xa \<and>
+                       equiv_for (aag_can_read_or_affect aag l) kheap x xa ")
+       apply (clarsimp simp: reads_equiv_def2 affects_equiv_def2
+                             states_equiv_for_def equiv_for_disj equiv_fpu_def)
+      apply clarsimp
+      apply (clarsimp simp: valid_cur_fpu_def equiv_for_def is_tcb_cur_fpu_def obj_at_def)
+      apply fastforce
+     apply clarsimp
+    apply wpsimp+
+      apply (wp switch_local_fpu_owner_equiv_but_for_labels)
+     apply (clarsimp split del: if_split cong: if_cong conj_cong)
+     apply wp
+    apply clarsimp
+   apply wpsimp+
+  done
+
+lemma prepare_thread_delete_reads_respects:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects aag l (pas_refined aag and valid_arch_state and valid_cur_fpu and K (is_subject aag thread))
+                              (prepare_thread_delete thread)"
+  unfolding prepare_thread_delete_def
+  apply (wpsimp wp: fpu_release_reads_respects dissociate_vcpu_tcb_reads_respects hoare_vcg_imp_lift'
+         | rule arch_thread_get_wp)+
+  apply (subgoal_tac "is_subject aag x")
+   apply fastforce
+  apply (erule associated_vcpu_is_subject)
+    apply (simp add: get_tcb_ko_at)
+   apply simp
+  apply simp
+  done
+
 lemma prepare_thread_delete_reads_respects_f[Finalise_IF_assms]:
-  "reads_respects_f aag l \<top> (prepare_thread_delete thread)"
-  unfolding prepare_thread_delete_def by wp
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects_f aag l (silc_inv aag st and pas_refined aag and valid_arch_state
+                                                 and valid_cur_fpu and K (is_subject aag thread))
+                                (prepare_thread_delete thread)"
+  apply (rule equiv_valid_guard_imp)
+   apply (wpsimp wp: reads_respects_f[OF prepare_thread_delete_reads_respects, where st=st])+
+  done
+
+lemma vcpu_finalise_reads_respects:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects aag l (pas_refined aag and valid_arch_state and K (is_subject aag vr)) (vcpu_finalise vr)"
+  unfolding vcpu_finalise_def
+  apply (rule gen_asm_ev)
+  apply (wpsimp wp: dissociate_vcpu_tcb_reads_respects get_vcpu_wp)
+  apply (fastforce dest: associated_tcb_is_subject)
+  done
 
 lemma arch_finalise_cap_reads_respects[Finalise_IF_assms]:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows
   "reads_respects aag l (pas_refined aag and invs and cte_wp_at ((=) (ArchObjectCap cap)) slot
                                          and K (pas_cap_cur_auth aag (ArchObjectCap cap)))
                         (arch_finalise_cap cap final)"
@@ -257,15 +1005,27 @@ lemma arch_finalise_cap_reads_respects[Finalise_IF_assms]:
      apply simp
      apply (simp split: bool.splits)
      apply (intro impI conjI)
-  by (wp delete_asid_pool_reads_respects unmap_page_reads_respects unmap_page_table_reads_respects
-         delete_asid_reads_respects find_vspace_for_asid_reads_respects
-      | simp add: invs_psp_aligned invs_vspace_objs invs_valid_objs valid_cap_def
-                  valid_arch_state_asid_table invs_arch_state wellformed_mapdata_def
-           split: option.splits bool.splits
-      | intro impI conjI allI
-      | elim conjE
-      | drule cte_wp_valid_cap
-      | fastforce dest: aag_can_read_own_asids aag_cap_auth_subject)+
+         apply (wp delete_asid_pool_reads_respects unmap_page_reads_respects unmap_page_table_reads_respects
+                   delete_asid_reads_respects find_vspace_for_asid_reads_respects vcpu_finalise_reads_respects
+                | simp add: invs_psp_aligned invs_vspace_objs invs_valid_objs valid_cap_def
+                            valid_arch_state_asid_table invs_arch_state wellformed_mapdata_def
+                     split: option.splits bool.splits pt_type.splits
+                | intro impI conjI allI
+                | elim conjE
+                | drule cte_wp_valid_cap
+                | fastforce dest: aag_can_read_own_asids aag_cap_auth_subject)+
+     apply (clarsimp simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def)
+     apply (drule (1) pas_refined_Control, clarsimp)
+    apply (wp delete_asid_pool_reads_respects unmap_page_reads_respects unmap_page_table_reads_respects
+              delete_asid_reads_respects find_vspace_for_asid_reads_respects vcpu_finalise_reads_respects
+           | simp add: invs_psp_aligned invs_vspace_objs invs_valid_objs valid_cap_def
+                       valid_arch_state_asid_table invs_arch_state wellformed_mapdata_def
+                split: option.splits bool.splits pt_type.splits
+           | intro impI conjI allI
+           | elim conjE
+           | drule cte_wp_valid_cap
+           | fastforce dest: aag_can_read_own_asids aag_cap_auth_subject)+
+  done
 
 (*NOTE: Required to dance around the issue of the base potentially
         being zero and thus we can't conclude it is in the current subject.*)
@@ -277,15 +1037,16 @@ lemma requiv_arm_asid_table_asid_high_bits_of_asid_eq':
    apply (case_tac "b = 0")
     apply (subgoal_tac "is_subject_asid aag 1")
      apply ((fastforce intro: requiv_arm_asid_table_asid_high_bits_of_asid_eq
-                              aag_cap_auth_ASIDPoolCap_asid)+)[2]
+                              aag_cap_auth_ASIDPoolCap_asid
+                    simp del: asid_high_bits_of_0)+)[2]
    apply (auto intro: requiv_arm_asid_table_asid_high_bits_of_asid_eq
                       aag_cap_auth_ASIDPoolCap_asid)[1]
   apply (simp add: asid_high_bits_of_def asid_low_bits_def)
   done
 
 lemma pt_cap_aligned:
-  "\<lbrakk> caps_of_state s p = Some (ArchObjectCap (PageTableCap word x)); valid_caps (caps_of_state s) s \<rbrakk>
-     \<Longrightarrow> is_aligned word pt_bits"
+  "\<lbrakk> caps_of_state s p = Some (ArchObjectCap (PageTableCap word pt_t x)); valid_caps (caps_of_state s) s \<rbrakk>
+     \<Longrightarrow> is_aligned word (pt_bits pt_t)"
   by (auto simp: obj_ref_of_def pt_bits_def pageBits_def
           dest!: cap_aligned_valid[OF valid_capsD, unfolded cap_aligned_def, THEN conjunct1])
 
@@ -321,7 +1082,37 @@ lemma delete_asid_globals_equiv:
    delete_asid asid pt
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding delete_asid_def
-  by (wpsimp wp: set_vm_root_globals_equiv set_asid_pool_globals_equiv simp: hwASIDFlush_def)
+  by (wpsimp wp: set_vm_root_globals_equiv set_asid_pool_globals_equiv hoare_drop_imps)
+
+lemma vcpu_finalise_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and invs\<rbrace>
+   vcpu_finalise vr
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding vcpu_finalise_def
+  apply (wpsimp wp: dissociate_vcpu_tcb_globals_equiv get_vcpu_wp)
+  apply (rule conjI, fastforce)
+    (* FIXME AARCH64 IF: boilerplate *)
+  apply (rename_tac s' vcpu tcb)
+  apply clarsimp
+  apply (prop_tac "(idle_thread s', HypTCBRef) \<in> state_hyp_refs_of s' vr")
+   apply (clarsimp simp: state_hyp_refs_of_def opt_map_def split: option.splits)
+  apply (drule sym_refsD)
+   apply (erule invs_hyp_sym_refs)
+  apply (clarsimp simp: obj_at_vcpu_hyp_live_of_s[symmetric] is_vcpu_def
+                     state_hyp_refs_of_def obj_at_def hyp_live_def hyp_refs_of_def
+                     tcb_vcpu_refs_def refs_of_ao_def arch_live_def vcpu_tcb_refs_def
+              split: option.splits kernel_object.splits arch_kernel_obj.splits)
+  apply (frule invs_valid_idle)
+  apply (clarsimp simp: valid_idle_def pred_tcb_at_def)
+  apply (frule invs_iflive)
+  apply (frule invs_valid_global_refs)
+  apply (frule invs_valid_objs)
+  apply (drule (1) idle_no_ex_cap)
+  apply (erule swap, erule if_live_then_nonz_capD)
+   apply simp
+  apply clarsimp
+  apply (clarsimp simp: live_def hyp_live_def)
+  done
 
 lemma arch_finalise_cap_globals_equiv[Finalise_IF_assms]:
   "\<lbrace>globals_equiv st and invs and valid_arch_cap cap\<rbrace>
@@ -330,13 +1121,123 @@ lemma arch_finalise_cap_globals_equiv[Finalise_IF_assms]:
   apply (induct cap; simp add: arch_finalise_cap_def)
   by (wp delete_asid_pool_globals_equiv case_option_wp unmap_page_globals_equiv
          unmap_page_table_globals_equiv delete_asid_globals_equiv
-      | wpc | clarsimp simp: valid_arch_cap_def wellformed_mapdata_def)+
+      | wpc | fastforce simp: valid_arch_cap_def wellformed_mapdata_def)+
+
+lemma arch_thread_set_fpu_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
+   arch_thread_set (tcb_cur_fpu_update f) t
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding arch_thread_set_is_thread_set
+  by (wpsimp wp: thread_set_globals_equiv simp: arch_tcb_context_get_def)
+
+lemma globals_equiv_fpu_owner_update[simp]:
+  "globals_equiv st (s\<lparr>arch_state := arch_state s\<lparr>arm_current_fpu_owner := cf\<rparr>\<rparr>) = globals_equiv st s"
+  by (auto simp: globals_equiv_def)
+
+lemma set_arm_current_fpu_owner_globals_equiv:
+  "\<lbrace>globals_equiv st and valid_arch_state\<rbrace>
+   set_arm_current_fpu_owner new_owner
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding set_arm_current_fpu_owner_def
+  by (wpsimp wp: hoare_drop_imps hoare_vcg_all_lift)+
+
+lemma load_fpu_state_globals_equiv:
+  "\<lbrace>globals_equiv st and valid_arch_state and (\<lambda>s. t \<noteq> idle_thread s)\<rbrace>
+   load_fpu_state t
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding load_fpu_state_def
+  by (wpsimp wp: dmo_globals_equiv)
+
+lemma save_fpu_state_globals_equiv:
+  "\<lbrace>globals_equiv st and valid_arch_state and (\<lambda>s. t \<noteq> idle_thread s)\<rbrace>
+   save_fpu_state t
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding save_fpu_state_def
+  by (wpsimp wp: dmo_globals_equiv)
+
+crunch load_fpu_state, save_fpu_state
+  for valid_arch_state[wp]: valid_arch_state
+
+(* FIXME AARCH64 IF: move *)
+lemma switch_local_fpu_owner_Some_globals_equiv:
+  "\<lbrace>globals_equiv st and invs and (\<lambda>s. t \<noteq> idle_thread s)\<rbrace>
+   switch_local_fpu_owner (Some t)
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding switch_local_fpu_owner_def
+  apply (wpsimp wp: set_arm_current_fpu_owner_globals_equiv dmo_globals_equiv
+                    load_fpu_state_globals_equiv save_fpu_state_globals_equiv
+                    hoare_vcg_all_lift hoare_vcg_imp_lift')
+  apply (fastforce simp: invs_def valid_state_def valid_pspace_def valid_cur_fpu_def
+                         is_tcb_cur_fpu_def live_def arch_tcb_live_def
+                   dest: idle_no_ex_cap if_live_then_nonz_capD)
+  done
+
+lemma switch_local_fpu_owner_None_globals_equiv:
+  "\<lbrace>globals_equiv st and invs\<rbrace>
+   switch_local_fpu_owner None
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding switch_local_fpu_owner_def
+  apply (wpsimp wp: set_arm_current_fpu_owner_globals_equiv dmo_globals_equiv
+                    load_fpu_state_globals_equiv save_fpu_state_globals_equiv
+                    hoare_vcg_all_lift hoare_vcg_imp_lift')
+  apply (fastforce simp: invs_def valid_state_def valid_pspace_def valid_cur_fpu_def
+                          is_tcb_cur_fpu_def live_def arch_tcb_live_def
+                    dest: idle_no_ex_cap if_live_then_nonz_capD)
+  done
+
+declare dissociate_vcpu_tcb_globals_equiv[wp del]
+
+(* FIXME AARCH64 IF: consolidate *)
+lemma dissociate_vcpu_tcb_globals_equiv[wp]:
+  "\<lbrace>globals_equiv s and invs\<rbrace>
+   dissociate_vcpu_tcb vr t
+   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding dissociate_vcpu_tcb_def
+  apply (wpsimp wp: as_user_globals_equiv simp: arch_tcb_context_get_def as_user_bind)
+       apply (rule_tac Q'="\<lambda>_ s. arm_current_vcpu (arch_state s) = None" in hoare_post_add)
+       apply (clarsimp cong: conj_cong)
+       apply (wpsimp wp: get_vcpu_wp arch_thread_get_wp)+
+  apply (subgoal_tac "(\<forall>tcb. ko_at (TCB tcb) t sa \<longrightarrow>
+                        (\<forall>v. vcpus_of sa vr = Some v \<longrightarrow>
+                             tcb_vcpu (tcb_arch tcb) = Some vr \<and> vcpu_tcb v = Some t \<longrightarrow>
+                             t \<noteq> idle_thread sa))")
+   apply fastforce
+  apply clarsimp
+    (* FIXME AARCH64 IF: boilerplate *)
+  apply (rename_tac s' tcb vcpu)
+  apply (prop_tac "(idle_thread s', HypTCBRef) \<in> state_hyp_refs_of s' vr")
+   apply (clarsimp simp: state_hyp_refs_of_def opt_map_def split: option.splits)
+  apply (drule sym_refsD)
+   apply (erule invs_hyp_sym_refs)
+  apply (clarsimp simp: obj_at_vcpu_hyp_live_of_s[symmetric] is_vcpu_def
+                        state_hyp_refs_of_def obj_at_def hyp_live_def hyp_refs_of_def
+                        tcb_vcpu_refs_def refs_of_ao_def arch_live_def vcpu_tcb_refs_def
+                 split: option.splits kernel_object.splits arch_kernel_obj.splits)
+  apply (frule invs_valid_idle)
+  apply (clarsimp simp: valid_idle_def pred_tcb_at_def)
+  apply (frule invs_iflive)
+  apply (frule invs_valid_global_refs)
+  apply (frule invs_valid_objs)
+  apply (drule (1) idle_no_ex_cap)
+  apply (erule swap, erule if_live_then_nonz_capD)
+   apply simp
+  apply clarsimp
+  apply (clarsimp simp: live_def hyp_live_def)
+  done
+
+lemma fpu_release_globals_equiv:
+  "\<lbrace>globals_equiv st and invs\<rbrace>
+   fpu_release t
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding fpu_release_def
+  by (wpsimp wp: switch_local_fpu_owner_None_globals_equiv)
+
+lemma prepare_thread_delete_globals_equiv[Finalise_IF_assms, wp]:
+  "\<lbrace>globals_equiv s and invs\<rbrace> prepare_thread_delete t \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  unfolding prepare_thread_delete_def
+  by (wpsimp wp: fpu_release_globals_equiv hoare_drop_imps)
 
 declare arch_get_sanitise_register_info_def[simp]
-
-crunch prepare_thread_delete
-  for globals_equiv[Finalise_IF_assms, wp]: "globals_equiv st"
-  (wp: dxo_wp_weak)
 
 lemma set_bound_notification_globals_equiv[Finalise_IF_assms]:
   "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>

--- a/proof/infoflow/AARCH64/ArchIRQMasks_IF.thy
+++ b/proof/infoflow/AARCH64/ArchIRQMasks_IF.thy
@@ -30,10 +30,14 @@ crunch invoke_untyped
        wp: mapME_x_inv_wp preemption_point_inv
      simp: crunch_simps no_irq_clearMemory mapM_x_def_bak unless_def)
 
+lemma vcpu_invalidate_active_irq_masks[wp]:
+  "vcpu_invalidate_active \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding vcpu_invalidate_active_def vcpu_disable_def
+  by (wpsimp wp: dmo_wp)
+
 crunch finalise_cap
   for irq_masks[IRQMasks_IF_assms, wp]: "\<lambda>s. P (irq_masks_of_state s)"
-  (  wp: crunch_wps dmo_wp no_irq
-   simp: crunch_simps no_irq_setVSpaceRoot no_irq_hwASIDFlush)
+  (wp: crunch_wps dmo_wp simp: crunch_simps)
 
 crunch send_signal, timer_tick
   for irq_masks[IRQMasks_IF_assms, wp]: "\<lambda>s. P (irq_masks_of_state s)"
@@ -53,21 +57,16 @@ lemma handle_interrupt_irq_masks[IRQMasks_IF_assms]:
    apply (wp dmo_wp
           | simp add: ackInterrupt_def maskInterrupt_def when_def split del: if_split
           | wpc
-          | simp add: get_irq_state_def handle_reserved_irq_def
-          | wp (once) hoare_drop_imp)+
+          | simp add: get_irq_state_def
+          | wp (once) hoare_drop_imp hoare_pre_cont)+
+  apply (fastforce simp: domain_sep_inv_def)
   done
 
 lemma arch_invoke_irq_control_irq_masks[IRQMasks_IF_assms]:
   "\<lbrace>domain_sep_inv False st and arch_irq_control_inv_valid invok\<rbrace>
    arch_invoke_irq_control invok
    \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  apply (case_tac invok)
-  apply (clarsimp simp: arch_irq_control_inv_valid_def domain_sep_inv_def valid_def)
-  done
-
-crunch handle_vm_fault, handle_hypervisor_fault
-  for irq_masks[IRQMasks_IF_assms, wp]: "\<lambda>s. P (irq_masks_of_state s)"
-  (wp: dmo_wp no_irq)
+  by (cases invok) (auto simp: arch_irq_control_inv_valid_def domain_sep_inv_def valid_def)
 
 lemma dmo_getActiveIRQ_irq_masks[IRQMasks_IF_assms, wp]:
   "do_machine_op (getActiveIRQ in_kernel) \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
@@ -81,15 +80,12 @@ lemma dmo_getActiveIRQ_return_axiom[IRQMasks_IF_assms, wp]:
   apply (rule hoare_pre, rule dmo_wp)
    apply (insert irq_oracle_max_irq)
    apply (wp dmo_getActiveIRQ_irq_masks)
-  apply clarsimp
+  apply (clarsimp simp: maxIRQ_def)
   done
 
-crunch activate_thread, handle_spurious_irq
+crunch activate_thread, handle_spurious_irq, handle_vm_fault
   for irq_masks[IRQMasks_IF_assms, wp]: "\<lambda>s. P (irq_masks_of_state s)"
-
-crunch schedule
-  for irq_masks[IRQMasks_IF_assms, wp]: "\<lambda>s. P (irq_masks_of_state s)"
-  (wp: dmo_wp crunch_wps dxo_wp_weak simp: crunch_simps)
+  (wp: dmo_wp no_irq)
 
 end
 
@@ -104,13 +100,22 @@ qed
 
 context Arch begin global_naming AARCH64
 
+crunch handle_vm_fault, handle_hypervisor_fault
+  for irq_masks[IRQMasks_IF_assms, wp]: "\<lambda>s. P (irq_masks_of_state s)"
+  (wp: dmo_wp no_irq)
+
 crunch do_reply_transfer, set_priority, set_flags, arch_post_set_flags
   for irq_masks[IRQMasks_IF_assms, wp]: "\<lambda>s. P (irq_masks_of_state s)"
-  (wp: crunch_wps empty_slot_irq_masks simp: crunch_simps unless_def)
+  (wp: crunch_wps dmo_wp empty_slot_irq_masks simp: crunch_simps unless_def)
 
-crunch arch_perform_invocation
+lemma no_irq_do_flush[wp,simp]:
+  "no_irq (do_flush type vstart vend pstart)"
+  by (wpsimp simp: do_flush_def)
+
+crunch perform_vspace_invocation, perform_page_table_invocation, perform_asid_control_invocation,
+       perform_asid_pool_invocation, perform_sgi_invocation, perform_page_invocation
   for irq_masks[IRQMasks_IF_assms, wp]: "\<lambda>s. P (irq_masks_of_state s)"
-  (wp: dmo_wp crunch_wps no_irq)
+  (wp: dmo_wp crunch_wps no_irq simp: crunch_simps)
 
 (* FIXME: remove duplication in this proof -- requires getting the wp automation
           to do the right thing with dropping imps in validE goals *)
@@ -151,12 +156,126 @@ lemma invoke_tcb_irq_masks[IRQMasks_IF_assms]:
     apply (simp add: option_update_thread_def | wp hoare_weak_lift_imp hoare_vcg_all_lift | wpc)+
   by fastforce+
 
-lemma init_arch_objects_irq_masks:
-  "init_arch_objects new_type dev ptr num_objects obj_sz refs \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
-  by (rule init_arch_objects_inv)
+crunch arch_prepare_set_domain,
+       invoke_vcpu_inject_irq, invoke_vcpu_read_register,
+       invoke_vcpu_write_register, invoke_vcpu_ack_vppi
+  for irq_masks[IRQMasks_IF_assms,wp]: "\<lambda>s. P (irq_masks_of_state s)"
+  (wp: dmo_wp mapM_x_wp_inv mapM_wp_inv)
 
-crunch arch_prepare_set_domain
-  for inv[IRQMasks_IF_assms,wp]: P
+lemma inactive_irqVTimerEvent:
+  "\<lbrace>domain_sep_inv False st and R False\<rbrace>
+   is_irq_active irqVTimerEvent
+   \<lbrace>\<lambda>rv. if rv then Q rv else R rv\<rbrace>"
+  unfolding is_irq_active_def get_irq_state_def
+  apply wpsimp
+  apply (fastforce simp: domain_sep_inv_def non_kernel_IRQs_def)
+  done
+
+crunch vcpu_restore_reg, vcpu_restore_reg_range
+  for irq_masks[wp]: "\<lambda>s. P (irq_masks_of_state s)"
+  (wp: dmo_wp mapM_x_wp)
+
+lemma restore_virt_timer_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+   restore_virt_timer vcpu_ptr
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding restore_virt_timer_def
+  by (wpsimp wp: inactive_irqVTimerEvent[where st=st] | wp hoare_pre_cont)+
+
+lemma vcpu_enable_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+   vcpu_enable vr
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding vcpu_enable_def
+  by (wpsimp wp: restore_virt_timer_irq_masks[where st=st] dmo_wp)
+
+lemma vcpu_restore_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+   vcpu_restore vr
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding vcpu_restore_def
+  by (wpsimp wp: vcpu_enable_irq_masks[where st=st] mapM_wp_inv dmo_wp)
+
+lemma vcpu_switch_Some_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+   vcpu_switch (Some vcpu)
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding vcpu_switch_def
+  by (wpsimp wp: vcpu_restore_irq_masks[where st=st] vcpu_enable_irq_masks[where st=st] dmo_wp)
+
+lemma associate_vcpu_tcb_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+   associate_vcpu_tcb vcpu_ptr t
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding associate_vcpu_tcb_def
+  by (wpsimp wp: vcpu_switch_Some_irq_masks[where st=st] hoare_weak_lift_imp | wps)+
+
+lemma perform_vcpu_invocation_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+   perform_vcpu_invocation i
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding perform_vcpu_invocation_def
+  by (wpsimp wp: associate_vcpu_tcb_irq_masks[where st=st])
+
+lemma perform_smc_invocation_irq_masks[wp]:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s))\<rbrace>
+   perform_smc_invocation i
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding perform_smc_invocation_def doSMC_mop_def
+  by (wpsimp simp: dmo_distr wp: hoare_drop_imps dmo_wp)
+
+lemma arch_perform_invocation_irq_masks[IRQMasks_IF_assms, wp]:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+   arch_perform_invocation i
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding arch_perform_invocation_def fun_app_def
+  by (wpsimp wp: perform_vcpu_invocation_irq_masks[where st=st])
+
+lemma maskVTimer_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and valid_irq_states\<rbrace>
+   do_machine_op (maskInterrupt True irqVTimerEvent)
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding maskInterrupt_def
+  apply (wpsimp wp: dmo_machine_state_lift)
+  apply (erule_tac P=P in rsubst)
+  apply (fastforce simp: domain_sep_inv_def non_kernel_IRQs_def valid_irq_states_def valid_irq_masks_def)
+  done
+
+lemma vcpu_disable_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and valid_irq_states\<rbrace>
+   vcpu_disable vo
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  by (wpsimp wp: maskVTimer_irq_masks[where st=st] hoare_drop_imps dmo_machine_state_lift
+           simp: vcpu_disable_def dmo_distr)
+
+lemma vcpu_switch_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and valid_irq_states\<rbrace>
+   vcpu_switch vo
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding vcpu_switch_def
+  by (wpsimp wp: vcpu_disable_irq_masks[where st=st]
+                 vcpu_restore_irq_masks[where st=st]
+                 vcpu_enable_irq_masks[where st=st]
+                 dmo_machine_state_lift)
+
+lemma arch_switch_to_idle_thread_irq_masks[IRQMasks_IF_assms]:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and valid_irq_states\<rbrace>
+   arch_switch_to_idle_thread
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding arch_switch_to_idle_thread_def
+  by (wpsimp wp: vcpu_switch_irq_masks[where st=st])
+
+lemma arch_switch_to_thread_irq_masks[IRQMasks_IF_assms]:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and valid_irq_states\<rbrace>
+   arch_switch_to_thread t
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding arch_switch_to_thread_def
+  by (wpsimp wp: vcpu_switch_irq_masks[where st=st])
+
+crunch arch_prepare_next_domain
+  for irq_masks[IRQMasks_IF_assms,wp]: "\<lambda>s. P (irq_masks_of_state s)"
+  and valid_irq_states[IRQMasks_IF_assms,wp]: "valid_irq_states"
+  (wp: crunch_wps)
 
 end
 
@@ -169,10 +288,10 @@ proof goal_cases
 qed
 
 
-requalify_facts
-  AARCH64.init_arch_objects_irq_masks
-  AARCH64.arch_activate_idle_thread_irq_masks
-  AARCH64.retype_region_irq_masks
+arch_requalify_facts
+  init_arch_objects_irq_masks
+  arch_activate_idle_thread_irq_masks
+  retype_region_irq_masks
 
 declare
   init_arch_objects_irq_masks[wp]

--- a/proof/infoflow/AARCH64/ArchInfoFlow.thy
+++ b/proof/infoflow/AARCH64/ArchInfoFlow.thy
@@ -10,6 +10,9 @@ imports
   "Lib.EquivValid"
 begin
 
+(* Declare here and define in InfoFlow_IF *)
+consts equiv_for :: "('a \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> 'a \<Rightarrow> 'c) \<Rightarrow> 'b \<Rightarrow> 'b \<Rightarrow> bool"
+
 context Arch begin global_naming AARCH64
 
 section \<open>Arch-specific equivalence properties\<close>
@@ -48,7 +51,65 @@ definition non_asid_pool_kheap_update where
          \<longrightarrow> kheap s x = kh x"
 
 
-subsection \<open>Exclusive machine state equivalence\<close>
+subsection \<open>VCPU equivalence\<close>
+
+(* FIXME AARCH64 IF: move *)
+locale_abbrev numlistregs :: "'s state \<Rightarrow> nat" where
+  "numlistregs s \<equiv> arm_gicvcpu_numlistregs (arch_state s)"
+
+(* FIXME AARCH64 IF: move *)
+locale_abbrev current_vcpu :: "'s state \<rightharpoonup> obj_ref \<times> bool" where
+  "current_vcpu s \<equiv> arm_current_vcpu (arch_state s)"
+
+definition hw_vcpu ::
+  "nat \<Rightarrow> bool option \<Rightarrow> vcpu_state \<rightharpoonup> vcpu_state"
+where
+  "hw_vcpu n cv vcpu \<equiv> case cv of
+     None \<Rightarrow> None
+   | Some enabled \<Rightarrow> Some
+       \<lparr>vcpu_vgic = \<lparr>vgic_hcr = if \<not>enabled then undefined else vgic_hcr (vcpu_vgic vcpu),
+                     vgic_vmcr = vgic_vmcr (vcpu_vgic vcpu),
+                     vgic_apr = vgic_apr (vcpu_vgic vcpu),
+                     vgic_lr = \<lambda>r. if r < n then vgic_lr (vcpu_vgic vcpu) r else undefined\<rparr>,
+        vcpu_regs = \<lambda>r. if \<not>enabled \<and> vcpuRegSavedWhenDisabled r
+                        then undefined
+                        else vcpu_regs vcpu r\<rparr>"
+
+locale_abbrev hw_vcpu_of where
+  "hw_vcpu_of s p \<equiv> hw_vcpu (numlistregs s) (cur_vcpu_of s p) (vcpu_state (machine_state s))"
+
+lemmas hw_vcpu_of_def = hw_vcpu_def
+
+definition equiv_hyp :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "equiv_hyp P s s' \<equiv> equiv_for P (K \<circ> numlistregs) s s' \<and>
+                       equiv_for P cur_vcpu_of s s' \<and>
+                       equiv_for P hw_vcpu_of s s'"
+
+
+subsection \<open>FPU equivalence\<close>
+
+(* FIXME AARCH64 IF: move *)
+locale_abbrev current_fpu :: "'s state \<rightharpoonup> obj_ref" where
+  "current_fpu s \<equiv> arm_current_fpu_owner (arch_state s)"
+
+definition is_arch_cur_fpu_2 :: "obj_ref \<Rightarrow> obj_ref option \<Rightarrow> bool" where
+  "is_arch_cur_fpu_2 ptr fopt \<equiv> fopt = Some ptr"
+
+locale_abbrev is_arch_cur_fpu :: "obj_ref \<Rightarrow> 's state \<Rightarrow> bool" where
+  "is_arch_cur_fpu ptr s \<equiv> is_arch_cur_fpu_2 ptr (arm_current_fpu_owner (arch_state s))"
+
+lemmas is_arch_cur_fpu_def = is_arch_cur_fpu_2_def
+
+definition hw_fpu :: "bool \<Rightarrow> fpu_state \<Rightarrow> fpu_state option"
+where
+  "hw_fpu cf fpu \<equiv> if cf then Some fpu else None"
+
+locale_abbrev hw_fpu_of where
+  "hw_fpu_of s t \<equiv> hw_fpu (is_arch_cur_fpu t s) (fpu_state (machine_state s))"
+
+definition equiv_fpu :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "equiv_fpu P s s' \<equiv> equiv_for P hw_fpu_of s s'"
+
 
 subsection \<open>Global (Kernel) VSpace equivalence\<close>
 (* globals_equiv should be maintained by everything except the scheduler, since
@@ -64,10 +125,11 @@ declare arch_globals_equiv_def[simp]
 
 end
 
-requalify_consts
-  AARCH64.equiv_asid
-  AARCH64.equiv_asid'
-  AARCH64.arch_globals_equiv
-  AARCH64.non_asid_pool_kheap_update
+(* FIXME AARCH64 IF: requalify elsewhere *)
+arch_requalify_consts
+  equiv_asid
+  equiv_asid'
+  arch_globals_equiv
+  non_asid_pool_kheap_update
 
 end

--- a/proof/infoflow/AARCH64/ArchInfoFlow_IF.thy
+++ b/proof/infoflow/AARCH64/ArchInfoFlow_IF.thy
@@ -12,6 +12,20 @@ context Arch begin global_naming AARCH64
 
 named_theorems InfoFlow_IF_assms
 
+definition identical_hyp_state_updates ::
+  "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> machine_state \<Rightarrow> machine_state \<Rightarrow> bool" where
+  "identical_hyp_state_updates P s s' ms ms' \<equiv>
+     identical_updates_for P (hw_vcpu_of s) (hw_vcpu_of s')
+                             (hw_vcpu_of (s\<lparr>machine_state := ms\<rparr>))
+                             (hw_vcpu_of (s'\<lparr>machine_state := ms'\<rparr>))"
+
+definition identical_fpu_state_updates ::
+  "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> machine_state \<Rightarrow> machine_state \<Rightarrow> bool" where
+  "identical_fpu_state_updates P s s' ms ms' \<equiv>
+     identical_updates_for P (hw_fpu_of s) (hw_fpu_of s')
+                             (hw_fpu_of (s\<lparr>machine_state := ms\<rparr>))
+                             (hw_fpu_of (s'\<lparr>machine_state := ms'\<rparr>))"
+
 lemma asid_pool_at_kheap:
   "asid_pool_at ptr s = (\<exists>asid_pool. kheap s ptr = Some (ArchObj (ASIDPool asid_pool)))"
   by (simp add: atyp_at_eq_kheap_obj)
@@ -34,6 +48,14 @@ lemma equiv_asids_trans[InfoFlow_IF_assms]:
   "\<lbrakk> equiv_asids R s t; equiv_asids R t u \<rbrakk> \<Longrightarrow> equiv_asids R s u"
   by (fastforce simp: equiv_asids_def equiv_asid_def asid_pool_at_kheap asid_pools_of_ko_at obj_at_def)
 
+lemma equiv_asids_trivial[InfoFlow_IF_assms]:
+  "(\<And>x. P x \<Longrightarrow> False) \<Longrightarrow> equiv_asids P x y"
+  by (auto simp: equiv_asids_def)
+
+lemma equiv_asids_guard_imp[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_asids R s s'; \<And>x. Q x \<Longrightarrow> R x \<rbrakk> \<Longrightarrow> equiv_asids Q s s'"
+  by (auto simp: equiv_asids_def)
+
 lemma equiv_asids_non_asid_pool_kheap_update[InfoFlow_IF_assms]:
   "\<lbrakk> equiv_asids R s s'; non_asid_pool_kheap_update s kh; non_asid_pool_kheap_update s' kh' \<rbrakk>
      \<Longrightarrow> equiv_asids R (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
@@ -49,10 +71,6 @@ lemma equiv_asids_identical_kheap_updates[InfoFlow_IF_assms]:
   apply (case_tac "kh pool_ptr = kh' pool_ptr"; fastforce)
   done
 
-lemma equiv_asids_trivial[InfoFlow_IF_assms]:
-  "(\<And>x. P x \<Longrightarrow> False) \<Longrightarrow> equiv_asids P x y"
-  by (auto simp: equiv_asids_def)
-
 lemma equiv_asids_triv':
   "\<lbrakk> equiv_asids R s s'; kheap t = kheap s; kheap t' = kheap s';
      arm_asid_table (arch_state t) = arm_asid_table (arch_state s);
@@ -65,6 +83,88 @@ lemma equiv_asids_triv[InfoFlow_IF_assms]:
      arch_state t = arch_state s; arch_state t' = arch_state s' \<rbrakk>
      \<Longrightarrow> equiv_asids R t t'"
   by (fastforce simp: equiv_asids_triv')
+
+lemma equiv_hyp_refl[InfoFlow_IF_assms]:
+  "equiv_hyp P s s"
+  by (auto simp: equiv_hyp_def equiv_for_def)
+
+lemma equiv_hyp_sym[InfoFlow_IF_assms]:
+  "equiv_hyp P s t \<Longrightarrow> equiv_hyp P t s"
+  by (auto simp: equiv_hyp_def equiv_for_def)
+
+lemma equiv_hyp_trans[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_hyp P s t; equiv_hyp P t u \<rbrakk> \<Longrightarrow> equiv_hyp P s u"
+  by (fastforce simp: equiv_hyp_def equiv_for_def)
+
+lemma equiv_hyp_False[InfoFlow_IF_assms]:
+  "(\<And>x. P x \<Longrightarrow> False) \<Longrightarrow> equiv_hyp P x y"
+  by (auto simp: equiv_hyp_def equiv_for_def)
+
+lemma equiv_hyp_guard_imp[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_hyp P s s'; \<And>x. Q x \<Longrightarrow> P x \<rbrakk> \<Longrightarrow> equiv_hyp Q s s'"
+  by (fastforce simp: equiv_hyp_def equiv_for_def)
+
+lemma equiv_hyp_triv':
+  "\<lbrakk> equiv_hyp P s s';
+     arm_current_vcpu (arch_state t) = arm_current_vcpu (arch_state s);
+     arm_current_vcpu (arch_state t') = arm_current_vcpu (arch_state s');
+     vcpu_state (machine_state t) = vcpu_state (machine_state s);
+     vcpu_state (machine_state t') = vcpu_state (machine_state s');
+     arm_gicvcpu_numlistregs (arch_state t) = arm_gicvcpu_numlistregs (arch_state s);
+     arm_gicvcpu_numlistregs (arch_state t') = arm_gicvcpu_numlistregs (arch_state s') \<rbrakk>
+     \<Longrightarrow> equiv_hyp P t t'"
+  by (fastforce simp: equiv_hyp_def equiv_for_def)
+
+lemma equiv_hyp_triv[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_hyp P s s'; arch_state t = arch_state s; arch_state t' = arch_state s';
+     machine_state t = machine_state s; machine_state t' = machine_state s' \<rbrakk>
+     \<Longrightarrow> equiv_hyp P t t'"
+  by (fastforce simp: equiv_hyp_triv')
+
+lemma equiv_hyp_machine_state_update[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_hyp P s s'; identical_hyp_state_updates P s s' ms ms' \<rbrakk>
+     \<Longrightarrow> equiv_hyp P (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>)"
+  by (fastforce simp: equiv_hyp_def equiv_for_def identical_hyp_state_updates_def identical_updates_def)
+
+lemma equiv_fpu_refl[InfoFlow_IF_assms]:
+  "equiv_fpu P s s"
+  by (auto simp: equiv_fpu_def equiv_for_def)
+
+lemma equiv_fpu_sym[InfoFlow_IF_assms]:
+  "equiv_fpu P s t \<Longrightarrow> equiv_fpu P t s"
+  by (auto simp: equiv_fpu_def equiv_for_def)
+
+lemma equiv_fpu_trans[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_fpu P s t; equiv_fpu P t u \<rbrakk> \<Longrightarrow> equiv_fpu P s u"
+  by (fastforce simp: equiv_fpu_def equiv_for_def)
+
+lemma equiv_fpu_False[InfoFlow_IF_assms]:
+  "(\<And>x. P x \<Longrightarrow> False) \<Longrightarrow> equiv_fpu P x y"
+  by (auto simp: equiv_fpu_def equiv_for_def)
+
+lemma equiv_fpu_guard_imp[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_fpu P s s'; \<And>x. Q x \<Longrightarrow> P x \<rbrakk> \<Longrightarrow> equiv_fpu Q s s'"
+  by (auto simp: equiv_fpu_def equiv_for_def)
+
+lemma equiv_fpu_triv':
+  "\<lbrakk> equiv_fpu P s s'; current_fpu t = current_fpu s; current_fpu t' = current_fpu s';
+     fpu_state (machine_state t) = fpu_state (machine_state s);
+     fpu_state (machine_state t') = fpu_state (machine_state s') \<rbrakk>
+     \<Longrightarrow> equiv_fpu P t t'"
+  by (auto simp: equiv_fpu_def equiv_for_def get_tcb_def hw_fpu_def )
+
+lemma equiv_fpu_triv[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_fpu P s s'; arch_state t = arch_state s; arch_state t' = arch_state s';
+     machine_state t = machine_state s; machine_state t' = machine_state s' \<rbrakk>
+     \<Longrightarrow> equiv_fpu P t t'"
+  by (fastforce simp: equiv_fpu_triv')
+
+lemma equiv_fpu_machine_state_update[InfoFlow_IF_assms]:
+  "\<lbrakk> equiv_fpu P s s'; identical_fpu_state_updates P s s' ms ms' \<rbrakk>
+     \<Longrightarrow> equiv_fpu P (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>)"
+  by (fastforce simp: equiv_fpu_def equiv_for_def hw_fpu_def
+                      identical_fpu_state_updates_def identical_updates_def
+               split: if_splits)
 
 lemma globals_equiv_refl[InfoFlow_IF_assms]:
   "globals_equiv s s"
@@ -79,9 +179,32 @@ lemma globals_equiv_trans[InfoFlow_IF_assms]:
   unfolding globals_equiv_def arch_globals_equiv_def
   by clarsimp (metis idle_equiv_trans idle_equiv_def)
 
-lemma equiv_asids_guard_imp[InfoFlow_IF_assms]:
-  "\<lbrakk> equiv_asids R s s'; \<And>x. Q x \<Longrightarrow> R x \<rbrakk> \<Longrightarrow> equiv_asids Q s s'"
-  by (auto simp: equiv_asids_def)
+lemma equiv_hypI[InfoFlow_IF_assms]:
+  assumes "\<And>x. P x \<Longrightarrow> equiv_hyp ((=) x) s t"
+  shows "equiv_hyp P s t"
+  using assms by (fastforce simp: equiv_hyp_def equiv_for_def)
+
+lemma equiv_fpuI[InfoFlow_IF_assms]:
+  assumes "\<And>x. P x \<Longrightarrow> equiv_fpu ((=) x) s t"
+  shows "equiv_fpu P s t"
+  using assms by (fastforce simp: equiv_fpu_def equiv_for_def)
+
+end
+
+arch_requalify_consts
+  identical_hyp_state_updates
+  identical_fpu_state_updates
+
+
+global_interpretation InfoFlow_IF_1?: InfoFlow_IF_1 identical_hyp_state_updates identical_fpu_state_updates
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact InfoFlow_IF_assms)?)
+qed
+
+
+context Arch begin arch_global_naming
 
 lemma dmo_loadWord_rev[InfoFlow_IF_assms]:
   "reads_equiv_valid_inv A aag (K (for_each_byte_of_word (aag_can_read aag) p))
@@ -109,10 +232,330 @@ lemma dmo_loadWord_rev[InfoFlow_IF_assms]:
       apply (wp wp_post_taut loadWord_inv | simp)+
   done
 
+definition cur_vcpu_for_2 where
+  "cur_vcpu_for_2 P cv \<equiv> case cv of
+     None \<Rightarrow> None
+   | Some (ptr,b) \<Rightarrow> if P ptr then Some b else None"
+
+locale_abbrev cur_vcpu_for where
+  "cur_vcpu_for P s \<equiv> cur_vcpu_for_2 P (current_vcpu s)"
+
+lemmas cur_vcpu_for_def = cur_vcpu_for_2_def
+
+lemma hw_vcpu_None[simp]:
+  "hw_vcpu n None vst = None"
+  by (simp add: hw_vcpu_def)
+
+definition equiv_hyp_state :: "nat \<Rightarrow> bool option \<Rightarrow> machine_state \<Rightarrow> machine_state \<Rightarrow> bool" where
+  "equiv_hyp_state n cv ms ms' \<equiv> hw_vcpu n cv (vcpu_state ms) = hw_vcpu n cv (vcpu_state ms')"
+
+definition equiv_fpu_state :: "bool \<Rightarrow> machine_state \<Rightarrow> machine_state \<Rightarrow> bool" where
+  "equiv_fpu_state cf ms ms' \<equiv> hw_fpu cf (fpu_state ms) = hw_fpu cf (fpu_state ms')"
+
+definition "no_hyp f \<equiv> \<forall>P. \<lbrace>\<lambda>s. P (vcpu_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (vcpu_state s)\<rbrace>"
+
+definition "no_fpu f \<equiv> \<forall>P. \<lbrace>\<lambda>s. P (fpu_state s)\<rbrace> f \<lbrace>\<lambda>_ s. P (fpu_state s)\<rbrace>"
+
+lemma equiv_hyp_state_identical_hyp_state_updates:
+  "\<lbrakk> equiv_hyp_state (numlistregs s) (cur_vcpu_for P s) ms ms'; equiv_hyp P s t \<rbrakk>
+       \<Longrightarrow> identical_hyp_state_updates P s t ms ms'"
+  apply (clarsimp simp: equiv_hyp_state_def equiv_for_def identical_hyp_state_updates_def equiv_hyp_def)
+  apply (erule_tac x=x in allE)+
+  apply (drule mp, fastforce)
+  apply (clarsimp simp: cur_vcpu_for_def cur_vcpu_of_def identical_updates_rv_def
+                 split: option.splits if_splits)
+  done
+
+lemma cur_vcpu_for_None:
+  "cur_vcpu_for_2 P None = None"
+  by (clarsimp simp: cur_vcpu_for_def)
+
+lemma cur_vcpu_for_Some:
+  "cur_vcpu_for_2 P (Some (a,b)) = (if P a then Some b else None)"
+  by (clarsimp simp: cur_vcpu_for_def)
+
+lemma cur_vcpu_for_equiv:
+  "\<lbrakk> reads_equiv aag st s; affects_equiv aag l st s \<rbrakk>
+     \<Longrightarrow> cur_vcpu_for (aag_can_read aag or aag_can_affect aag l) st = cur_vcpu_for (aag_can_read aag or aag_can_affect aag l) s"
+  apply (prop_tac "equiv_for (aag_can_read aag or aag_can_affect aag l) cur_vcpu_of st s")
+   apply (simp add: equiv_hyp_def equiv_for_or reads_equiv_def2 affects_equiv_def2 states_equiv_for_def)
+  apply (case_tac "current_vcpu st"; case_tac "current_vcpu s"; clarsimp)
+    apply (clarsimp simp: cur_vcpu_for_None)
+    apply (case_tac "(aag_can_read aag or aag_can_affect aag l) a")
+     prefer 2
+     apply (clarsimp simp: cur_vcpu_for_Some)
+    apply (erule equiv_forE)
+    apply (erule_tac x=a in meta_allE)
+    apply (drule (1) meta_mp)
+    apply (clarsimp simp: cur_vcpu_of_def)
+   apply (clarsimp simp: cur_vcpu_for_None)
+   apply (case_tac "(aag_can_read aag or aag_can_affect aag l) a")
+    prefer 2
+    apply (clarsimp simp: cur_vcpu_for_Some)
+   apply (erule equiv_forE)
+   apply (erule_tac x=a in meta_allE)
+   apply (drule (1) meta_mp)
+   apply (clarsimp simp: cur_vcpu_of_def)
+  apply (case_tac "(aag_can_read aag or aag_can_affect aag l) a"; case_tac "(aag_can_read aag or aag_can_affect aag l) aa")
+     apply (erule equiv_forE)
+     apply (erule_tac x=a in meta_allE)
+     apply (drule (1) meta_mp)
+     apply (clarsimp simp: cur_vcpu_of_def split: if_splits)
+    apply (erule equiv_forE)
+    apply (erule_tac x=a in meta_allE)
+    apply (drule (1) meta_mp)
+    apply (clarsimp simp: cur_vcpu_of_def split: if_splits)
+   apply (erule equiv_forE)
+   apply (erule_tac x=aa in meta_allE)
+   apply (drule (1) meta_mp)
+   apply (clarsimp simp: cur_vcpu_of_def split: if_splits)
+  apply (clarsimp simp: cur_vcpu_for_Some)
+  done
+
+lemma aequiv_get_tcb_eq'[intro]:
+  "\<lbrakk> affects_equiv aag l s t; aag_can_affect aag l thread \<rbrakk>
+     \<Longrightarrow> get_tcb thread s = get_tcb thread t"
+  by (auto simp: affects_equiv_def2 get_tcb_def elim: states_equiv_forE_kheap)
+
+definition cur_fpu_for where
+  "cur_fpu_for P s \<equiv> \<exists>ptr. P ptr \<and> is_arch_cur_fpu ptr s"
+
+lemma equiv_fpu_cur_fpu_for:
+  "equiv_fpu P st s \<Longrightarrow> cur_fpu_for P st = cur_fpu_for P s"
+  apply (clarsimp simp: equiv_fpu_def equiv_for_def cur_fpu_for_def)
+  apply (rule iffI; erule ex_forward; erule_tac x=ptr in allE; clarsimp simp: hw_fpu_def split: if_splits)
+  done
+
+lemma cur_fpu_for_equiv:
+  "\<lbrakk> reads_equiv aag st s; affects_equiv aag l st s \<rbrakk>
+     \<Longrightarrow> cur_fpu_for (aag_can_read aag or aag_can_affect aag l) st =
+         cur_fpu_for (aag_can_read aag or aag_can_affect aag l) s"
+  apply (prop_tac "equiv_fpu (aag_can_read aag or aag_can_affect aag l) st s")
+   apply (clarsimp simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_fpu_def equiv_for_def)
+  apply (simp add: equiv_fpu_cur_fpu_for)
+  done
+
+lemma equiv_fpu_state_identical_fpu_state_updates:
+  "\<lbrakk> equiv_fpu_state (cur_fpu_for P s) ms ms'; equiv_fpu P s t \<rbrakk>
+       \<Longrightarrow> identical_fpu_state_updates P s t ms ms'"
+  unfolding identical_fpu_state_updates_def
+  apply (clarsimp simp: identical_fpu_state_updates_def identical_updates_def)
+  apply (clarsimp simp: equiv_fpu_state_def equiv_for_def equiv_fpu_def)
+  apply (erule_tac x=x in allE, clarsimp)
+  apply (auto simp: cur_fpu_for_def hw_fpu_def get_tcb_def identical_updates_rv_def split: if_splits option.splits kernel_object.splits)
+  done
+
+definition numlistregs_for where
+  "numlistregs_for P s \<equiv> if \<exists>x. P x then numlistregs s else undefined"
+
+lemma numlistregs_for_equiv:
+  "\<lbrakk> reads_equiv aag st s; affects_equiv aag l st s \<rbrakk>
+     \<Longrightarrow> numlistregs_for (aag_can_read aag or aag_can_affect aag l) st = numlistregs_for (aag_can_read aag or aag_can_affect aag l) s"
+  by (auto simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_hyp_def equiv_for_def numlistregs_for_def)
+
+lemma equiv_hyp_state_sym:
+  "equiv_hyp_state n cv ms' ms \<Longrightarrow> equiv_hyp_state n cv ms ms'"
+  by (simp add: equiv_hyp_state_def)
+
+lemma equiv_fpu_state_sym:
+  "equiv_fpu_state cf ms' ms \<Longrightarrow> equiv_fpu_state cf ms ms'"
+  by (simp add: equiv_fpu_state_def)
+
+lemma spec_equiv_valid_add_inv:
+  assumes "spec_equiv_valid st I A B (P and I st) f"
+  and "\<And>s. I s s"
+  shows "spec_equiv_valid st I A B P f"
+  using assms by (fastforce simp: spec_equiv_valid_def equiv_valid_2_def)
+
+lemma spec_equiv_valid_add_A:
+  assumes "spec_equiv_valid st I A B (P and A st) f"
+  and "\<And>s. A s s"
+  shows "spec_equiv_valid st I A B P f"
+  using assms by (fastforce simp: spec_equiv_valid_def equiv_valid_2_def)
+
+lemma do_machine_op_reads_respects'':
+  assumes equiv_dmo:
+   "\<And>n cv cf. equiv_valid_inv (equiv_irq_state and equiv_machine_state (aag_can_read aag)
+                                               and equiv_hyp_state n cv
+                                               and equiv_fpu_state cf)
+                             (equiv_machine_state (aag_can_affect aag l)) (Q n cv cf) f"
+  assumes guard:
+    "\<And>s. P s \<Longrightarrow> Q (numlistregs_for (aag_can_read aag or aag_can_affect aag l) s)
+                    (cur_vcpu_for (aag_can_read aag or aag_can_affect aag l) s)
+                    (cur_fpu_for (aag_can_read aag or aag_can_affect aag l) s)
+                    (machine_state s)"
+  shows
+    "reads_respects aag l P (do_machine_op f)"
+  apply (rule use_spec_ev)
+  apply (rule spec_equiv_valid_add_inv)
+   prefer 2
+   apply (simp add: reads_equiv_refl)
+  apply (rule spec_equiv_valid_add_A)
+   prefer 2
+   apply (simp add: affects_equiv_refl)
+  unfolding do_machine_op_def spec_equiv_valid_def
+  supply equiv_for_disj[simp]
+  apply (rule equiv_valid_2_guard_imp)
+    apply (rule_tac R'="\<lambda>rv rv'. equiv_machine_state (aag_can_read aag or aag_can_affect aag l) rv rv' \<and>
+                                 equiv_irq_state rv rv' \<and>
+                                 equiv_hyp_state (numlistregs_for (aag_can_read aag or aag_can_affect aag l) st) (cur_vcpu_for (aag_can_read aag or aag_can_affect aag l) st) rv rv' \<and>
+                                 equiv_fpu_state (cur_fpu_for (aag_can_read aag or aag_can_affect aag l) st) rv rv'"
+   and Q="\<lambda>r s. st = s \<and> Q (numlistregs_for (aag_can_read aag or aag_can_affect aag l) st) (cur_vcpu_for (aag_can_read aag or aag_can_affect aag l) st) (cur_fpu_for (aag_can_read aag or aag_can_affect aag l) st) r"
+                and Q'="\<lambda>r s. Q (numlistregs_for (aag_can_read aag or aag_can_affect aag l) st) (cur_vcpu_for (aag_can_read aag or aag_can_affect aag l) st) (cur_fpu_for (aag_can_read aag or aag_can_affect aag l) st) r"
+                and P="(=) st" and P'="\<top>" in equiv_valid_2_bind)
+       apply (rule gen_asm_ev2_l[simplified K_def pred_conj_def])
+       apply (rule gen_asm_ev2_r')
+       apply (rule_tac R'="\<lambda>(r, ms') (r', ms''). r = r' \<and> equiv_machine_state (aag_can_read aag or aag_can_affect aag l) ms' ms''
+                                                        \<and> equiv_irq_state ms' ms''
+                                                        \<and> equiv_hyp_state (numlistregs_for (aag_can_read aag or aag_can_affect aag l) st) (cur_vcpu_for (aag_can_read aag or aag_can_affect aag l) st) ms' ms''
+                                                        \<and> equiv_fpu_state (cur_fpu_for (aag_can_read aag or aag_can_affect aag l) st) ms' ms''"
+                   and Q="\<lambda>r s. s = st"
+                   and Q'="\<top>\<top>"
+                   and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
+            apply (clarsimp simp: modify_def get_def put_def bind_def return_def equiv_valid_2_def)
+            apply (rule conjI)
+             apply (rule reads_equiv_machine_state_update; clarsimp?)
+              apply (rule equiv_hyp_state_identical_hyp_state_updates)
+               apply (clarsimp simp: equiv_hyp_state_def cur_vcpu_for_def numlistregs_for_def split: option.splits if_splits)
+              apply (erule reads_equivE, clarsimp simp: equiv_hyp_def)
+             apply (rule equiv_fpu_state_identical_fpu_state_updates)
+              apply (fastforce simp: equiv_fpu_state_def cur_fpu_for_def hw_fpu_def split: option.splits if_splits)
+             apply (erule reads_equivE, clarsimp simp: equiv_fpu_def)
+            apply (rule affects_equiv_machine_state_update; clarsimp?)
+             apply (rule equiv_hyp_state_identical_hyp_state_updates)
+              apply (clarsimp simp: equiv_hyp_state_def cur_vcpu_for_def numlistregs_for_def split: option.splits if_splits)
+             apply (erule affects_equivE, clarsimp simp: equiv_hyp_def)
+            apply (rule equiv_fpu_state_identical_fpu_state_updates)
+             apply (fastforce simp: equiv_fpu_state_def cur_fpu_for_def hw_fpu_def split: option.splits if_splits)
+            apply (erule affects_equivE, clarsimp simp: equiv_fpu_def)
+           apply (insert equiv_dmo)[1]
+           apply (clarsimp simp: select_f_def equiv_valid_2_def equiv_valid_def2 equiv_for_or
+                           simp: split_def split: prod.splits simp: equiv_for_def)[1]
+           apply (erule_tac x="numlistregs_for (aag_can_read aag or aag_can_affect aag l) st" in meta_allE)
+           apply (erule_tac x="cur_vcpu_for (aag_can_read aag or aag_can_affect aag l) st" in meta_allE)
+           apply (erule_tac x="cur_fpu_for (aag_can_read aag or aag_can_affect aag l) st" in meta_allE)
+           apply (drule_tac x=rv in spec, drule_tac x=rv' in spec)
+           apply clarsimp
+           apply (rename_tac r ms r' ms' s t)
+           apply (drule (1) bspec)+
+           apply clarsimp
+          apply wp
+         apply wp
+        apply clarsimp
+       apply clarsimp
+      apply (clarsimp simp: equiv_valid_2_def in_monad)
+      apply (intro conjI)
+            apply (fastforce elim: reads_equivE affects_equivE equiv_forE intro: equiv_forI)
+           apply (fastforce elim: reads_equivE affects_equivE equiv_forE intro: equiv_forI)
+          apply (fastforce elim: reads_equivE affects_equivE equiv_forE intro: equiv_forI)
+         apply (fastforce elim: reads_equivE affects_equivE equiv_forE intro: equiv_forI)
+        apply (fastforce elim: reads_equivE affects_equivE equiv_forE intro: equiv_forI)
+       apply (frule (1) cur_vcpu_for_equiv)
+       apply (clarsimp simp: equiv_hyp_state_def)
+       apply (prop_tac "equiv_for (aag_can_read aag or aag_can_affect aag l) (K \<circ> numlistregs) st t")
+        apply (simp add: equiv_hyp_def equiv_for_or reads_equiv_def2 affects_equiv_def2 states_equiv_for_def)
+       apply (prop_tac "equiv_for (aag_can_read aag or aag_can_affect aag l) hw_vcpu_of st t")
+        apply (simp add: equiv_hyp_def equiv_for_or reads_equiv_def2 affects_equiv_def2 states_equiv_for_def)
+       apply (case_tac "cur_vcpu_for (aag_can_read aag or aag_can_affect aag l) t"; clarsimp)
+       apply (clarsimp simp: cur_vcpu_for_def split: option.splits if_splits)
+       apply (erule equiv_forE)+
+       apply (erule_tac x=aa in meta_allE, clarsimp)+
+       apply (clarsimp simp: cur_vcpu_of_def hw_vcpu_def numlistregs_for_def split: if_splits)
+      apply (frule (1) cur_fpu_for_equiv)
+      apply (clarsimp simp: equiv_fpu_state_def)
+  apply (prop_tac "equiv_for ((aag_can_read aag or aag_can_affect aag l)) hw_fpu_of st t")
+  apply (simp add: equiv_fpu_def equiv_for_or reads_equiv_def2 affects_equiv_def2 states_equiv_for_def)
+  apply (fastforce simp: equiv_for_def hw_fpu_def cur_fpu_for_def split: if_splits)
+  apply (wp | simp add: guard)+
+  using guard cur_fpu_for_equiv cur_vcpu_for_equiv numlistregs_for_equiv apply fastforce
+  done
+
+lemma do_machine_op_reads_respects'[InfoFlow_IF_assms]:
+  assumes equiv_dmo:
+    "equiv_valid_inv (equiv_machine_state (aag_can_read aag) and equiv_irq_state)
+                    (equiv_machine_state (aag_can_affect aag l)) Q f"
+  assumes guard:
+    "\<And>s. P s \<Longrightarrow> Q (machine_state s)"
+  assumes no_hyp: "no_hyp f"
+  assumes no_fpu: "no_fpu f"
+  shows
+    "reads_respects aag l P (do_machine_op f)"
+  apply (rule do_machine_op_reads_respects''[where Q="\<lambda>_ _ _. Q"])
+   apply (insert equiv_dmo no_hyp no_fpu)
+   apply (clarsimp simp: equiv_valid_2_def equiv_valid_def2 equiv_for_or no_hyp_def no_fpu_def
+                         equiv_for_def split_def)
+   apply (rename_tac rv st rv' st')
+   apply (drule_tac x=s in spec, drule_tac x=t in spec)
+   apply clarsimp
+   apply (drule (1) bspec)+
+   apply clarsimp
+   apply (rule conjI)
+    apply (clarsimp simp: equiv_hyp_state_def )
+    apply (erule use_valid, erule spec)+
+    apply clarsimp
+   apply (clarsimp simp: equiv_fpu_state_def)
+   apply (erule use_valid, erule spec)+
+   apply clarsimp
+  apply (simp add: guard)
+  done
+
+lemma equiv_hyp_state_upds[simp]:
+  "\<And>f. equiv_hyp_state n cv ms (underlying_memory_update f ms') = equiv_hyp_state n cv ms ms'"
+  "\<And>f. equiv_hyp_state n cv (underlying_memory_update f ms) ms' = equiv_hyp_state n cv ms ms'"
+  "\<And>f. equiv_hyp_state n cv ms (device_state_update f ms') = equiv_hyp_state n cv ms ms'"
+  "\<And>f. equiv_hyp_state n cv (device_state_update f ms) ms' = equiv_hyp_state n cv ms ms'"
+  "\<And>f. equiv_hyp_state n cv ms (machine_state_rest_update f ms') = equiv_hyp_state n cv ms ms'"
+  "\<And>f. equiv_hyp_state n cv (machine_state_rest_update f ms) ms' = equiv_hyp_state n cv ms ms'"
+  by (auto simp: equiv_hyp_state_def)
+
+lemma equiv_fpu_state_upds[simp]:
+  "\<And>f. equiv_fpu_state cf ms (underlying_memory_update f ms') = equiv_fpu_state cf ms ms'"
+  "\<And>f. equiv_fpu_state cf (underlying_memory_update f ms) ms' = equiv_fpu_state cf ms ms'"
+  "\<And>f. equiv_fpu_state cf ms (device_state_update f ms') = equiv_fpu_state cf ms ms'"
+  "\<And>f. equiv_fpu_state cf (device_state_update f ms) ms' = equiv_fpu_state cf ms ms'"
+  "\<And>f. equiv_fpu_state cf ms (machine_state_rest_update f ms') = equiv_fpu_state cf ms ms'"
+  "\<And>f. equiv_fpu_state cf (machine_state_rest_update f ms) ms' = equiv_fpu_state cf ms ms'"
+  by (auto simp: equiv_fpu_state_def)
+
+lemma no_hyp_bind:
+  "\<lbrakk> no_hyp f; \<And>rv. no_hyp (g rv) \<rbrakk> \<Longrightarrow> no_hyp (f >>= g)"
+  unfolding no_hyp_def
+  by (wpsimp, blast+)
+
+lemma no_fpu_bind:
+  "\<lbrakk> no_fpu f; \<And>rv. no_fpu (g rv) \<rbrakk> \<Longrightarrow> no_fpu (f >>= g)"
+  unfolding no_fpu_def
+  by (wpsimp, blast+)
+
+lemma equiv_hyp_state_lift[wp]:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (vcpu_state s)\<rbrace>"
+  shows "f \<lbrace>equiv_hyp_state n cv st\<rbrace>"
+  unfolding equiv_hyp_state_def
+  by (wp assms)
+
+lemma equiv_fpu_state_lift[wp]:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (fpu_state s)\<rbrace>"
+  shows "f \<lbrace>equiv_fpu_state cf st\<rbrace>"
+  unfolding equiv_fpu_state_def
+  by (wp assms)
+
+lemma no_hyp_lift[wp]:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (vcpu_state s)\<rbrace>"
+  shows "no_hyp f"
+  using assms by (simp add: no_hyp_def)
+
+lemma no_fpu_lift[wp]:
+  assumes "\<And>P. f \<lbrace>\<lambda>s. P (fpu_state s)\<rbrace>"
+  shows "no_fpu f"
+  using assms by (simp add: no_fpu_def)
+
 end
 
+arch_requalify_consts
+  no_hyp no_fpu
 
-global_interpretation InfoFlow_IF_1?: InfoFlow_IF_1
+
+global_interpretation InfoFlow_IF_2?: InfoFlow_IF_2 identical_hyp_state_updates identical_fpu_state_updates no_hyp no_fpu
 proof goal_cases
   interpret Arch .
   case 1 show ?case

--- a/proof/infoflow/AARCH64/ArchInterrupt_IF.thy
+++ b/proof/infoflow/AARCH64/ArchInterrupt_IF.thy
@@ -14,33 +14,40 @@ named_theorems Interrupt_IF_assms
 
 lemma arch_invoke_irq_handler_reads_respects[Interrupt_IF_assms, wp]:
   "reads_respects_f aag l (silc_inv aag st) (arch_invoke_irq_handler irq)"
-  apply (cases irq; wpsimp simp: plic_complete_claim_def)
-  apply (rule reads_respects_f[OF dmo_mol_reads_respects, where Q=\<top>, simplified])
-  apply wpsimp
+  apply (cases irq)
+    apply (wpsimp simp: deactivateInterrupt_def maskInterrupt_def)
+    apply (rule reads_respects_f[where P=\<top> and Q=\<top>, simplified])
+     apply (rule do_machine_op_reads_respects)
+        apply (simp add: equiv_valid_def2)
+        apply (rule modify_ev2)
+        apply (fastforce simp: equiv_for_def)
+       apply wpsimp+
   done
 
 lemma arch_invoke_irq_control_reads_respects[Interrupt_IF_assms]:
   "reads_respects aag (l :: 'a subject_label) (K (arch_authorised_irq_ctl_inv aag i))
                   (arch_invoke_irq_control i)"
   apply (cases i)
-  apply (simp add: setIRQTrigger_def)
-  apply (wp cap_insert_reads_respects set_irq_state_reads_respects dmo_mol_reads_respects | simp)+
+   apply (simp add: setIRQTrigger_def)
+   apply (wp cap_insert_reads_respects set_irq_state_reads_respects dmo_mol_reads_respects | simp)+
+   apply (clarsimp simp: arch_authorised_irq_ctl_inv_def)
+  apply (wpsimp wp: equiv_valid_guard_imp[OF cap_insert_reads_respects])
   apply (clarsimp simp: arch_authorised_irq_ctl_inv_def)
   done
 
 lemma arch_invoke_irq_control_globals_equiv[Interrupt_IF_assms]:
-  "\<lbrace>globals_equiv st and valid_arch_state and valid_global_objs\<rbrace>
+  "\<lbrace>globals_equiv st and valid_arch_state\<rbrace>
    arch_invoke_irq_control ai
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (induct ai)
-  apply (simp add: setIRQTrigger_def)
-  apply (wpsimp wp: set_irq_state_globals_equiv set_irq_state_valid_global_objs
-                    cap_insert_globals_equiv'' dmo_mol_globals_equiv)
+   apply (simp add: setIRQTrigger_def)
+   apply (wpsimp wp: set_irq_state_globals_equiv set_irq_state_valid_global_objs
+                     cap_insert_globals_equiv dmo_mol_globals_equiv)+
   done
 
 lemma arch_invoke_irq_handler_globals_equiv[Interrupt_IF_assms, wp]:
   "arch_invoke_irq_handler irq \<lbrace>globals_equiv st\<rbrace>"
-  by (cases irq; wpsimp wp: dmo_no_mem_globals_equiv simp: plic_complete_claim_def)
+  by (cases irq; wpsimp wp: dmo_no_mem_globals_equiv simp: deactivateInterrupt_def)
 
 end
 

--- a/proof/infoflow/AARCH64/ArchIpc_IF.thy
+++ b/proof/infoflow/AARCH64/ArchIpc_IF.thy
@@ -36,24 +36,26 @@ lemma storeWord_equiv_but_for_labels[Ipc_IF_assms]:
   apply (wp modify_wp)
   apply (clarsimp simp: equiv_but_for_labels_def)
   apply (rule states_equiv_forI)
-          apply (fastforce intro!: equiv_forI elim!: states_equiv_forE dest: equiv_forD)
-         apply (simp add: states_equiv_for_def)
-         apply (rule conjI)
-          apply (rule equiv_forI)
-          apply clarsimp
-          apply (drule_tac f=underlying_memory in equiv_forD,fastforce)
-          apply (fastforce intro: is_aligned_no_wrap' word_plus_mono_right
-                            simp: is_aligned_mask for_each_byte_of_word_def word_size_def upto.simps)
-         apply (rule equiv_forI)
-         apply clarsimp
-         apply (drule_tac f=device_state in equiv_forD,fastforce)
-         apply clarsimp
-        apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt])
-       apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt_list])
-      apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=is_original_cap])
-     apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_states])
-    apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_irq_node])
-   apply (fastforce simp: equiv_asids_def equiv_asid_def elim: states_equiv_forE)
+            apply (fastforce intro!: equiv_forI elim!: states_equiv_forE dest: equiv_forD)
+           apply (simp add: states_equiv_for_def)
+           apply (rule conjI)
+            apply (rule equiv_forI)
+            apply clarsimp
+            apply (drule_tac f=underlying_memory in equiv_forD,fastforce)
+            apply (fastforce intro: is_aligned_no_wrap' word_plus_mono_right
+                              simp: is_aligned_mask for_each_byte_of_word_def word_size_def upto.simps)
+           apply (rule equiv_forI)
+           apply clarsimp
+           apply (drule_tac f=device_state in equiv_forD,fastforce)
+           apply clarsimp
+          apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt])
+         apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt_list])
+        apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=is_original_cap])
+       apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_states])
+      apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_irq_node])
+     apply (fastforce simp: equiv_asids_def equiv_asid_def elim: states_equiv_forE)
+    apply (fastforce simp: equiv_hyp_def equiv_for_def elim: states_equiv_forE)
+   apply (fastforce simp: equiv_fpu_def equiv_for_def cur_fpu_for_def elim: states_equiv_forE)
   apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=ready_queues])
   done
 
@@ -202,9 +204,7 @@ lemma dmo_loadWord_reads_respects[Ipc_IF_assms]:
   "reads_respects aag l (K (for_each_byte_of_word (\<lambda> x. aag_can_read_or_affect aag l x) p))
                   (do_machine_op (loadWord p))"
   apply (rule gen_asm_ev)
-  apply (rule use_spec_ev)
-  apply (rule spec_equiv_valid_hoist_guard)
-  apply (rule do_machine_op_spec_reads_respects)
+  apply (rule do_machine_op_reads_respects)
    apply (simp add: loadWord_def equiv_valid_def2 spec_equiv_valid_def)
    apply (rule_tac R'="\<lambda>rv rv'. for_each_byte_of_word (\<lambda>y. rv y = rv' y) p"
                and Q="\<top>\<top>" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
@@ -234,8 +234,15 @@ lemma handle_arch_fault_reply_reads_respects[Ipc_IF_assms, wp]:
   "reads_respects aag l (K (aag_can_read aag thread)) (handle_arch_fault_reply afault thread x y)"
   by (simp add: handle_arch_fault_reply_def, wp)
 
+lemma arch_thread_get_reads_respects[wp]:
+  "reads_respects aag l (K (aag_can_read_or_affect aag l t)) (arch_thread_get f t)"
+  unfolding arch_thread_get_def
+  apply (wpsimp)
+  apply (fastforce elim: reads_equivE affects_equivE equiv_forE simp: get_tcb_def split: option.splits)
+  done
+
 lemma arch_get_sanitise_register_info_reads_respects[Ipc_IF_assms, wp]:
-  "reads_respects aag l \<top> (arch_get_sanitise_register_info t)"
+  "reads_respects aag l (K (aag_can_read_or_affect aag l t)) (arch_get_sanitise_register_info t)"
   by wpsimp
 
 declare arch_get_sanitise_register_info_inv[Ipc_IF_assms]
@@ -441,7 +448,7 @@ lemma set_mrs_reads_respects'[Ipc_IF_assms]:
   apply (simp add: equiv_valid_def2)
   apply (rule equiv_valid_rv_guard_imp)
    apply (case_tac buf)
-    apply (rule_tac Q="\<top>" and P="\<top>" and L="{pasObjectAbs aag thread}" in ev_invisible[OF domains_distinct])
+    apply (rule_tac Q="\<top>" and P="\<top>" and L="{pasObjectAbs aag thread}" in revrv_invisible[OF domains_distinct])
       apply (clarsimp simp: labels_are_invisible_def)
      apply (rule modifies_at_mostI)
      apply (simp add: set_mrs_def)
@@ -451,7 +458,7 @@ lemma set_mrs_reads_respects'[Ipc_IF_assms]:
    apply (rename_tac buf')
    apply (rule_tac Q="\<top>" and L="{pasObjectAbs aag thread} \<union> (pasObjectAbs aag)
                                  ` (ptr_range buf' msg_align_bits)"
-                in ev_invisible[OF domains_distinct])
+                in revrv_invisible[OF domains_distinct])
      apply (auto simp: labels_are_invisible_def ipc_buffer_has_auth_def
                  dest: reads_read_page_read_thread simp: aag_can_affect_label_def)[1]
     apply (rule modifies_at_mostI)

--- a/proof/infoflow/AARCH64/ArchNoninterference.thy
+++ b/proof/infoflow/AARCH64/ArchNoninterference.thy
@@ -8,6 +8,8 @@ theory ArchNoninterference
 imports Noninterference
 begin
 
+(* FIXME AARCH64 IF: clean and refactor theory *)
+
 context Arch begin global_naming AARCH64
 
 named_theorems Noninterference_assms
@@ -66,14 +68,14 @@ lemma do_user_op_if_partitionIntegrity[Noninterference_assms]:
   "\<lbrace>partitionIntegrity aag st and pas_refined aag and invs and is_subject aag \<circ> cur_thread\<rbrace>
    do_user_op_if tc uop
    \<lbrace>\<lambda>_. partitionIntegrity aag st\<rbrace>"
- apply (rule_tac Q'="\<lambda>rv s. integrity (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
-                                     (scheduler_affects_globals_frame st) st s \<and>
-                           domain_fields_equiv st s \<and> idle_thread s = idle_thread st \<and>
-                           globals_equiv_scheduler st s \<and> silc_dom_equiv aag st s"
-              in hoare_strengthen_post)
-   apply (wp hoare_vcg_conj_lift do_user_op_if_integrity do_user_op_if_globals_equiv_scheduler
-             hoare_vcg_all_lift domain_fields_equiv_lift[where Q="\<top>" and R="\<top>"] | simp)+
-  apply (clarsimp simp: partitionIntegrity_def)+
+  apply (rule_tac Q'="\<lambda>rv s. integrity (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+                                      (scheduler_affects_globals_frame st) st s \<and>
+                             domain_fields_equiv st s \<and> idle_thread s = idle_thread st \<and>
+                             globals_equiv_scheduler st s \<and> silc_dom_equiv aag st s"
+               in hoare_strengthen_post)
+   apply (wpsimp wp: do_user_op_if_globals_equiv_scheduler
+                     do_user_op_if_integrity domain_fields_equiv_lift)
+   apply (auto simp: partitionIntegrity_def)
   done
 
 lemma arch_activate_idle_thread_reads_respects_g[Noninterference_assms, wp]:
@@ -107,6 +109,114 @@ lemma integrity_asids_update_reference_state[Noninterference_assms]:
     \<Longrightarrow> integrity_asids aag {pasSubject aag} x a s (s\<lparr>kheap := (kheap s)(t \<mapsto> blah)\<rparr>)"
   by (clarsimp simp: integrity_asids_def opt_map_def)
 
+lemma partitionIntegrity_cur_vcpu_None:
+   "\<lbrakk> partitionIntegrity aag s s'; valid_objs s; valid_objs s';
+      cur_vcpu_of s x = None; cur_vcpu_of s' x = None; vcpu_at x s \<rbrakk>
+     \<Longrightarrow> is_subject aag x \<or> kheap s x = kheap s' x"
+  apply (prop_tac "integrity_obj (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+                                 False {pasSubject aag} (pasObjectAbs aag x) (kheap s x) (kheap s' x)")
+   apply (clarsimp simp: partitionIntegrity_def integrity_subjects_def)
+  apply (prop_tac "integrity_hyp (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+                                 {pasSubject aag} x s s'")
+   apply (clarsimp simp: partitionIntegrity_def integrity_subjects_def)
+  apply (rule disjCI2)
+  apply (drule tro_tro_alt)
+  apply (clarsimp simp: obj_at_def)
+  apply (erule integrity_obj_alt.cases; clarsimp)
+  apply (erule arch_integrity_obj_alt.cases; clarsimp)
+  apply (rename_tac vcpu vcpu')
+  apply (prop_tac "valid_vcpu vcpu s")
+   apply (erule valid_objsE, simp, fastforce simp: valid_obj_def)
+  apply (prop_tac "valid_vcpu vcpu' s'")
+   apply (erule valid_objsE, simp, fastforce simp: valid_obj_def)
+  apply (prop_tac "vcpus_of s x = Some vcpu")
+   apply (clarsimp simp: opt_map_def)
+  apply (prop_tac "vcpus_of s' x = Some vcpu'")
+   apply (clarsimp simp: opt_map_def)
+  apply (prop_tac "integrity_obj (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>) False
+               {pasSubject aag} (pasObjectAbs aag x) (kheap s x) (kheap s' x)")
+   apply (thin_tac "kheap _ x = _")+
+   apply (clarsimp simp: partitionIntegrity_def integrity_subjects_def)
+  apply (erule integrity_objE; fastforce?)
+  apply (erule arch_integrity_obj_alt.cases; fastforce?)
+  apply clarsimp
+  apply (clarsimp simp: integrity_hyp_def vcpu_integrity_def vcpu_extra_lrs_def vcpu_of_state_def)
+  apply (case_tac vcpu; case_tac vcpu'; clarsimp)
+  apply (case_tac vcpu_vgic; case_tac vcpu_vgica; clarsimp)
+  apply (rule ext)
+  apply (drule_tac x=xa in fun_cong)+
+  apply (auto split: if_splits)
+  done
+
+lemma partitionIntegrity_cur_vcpu_Some:
+  "\<lbrakk> invs s; pas_refined aag s; pas_cur_domain aag s; pas_domains_distinct aag;
+     cur_vcpu_in_cur_domain s; current_vcpu s = Some (vr,b) \<rbrakk>
+     \<Longrightarrow> is_subject aag vr"
+  apply (clarsimp simp: cur_vcpu_in_cur_domain_def cur_vcpu_tcb_def split: option.splits)
+   defer
+   apply (rename_tac t)
+   apply (prop_tac "is_subject aag vr")
+    apply (prop_tac "\<exists>tcb. ko_at (TCB tcb) t s")
+     apply (prop_tac "valid_objs s")
+      apply fastforce
+     apply (clarsimp simp: opt_map_def split: option.splits)
+     apply (erule (1) valid_objsE)
+     apply (clarsimp simp: valid_obj_def valid_vcpu_def obj_at_def)
+    apply (prop_tac "is_subject aag t")
+     apply clarsimp
+     apply (drule ko_at_etcbD)
+     apply (frule (1) tcb_domain_wellformed)
+     apply (prop_tac "etcb_domain (etcb_of tcb) = cur_domain s")
+      apply (clarsimp simp: in_cur_domain_def)
+      apply (clarsimp simp: etcbs_of'_def etcb_at'_def split: option.splits kernel_object.splits)
+     apply simp
+     apply (prop_tac "pasDomainAbs aag (cur_domain s) = {pasSubject aag}")
+      apply (clarsimp simp: pas_domains_distinct_def)
+      apply (metis singletonD)
+     apply blast
+    apply clarsimp
+    apply (clarsimp simp: opt_map_def split: option.splits)
+    apply (prop_tac "sym_refs (state_hyp_refs_of s)")
+     apply fastforce
+    apply (drule_tac x=vr in sym_refsD[rotated])
+     apply (simp add: state_hyp_refs_of_def)
+    apply (clarsimp simp: state_hyp_refs_of_def hyp_refs_of_def obj_at_def tcb_vcpu_refs_def split: option.splits)
+    apply (erule associated_vcpu_is_subject)
+      apply (simp add: get_tcb_Some_ko_at obj_at_def)
+     apply simp+
+  apply (prop_tac "cur_vcpu s")
+   apply (prop_tac "valid_arch_state s")
+    apply fastforce
+   apply (clarsimp simp: valid_arch_state_def)
+  apply (clarsimp simp: cur_vcpu_def opt_map_def opt_pred_def)
+  done
+
+lemma cur_vcpu_of_Some:
+  "cur_vcpu_of s vr = Some b \<longleftrightarrow> current_vcpu s = Some (vr,b)"
+  by (auto simp: cur_vcpu_of_def split: option.splits)
+
+lemma partitionIntegrity_subjectAffects_vcpu:
+  assumes par_inte: "partitionIntegrity aag s s'"
+  and "kheap s x = Some (ArchObj (VCPU vcpu))"
+  and kh_neq: "kheap s x \<noteq> kheap s' x"
+  and "silc_inv aag st s"
+      "pas_wellformed_noninterference aag"
+      "pas_refined aag s" "pas_refined aag s'"
+      "pas_cur_domain aag s" "pas_cur_domain aag s'"
+      "cur_vcpu_in_cur_domain s" "cur_vcpu_in_cur_domain s'"
+      "invs s" "invs s'"
+  notes inte_obj = par_inte[THEN partitionIntegrity_integrity, THEN integrity_subjects_obj,
+                            THEN spec[where x=x], simplified integrity_obj_def, simplified]
+  shows "subject_can_affect_label_directly aag (pasObjectAbs aag x)"
+  apply (rule ssubst[where s="pasSubject aag", OF _ affects_lrefl])
+  apply (case_tac "cur_vcpu_of s x = None \<and> cur_vcpu_of s' x = None"; clarsimp)
+   apply (drule (1) partitionIntegrity_cur_vcpu_None[OF par_inte, rotated 2])
+      apply (simp_all add: assms obj_at_def invs_valid_objs)[3]
+   apply (fastforce simp: kh_neq)
+  apply (elim disjE; clarsimp; rule partitionIntegrity_cur_vcpu_Some
+                   ; simp add: assms cur_vcpu_of_Some pas_wellformed_noninterference_domains_distinct)
+  done
+
 lemma inte_obj_arch:
   assumes inte_obj: "(integrity_obj_atomic aag activate subjects l)\<^sup>*\<^sup>* ko ko'"
   assumes "ko = Some (ArchObj ao)"
@@ -131,7 +241,7 @@ next
       using False inte_obj assms
       by (auto elim!: rtranclp_induct integrity_obj_atomic.cases)
     then show ?case using step.hyps
-      by (fastforce intro: troa_arch arch_troa_asidpool_clear integrity_obj_atomic.intros
+      by (fastforce intro: arch_integrity_obj_atomic.intros integrity_obj_atomic.intros
                     elim!: integrity_obj_atomic.cases arch_integrity_obj_atomic.cases)
   qed
   then show ?thesis
@@ -140,20 +250,20 @@ qed
 
 lemma asid_pool_into_aag:
   "\<lbrakk> pool_for_asid asid s = Some p; kheap s p = Some (ArchObj (ASIDPool pool));
-     pool r = Some p'; pas_refined aag s \<rbrakk>
+      pool r = Some entry; ap_vspace entry = p'; pas_refined aag s \<rbrakk>
      \<Longrightarrow> abs_has_auth_to aag Control p p'"
   apply (rule pas_refined_mem [rotated], assumption)
   apply (rule sta_vref)
   apply (rule state_vrefsD)
      apply (erule pool_for_asid_vs_lookupD)
-    apply (fastforce simp: aobjs_of_Some)
+    apply (fastforce simp: opt_map_def)
    apply fastforce
   apply (fastforce simp: vs_refs_aux_def graph_of_def image_iff)
   done
 
 lemma owns_mapping_owns_asidpool:
   "\<lbrakk> pool_for_asid asid s = Some p; kheap s p = Some (ArchObj (ASIDPool pool));
-     pool r = Some p'; pas_refined aag s; is_subject aag p';
+     pool r = Some entry; ap_vspace entry = p'; pas_refined aag s; is_subject aag p';
      pas_wellformed (aag\<lparr>pasSubject := (pasObjectAbs aag p)\<rparr>) \<rbrakk>
      \<Longrightarrow> is_subject aag p"
   apply (frule asid_pool_into_aag)
@@ -163,35 +273,77 @@ lemma owns_mapping_owns_asidpool:
   apply simp
   done
 
-lemma partitionIntegrity_subjectAffects_aobj':
+lemma partitionIntegrity_subjectAffects_asid_pool':
   "\<lbrakk> pool_for_asid asid s = Some x; kheap s x = Some (ArchObj ao); ao \<noteq> ao';
-     pas_refined aag s; silc_inv aag st s; pas_wellformed_noninterference aag;
+     pas_refined aag s; silc_inv aag st s; pas_wellformed_noninterference aag; valid_arch_state s;
      arch_integrity_obj_atomic (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
-                               {pasSubject aag} (pasObjectAbs aag x) ao ao' \<rbrakk>
+                              {pasSubject aag} (pasObjectAbs aag x) ao ao' \<rbrakk>
      \<Longrightarrow> subject_can_affect_label_directly aag (pasObjectAbs aag x)"
   unfolding arch_integrity_obj_atomic.simps asid_pool_integrity_def
+  apply (elim disjE)
+   apply clarsimp
+   apply (rule ccontr)
+   apply (drule fun_noteqD)
+   apply (erule exE, rename_tac r)
+   apply (drule_tac x=r in spec)
+   apply (clarsimp dest!: not_sym[where t=None])
+   apply (subgoal_tac "is_subject aag x", force intro: affects_lrefl)
+   apply (frule (1) aag_Control_into_owns)
+   apply (frule (2) asid_pool_into_aag)
+     apply simp
+    apply simp
+   apply (frule (1) pas_wellformed_noninterference_control_to_eq)
+    apply (fastforce elim!: silc_inv_cnode_onlyE obj_atE simp: is_cap_table_def)
+   apply clarsimp
   apply clarsimp
-  apply (rule ccontr)
-  apply (drule fun_noteqD)
-  apply (erule exE, rename_tac r)
-  apply (drule_tac x=r in spec)
-  apply (clarsimp dest!: not_sym[where t=None])
-  apply (subgoal_tac "is_subject aag x", force intro: affects_lrefl)
-  apply (frule (1) aag_Control_into_owns)
-  apply (frule (3) asid_pool_into_aag)
-  apply simp
-  apply (frule (1) pas_wellformed_noninterference_control_to_eq)
-   apply (fastforce elim!: silc_inv_cnode_onlyE obj_atE simp: is_cap_table_def)
-  apply clarsimp
+  apply (drule (1) pool_for_asid_ap_at)
+  apply (clarsimp simp: obj_at_def)
   done
 
-lemma partitionIntegrity_subjectAffects_aobj[Noninterference_assms]:
+lemma partitionIntegrity_subjectAffects_asid_pool:
+  assumes par_inte: "partitionIntegrity aag s s'"
+  and "kheap s x = Some (ArchObj (ASIDPool pool))"
+      "kheap s x \<noteq> kheap s' x"
+      "silc_inv aag st s"
+      "pas_refined aag s"
+      "valid_arch_state s"
+      "pas_wellformed_noninterference aag"
+  notes inte_obj = par_inte[THEN partitionIntegrity_integrity, THEN integrity_subjects_obj,
+                            THEN spec[where x=x], simplified integrity_obj_def, simplified]
+  shows "subject_can_affect_label_directly aag (pasObjectAbs aag x)"
+proof (cases "pasObjectAbs aag x = pasSubject aag")
+  case True
+  then show ?thesis by (simp add: subjectAffects.intros(1))
+next
+  case False
+  obtain ao' where ao': "kheap s' x = Some (ArchObj ao')"
+    using assms False inte_obj_arch[OF inte_obj]
+    by (auto elim: integrity_obj_atomic.cases)
+  have arch_tro:
+    "arch_integrity_obj_atomic (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+                               {pasSubject aag} (pasObjectAbs aag x) (ASIDPool pool) ao'"
+    using assms False ao' inte_obj_arch[OF inte_obj]
+    by (auto elim: integrity_obj_atomic.cases)
+  obtain asid where asid: "pool_for_asid asid s = Some x"
+    using assms False inte_obj_arch[OF inte_obj]
+          integrity_subjects_asids[OF partitionIntegrity_integrity[OF par_inte]]
+    by (fastforce elim!: integrity_obj_atomic.cases arch_integrity_obj_atomic.cases
+                   simp: integrity_asids_def aobjs_of_Some opt_map_def pool_for_asid_def)+
+  show ?thesis
+    using assms ao' asid arch_tro
+    by (fastforce dest: partitionIntegrity_subjectAffects_asid_pool')
+qed
+
+lemma partitionIntegrity_subjectAffects_aobj:
   assumes par_inte: "partitionIntegrity aag s s'"
   and "kheap s x = Some (ArchObj ao)"
       "kheap s x \<noteq> kheap s' x"
       "silc_inv aag st s"
-      "pas_refined aag s"
       "pas_wellformed_noninterference aag"
+      "pas_refined aag s" "pas_refined aag s'"
+      "pas_cur_domain aag s" "pas_cur_domain aag s'"
+      "cur_vcpu_in_cur_domain s" "cur_vcpu_in_cur_domain s'"
+      "invs s" "invs s'"
   notes inte_obj = par_inte[THEN partitionIntegrity_integrity, THEN integrity_subjects_obj,
                             THEN spec[where x=x], simplified integrity_obj_def, simplified]
   shows "subject_can_affect_label_directly aag (pasObjectAbs aag x)"
@@ -208,15 +360,166 @@ next
                                {pasSubject aag} (pasObjectAbs aag x) ao ao'"
     using assms False ao' inte_obj_arch[OF inte_obj]
     by (auto elim: integrity_obj_atomic.cases)
-  obtain asid where asid: "pool_for_asid asid s = Some x"
-    using assms False inte_obj_arch[OF inte_obj]
-          integrity_subjects_asids[OF partitionIntegrity_integrity[OF par_inte]]
-    by (fastforce elim!: integrity_obj_atomic.cases arch_integrity_obj_atomic.cases
-                   simp: integrity_asids_def aobjs_of_Some opt_map_def pool_for_asid_def)+
   show ?thesis
-    using assms ao' asid arch_tro
-    by (fastforce dest: partitionIntegrity_subjectAffects_aobj')
+    apply (case_tac ao)
+       apply (insert partitionIntegrity_subjectAffects_asid_pool[of aag s s' x _ st])
+    using assms apply (simp add: invs_arch_state)
+    using arch_tro apply (fastforce elim: arch_integrity_obj_atomic.cases)
+    using arch_tro apply (fastforce elim: arch_integrity_obj_atomic.cases)
+    apply (insert partitionIntegrity_subjectAffects_vcpu[of aag s s' x _ st])
+    using assms apply (simp add: invs_arch_state)
+    done
 qed
+
+declare cur_vcpu_for_None[simp]
+
+lemma cur_vcpu_of_None[simp]:
+  "cur_vcpu_of_2 None vst = None"
+  by (clarsimp simp: cur_vcpu_of_def)
+
+lemma partitionIntegrity_subjectAffects_numlistregs:
+  "\<lbrakk> partitionIntegrity aag s s' \<rbrakk>
+     \<Longrightarrow> equiv_for (\<lambda>x. pasObjectAbs aag x = da) (K \<circ> numlistregs) s s'"
+  by (clarsimp simp: partitionIntegrity_def integrity_subjects_def integrity_hyp_def equiv_for_def)
+
+lemma partitionIntegrity_subjectAffects_cur_vcpu_of:
+   "\<lbrakk> invs s; invs s';
+      cur_vcpu_in_cur_domain s; cur_vcpu_in_cur_domain s';
+      pas_refined aag s; pas_refined aag s';
+      pas_cur_domain aag s; pas_cur_domain aag s';
+      pas_domains_distinct aag;
+      \<not> equiv_for (\<lambda>x. pasObjectAbs aag x = a) cur_vcpu_of s s' \<rbrakk>
+       \<Longrightarrow> a \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  apply (case_tac "\<exists>b. cur_vcpu_for (\<lambda>x. pasObjectAbs aag x = a) s = Some b")
+   apply (clarsimp simp: affects_lrefl partitionIntegrity_cur_vcpu_Some cur_vcpu_for_def split: option.splits if_splits)
+  apply (case_tac "\<exists>b. cur_vcpu_for (\<lambda>x. pasObjectAbs aag x = a) s' = Some b")
+   apply (clarsimp simp: affects_lrefl partitionIntegrity_cur_vcpu_Some cur_vcpu_for_def split: option.splits if_splits)
+  apply clarsimp
+  apply (erule swap)
+  apply (clarsimp simp: equiv_for_def cur_vcpu_of_def split: option.splits)
+  done
+
+lemma partitionIntegrity_subjectAffects_hw_vcpu:
+   "\<lbrakk> invs s; invs s';
+      cur_vcpu_in_cur_domain s; cur_vcpu_in_cur_domain s';
+      pas_refined aag s; pas_refined aag s';
+      pas_cur_domain aag s; pas_cur_domain aag s';
+      pas_domains_distinct aag;
+      \<not> equiv_for (\<lambda>x. pasObjectAbs aag x = a) hw_vcpu_of s s' \<rbrakk>
+       \<Longrightarrow> a \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  apply (case_tac "\<exists>b. cur_vcpu_for (\<lambda>x. pasObjectAbs aag x = a) s = Some b")
+   apply (clarsimp simp: affects_lrefl partitionIntegrity_cur_vcpu_Some cur_vcpu_for_def split: option.splits if_splits)
+  apply (case_tac "\<exists>b. cur_vcpu_for (\<lambda>x. pasObjectAbs aag x = a) s' = Some b")
+   apply (clarsimp simp: affects_lrefl partitionIntegrity_cur_vcpu_Some cur_vcpu_for_def split: option.splits if_splits)
+  apply clarsimp
+  apply (clarsimp simp: equiv_for_def)
+  apply (clarsimp simp: cur_vcpu_of_def cur_vcpu_for_def split: option.splits if_splits)
+  done
+
+lemma partitionIntegrity_subjectAffects_hyp:
+   "\<lbrakk> partitionIntegrity aag s s';
+      invs s; invs s';
+      cur_vcpu_in_cur_domain s; cur_vcpu_in_cur_domain s';
+      pas_refined aag s; pas_refined aag s';
+      pas_cur_domain aag s; pas_cur_domain aag s';
+      pas_domains_distinct aag;
+      \<not> equiv_hyp (\<lambda>x. pasObjectAbs aag x = a) s s' \<rbrakk>
+       \<Longrightarrow> a \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  unfolding equiv_hyp_def
+  using partitionIntegrity_subjectAffects_numlistregs
+        partitionIntegrity_subjectAffects_cur_vcpu_of
+        partitionIntegrity_subjectAffects_hw_vcpu
+  by (metis (mono_tags))
+
+lemma cur_fpu_is_subject:
+  "\<lbrakk> invs s; pas_refined aag s; pas_cur_domain aag s; pas_domains_distinct aag;
+     cur_fpu_in_cur_domain s; current_fpu s = Some t \<rbrakk>
+     \<Longrightarrow> is_subject aag t"
+  apply (clarsimp simp: cur_fpu_in_cur_domain_def split: option.splits)
+  apply (frule current_fpu_owner_Some_tcb_at, fastforce)
+  apply (drule tcb_at_ko_at, clarsimp)
+  apply (drule ko_at_etcbD)
+  apply (frule (1) tcb_domain_wellformed)
+  apply (prop_tac "etcb_domain (etcb_of tcb) = cur_domain s")
+   apply (clarsimp simp: in_cur_domain_def)
+   apply (clarsimp simp: etcbs_of'_def etcb_at'_def split: option.splits kernel_object.splits)
+  apply simp
+  apply (prop_tac "pasDomainAbs aag (cur_domain s) = {pasSubject aag}")
+   apply (clarsimp simp: pas_domains_distinct_def)
+   apply (metis singletonD)
+  apply blast
+  done
+
+lemma partitionIntegrity_subjectAffects_fpu:
+   "\<lbrakk> partitionIntegrity aag s s';
+      invs s; invs s';
+      cur_fpu_in_cur_domain s; cur_fpu_in_cur_domain s';
+      pas_refined aag s; pas_refined aag s';
+      pas_cur_domain aag s; pas_cur_domain aag s';
+      pas_domains_distinct aag;
+      \<not> equiv_fpu (\<lambda>x. pasObjectAbs aag x = a) s s' \<rbrakk>
+       \<Longrightarrow> a \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  unfolding equiv_fpu_def
+  apply (clarsimp simp: equiv_for_def)
+  apply (case_tac "is_arch_cur_fpu x s")
+   apply (frule (4) cur_fpu_is_subject[of s])
+    apply (simp add: is_arch_cur_fpu_def)
+   apply (clarsimp simp: affects_lrefl)
+  apply (case_tac "is_arch_cur_fpu x s'")
+   apply (frule (4) cur_fpu_is_subject[of s'])
+    apply (simp add: is_arch_cur_fpu_def)
+   apply (clarsimp simp: affects_lrefl)
+  apply (clarsimp simp: hw_fpu_def)
+  done
+
+lemma partitionIntegrity_subjectAffects_tcb_fpu':
+   "\<lbrakk> partitionIntegrity aag s s'; valid_cur_fpu s; valid_cur_fpu s';
+      kheap s x = Some (TCB tcb); kheap s' x = Some (TCB tcb');
+      tcb' = tcb\<lparr>tcb_arch := new_arch\<rparr>;
+      arch_tcb_get_registers new_arch = arch_tcb_get_registers (tcb_arch tcb);
+      tcb_hyp_refs new_arch = tcb_hyp_refs (tcb_arch tcb);
+      current_fpu s \<noteq> Some x; current_fpu s' \<noteq> Some x \<rbrakk>
+     \<Longrightarrow> is_subject aag x \<or> kheap s x = kheap s' x"
+  apply clarsimp
+  apply (erule_tac P="tcb = tcb\<lparr>tcb_arch := new_arch\<rparr>" in swap)
+  apply (prop_tac "integrity_fpu
+            (aag\<lparr>pasMayActivate := False, pasMayEditReadyQueues := False\<rparr>)
+            {pasSubject aag} x s s'")
+   apply (clarsimp simp: partitionIntegrity_def integrity_subjects_def)
+  apply (clarsimp simp: integrity_fpu_def)
+  apply (clarsimp simp: fpu_of_state_def)
+  apply (clarsimp simp: valid_cur_fpu_def)
+  apply (erule_tac x=x in allE)+
+  apply (clarsimp simp: is_tcb_cur_fpu_def obj_at_def)
+  apply (subgoal_tac "tcb_arch tcb = new_arch")
+   apply (case_tac tcb; clarsimp)
+  apply (subgoal_tac "tcb_context (tcb_arch tcb) = tcb_context new_arch")
+   apply (case_tac "tcb_arch tcb"; case_tac new_arch; clarsimp simp: tcb_vcpu_refs_def split: option.splits)
+  apply (case_tac "tcb_context (tcb_arch tcb)"; case_tac "tcb_context new_arch"; clarsimp simp: arch_tcb_get_registers_def)
+  done
+
+lemma partitionIntegrity_subjectAffects_tcb_fpu:
+  assumes par_inte: "partitionIntegrity aag s s'"
+  and "kheap s x = Some (TCB tcb)"
+      "kheap s' x = Some (TCB tcb')"
+      "tcb' = tcb\<lparr>tcb_arch := new_arch\<rparr>"
+      "arch_tcb_get_registers new_arch = arch_tcb_get_registers (tcb_arch tcb)"
+      "tcb_hyp_refs new_arch = tcb_hyp_refs (tcb_arch tcb)"
+      "kheap s x \<noteq> kheap s' x"
+      "silc_inv aag st s"
+      "pas_wellformed_noninterference aag"
+      "pas_refined aag s" "pas_refined aag s'"
+      "pas_cur_domain aag s" "pas_cur_domain aag s'"
+      "cur_fpu_in_cur_domain s" "cur_fpu_in_cur_domain s'"
+      "invs s" "invs s'"
+  notes inte_obj = par_inte[THEN partitionIntegrity_integrity, THEN integrity_subjects_obj,
+                            THEN spec[where x=x], simplified integrity_obj_def, simplified]
+  shows "subject_can_affect_label_directly aag (pasObjectAbs aag x)"
+  apply (rule ssubst[where s="pasSubject aag", OF _ affects_lrefl])
+  apply (case_tac "current_fpu s \<noteq> Some x \<and> current_fpu s' \<noteq> Some x"; clarsimp)
+   using assms apply (fastforce dest!: partitionIntegrity_subjectAffects_tcb_fpu'[OF par_inte, rotated 7])
+  apply (elim disjE; rule cur_fpu_is_subject; simp add: assms pas_wellformed_noninterference_domains_distinct)
+  done
 
 lemma partitionIntegrity_subjectAffects_asid[Noninterference_assms]:
   "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; valid_objs s;
@@ -258,7 +561,7 @@ lemma partitionIntegrity_subjectAffects_asid[Noninterference_assms]:
     apply (drule owns_mapping_owns_asidpool[rotated])
          apply ((simp | blast intro: pas_refined_Control[THEN sym]
                       | fastforce simp: pool_for_asid_def
-                                 intro: pas_wellformed_pasSubject_update[simplified])+)[5]
+                                 intro: pas_wellformed_pasSubject_update[simplified])+)[6]
     apply (drule_tac t="pasSubject aag" in sym)+
     apply simp
     apply (rule sata_asidpool)
@@ -282,11 +585,15 @@ lemma dmo_storeWord_reads_respects_g[Noninterference_assms, wp]:
    apply (rule ev_modify)
    apply (rule conjI)
     apply (fastforce simp: reads_equiv_g_def globals_equiv_def reads_equiv_def2 states_equiv_for_def
-                           equiv_for_def equiv_asids_def equiv_asid_def silc_dom_equiv_def upto.simps)
+                           equiv_for_def equiv_asids_def equiv_asid_def silc_dom_equiv_def upto.simps equiv_hyp_def equiv_fpu_def cur_fpu_for_def)
    apply (rule affects_equiv_machine_state_update, assumption)
    apply (fastforce simp: equiv_for_def affects_equiv_def states_equiv_for_def upto.simps)
+    apply (clarsimp simp: identical_hyp_state_updates_def identical_updates_rv_def)
+   apply (clarsimp simp: identical_fpu_state_updates_def identical_updates_rv_def cur_fpu_for_def)
   apply (simp add: equiv_valid_def2 equiv_valid_2_def)
   done
+
+declare set_vm_root_states_equiv_for[wp]
 
 lemma set_vm_root_reads_respects:
   "reads_respects aag l \<top> (set_vm_root tcb)"
@@ -294,19 +601,37 @@ lemma set_vm_root_reads_respects:
 
 lemmas set_vm_root_reads_respects_g[wp] =
   reads_respects_g[OF set_vm_root_reads_respects,
-                   OF doesnt_touch_globalsI[where P="\<top>"],
-                   simplified,
-                   OF set_vm_root_globals_equiv]
+                   OF doesnt_touch_globalsI[where P="valid_global_arch_objs"],
+                   simplified, OF set_vm_root_globals_equiv]
+
+lemmas lazy_fpu_restore_reads_respects_g[wp] =
+   reads_respects_g[OF lazy_fpu_restore_reads_respects,
+                    OF doesnt_touch_globalsI[where P=invs],
+                    simplified, OF lazy_fpu_restore_globals_equiv]
+
+lemmas vcpu_switch_reads_respects_g[wp] =
+   reads_respects_g[OF vcpu_switch_reads_respects,
+                    OF doesnt_touch_globalsI[where P=valid_arch_state],
+                    simplified, OF vcpu_switch_globals_equiv]
+
+crunch vcpu_switch
+  for global_pt[wp]: "\<lambda>s. P (global_pt s)"
+  (wp: valid_global_arch_objs_lift)
+
+crunch vcpu_switch
+  for valid_global_arch_objs[wp]: "valid_global_arch_objs"
+  (wp: valid_global_arch_objs_lift)
 
 lemma arch_switch_to_thread_reads_respects_g'[Noninterference_assms]:
   "equiv_valid (reads_equiv_g aag) (affects_equiv aag l)
                (\<lambda>s s'. affects_equiv aag l s s' \<and>
                        arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
-               (\<lambda>s. is_subject aag t)
+               (\<lambda>s. invs s \<and> is_subject aag t)
                (arch_switch_to_thread t)"
   apply (simp add: arch_switch_to_thread_def)
-  apply (rule equiv_valid_guard_imp)
-  by (wp bind_ev_general thread_get_reads_respects_g | simp)+
+  apply (wp bind_ev_general thread_get_reads_respects_g)
+  apply (auto intro: sym_refs_VCPU_hyp_live simp: reads_equiv_g_def)
+  done
 
 (* consider rewriting the return-value assumption using equiv_valid_rv_inv *)
 lemma ev2_invisible'[Noninterference_assms]:
@@ -340,11 +665,23 @@ lemma ev2_invisible'[Noninterference_assms]:
                       affects_equiv_sym globals_equiv_trans globals_equiv_sym)
   done
 
+lemmas dmo_mol_reads_respects_g[wp] =
+  reads_respects_g[OF dmo_mol_reads_respects,
+                   OF doesnt_touch_globalsI[where P="\<top>"],
+                   simplified,
+                   OF dmo_mol_globals_equiv]
+
+lemma set_global_user_vspace_reads_respects_g[Noninterference_assms, wp]:
+  "reads_respects_g aag l \<top> (set_global_user_vspace)"
+  unfolding set_global_user_vspace_def setVSpaceRoot_def
+  apply wpsimp
+  apply (clarsimp simp: reads_equiv_g_def globals_equiv_def)
+  done
+
 lemma arch_switch_to_idle_thread_reads_respects_g[Noninterference_assms, wp]:
-  "reads_respects_g aag l \<top> (arch_switch_to_idle_thread)"
+  "reads_respects_g aag l valid_arch_state (arch_switch_to_idle_thread)"
   apply (simp add: arch_switch_to_idle_thread_def)
   apply wp
-  apply (clarsimp simp: reads_equiv_g_def globals_equiv_idle_thread_ptr)
   done
 
 lemma arch_globals_equiv_threads_eq[Noninterference_assms]:
@@ -364,7 +701,7 @@ lemma getActiveIRQ_ret_no_dmo[Noninterference_assms, wp]:
   apply (rule hoare_pre)
    apply (insert irq_oracle_max_irq)
    apply (wp dmo_getActiveIRQ_irq_masks)
-  apply clarsimp
+  apply (clarsimp simp: maxIRQ_def)
   done
 
 (*FIXME: Move to scheduler_if*)
@@ -378,7 +715,7 @@ lemma dmo_getActive_IRQ_reads_respect_scheduler[Noninterference_assms]:
       apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
                             scheduler_affects_equiv_def arch_scheduler_affects_equiv_def
                             states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def
-                            scheduler_globals_frame_equiv_def silc_dom_equiv_def idle_equiv_def)
+                            scheduler_globals_frame_equiv_def silc_dom_equiv_def idle_equiv_def equiv_hyp_def equiv_fpu_def cur_fpu_for_def)
      apply wp
     apply (rule_tac P="\<lambda>s. irq_masks_of_state st = irq_masks_of_state s" in gets_ev')
    apply wp
@@ -386,18 +723,80 @@ lemma dmo_getActive_IRQ_reads_respect_scheduler[Noninterference_assms]:
   apply (simp add: scheduler_equiv_def)
   done
 
-lemma getActiveIRQ_no_non_kernel_IRQs[Noninterference_assms]:
-  "getActiveIRQ True = getActiveIRQ False"
-  by (clarsimp simp: getActiveIRQ_def non_kernel_IRQs_def)
+lemma integrity_hyp_update_reference_state[Noninterference_assms]:
+   "is_subject aag t
+    \<Longrightarrow> integrity_hyp aag {pasSubject aag} x s (s\<lparr>kheap := (kheap s)(t \<mapsto> blah)\<rparr>)"
+  by (auto simp: integrity_hyp_def vcpu_integrity_def vcpu_of_state_def opt_map_def)
 
-lemma valid_cur_hyp_triv[Noninterference_assms]:
-  "valid_cur_hyp s"
-  by (simp add: valid_cur_hyp_def)
+lemma integrity_fpu_update_reference_state[Noninterference_assms]:
+  "is_subject aag t
+   \<Longrightarrow> integrity_fpu aag {pasSubject aag} x s (s\<lparr>kheap := (kheap s)(t \<mapsto> blah)\<rparr>)"
+  by (auto simp: integrity_fpu_def fpu_of_state_def)
 
-lemma arch_tcb_get_registers_equality[Noninterference_assms]:
-  "arch_tcb_get_registers (tcb_arch tcb) = arch_tcb_get_registers (tcb_arch tcb')
-   \<Longrightarrow> tcb_arch tcb = tcb_arch tcb'"
-  by (auto simp: arch_tcb_get_registers_def intro: arch_tcb.equality user_context.expand)
+definition irq_at' :: "bool \<Rightarrow> nat \<Rightarrow> (irq \<Rightarrow> bool) \<Rightarrow> irq option" where
+  "irq_at' in_kernel pos masks \<equiv>
+   let i = irq_oracle pos in (if masks i \<or> in_kernel \<and> i \<in> non_kernel_IRQs then None else Some i)"
+
+lemma dmo_getActiveIRQ_wp':
+  "\<lbrace>\<lambda>s. P (irq_at' in_kernel (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
+          (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>)\<rbrace>
+   do_machine_op (getActiveIRQ in_kernel)
+   \<lbrace>P\<rbrace>"
+  apply (simp add: do_machine_op_def getActiveIRQ_def non_kernel_IRQs_def)
+  apply (wp modify_wp | wpc)+
+  apply clarsimp
+  apply (erule use_valid)
+   apply (wp modify_wp)
+  apply (auto simp: Let_def non_kernel_IRQs_def irq_at'_def split: if_splits)
+  done
+
+lemma getActiveIRQ_ev2[Noninterference_assms]:
+  "equiv_valid_2 (scheduler_equiv aag)
+                 (scheduler_affects_equiv aag l) (scheduler_affects_equiv aag l)
+                 (\<lambda>irq irq'. irq = irq' \<or> irq = None \<and> irq' \<in> Some ` non_kernel_IRQs)
+                 (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+                 (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+   (do_machine_op (getActiveIRQ True)) (do_machine_op (getActiveIRQ False))"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (erule use_valid, rule dmo_getActiveIRQ_wp')+
+  apply (intro conjI)
+   apply (clarsimp simp: scheduler_equiv_def irq_at'_def Let_def)
+   apply clarsimp
+   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
+                         silc_dom_equiv_def equiv_for_def)
+  apply (clarsimp simp: scheduler_affects_equiv_def)
+  apply (intro conjI impI)
+    apply (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def equiv_hyp_def equiv_fpu_def cur_fpu_for_def)
+   apply (clarsimp simp: scheduler_globals_frame_equiv_def)
+  apply (clarsimp simp: arch_scheduler_affects_equiv_def)
+  done
+
+crunch arch_prepare_next_domain
+  for work_units_completed[wp]: "\<lambda>s. P (work_units_completed s)"
+
+lemma arch_prepare_next_domain_reads_respects:
+  "reads_respects aag l invs arch_prepare_next_domain"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_from_labels)
+        apply (rule arch_prepare_next_domain_reads_respects_l)
+       apply wpsimp+
+  done
+
+lemma arch_prepare_next_domain_reads_respects_g:
+  "reads_respects_g aag l invs arch_prepare_next_domain"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_g[OF arch_prepare_next_domain_reads_respects doesnt_touch_globalsI])
+   apply wpsimp
+   apply assumption
+  apply clarsimp
+  done
+
+lemmas [Noninterference_assms] =
+  arch_prepare_next_domain_reads_respects_g
+  partitionIntegrity_subjectAffects_aobj
+  partitionIntegrity_subjectAffects_hyp
+  partitionIntegrity_subjectAffects_fpu
+  partitionIntegrity_subjectAffects_tcb_fpu
 
 end
 
@@ -410,7 +809,7 @@ global_interpretation Noninterference_1?: Noninterference_1 _ arch_globals_equiv
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Noninterference_assms | solves \<open>rule integrity_arch_triv\<close>)?)
+    by (unfold_locales; (unfold cur_hyp_in_cur_domain_def)?; (fact Noninterference_assms)?)
 qed
 
 

--- a/proof/infoflow/AARCH64/ArchPasUpdates.thy
+++ b/proof/infoflow/AARCH64/ArchPasUpdates.thy
@@ -12,38 +12,6 @@ context Arch begin
 
 named_theorems PasUpdates_assms
 
-crunch arch_post_cap_deletion, arch_finalise_cap, prepare_thread_delete
-  for domain_fields[PasUpdates_assms, wp]: "domain_fields P"
-  (    wp: syscall_valid crunch_wps rec_del_preservation cap_revoke_preservation modify_wp
-     simp: crunch_simps check_cap_at_def filterM_mapM unless_def
-   ignore: without_preemption filterM rec_del check_cap_at cap_revoke
-   ignore_del: create_cap_ext cap_insert_ext cap_move_ext
-               empty_slot_ext cap_swap_ext set_thread_state_act tcb_sched_action reschedule_required)
-
-end
-
-
-global_interpretation PasUpdates_1?: PasUpdates_1
-proof goal_cases
-  interpret Arch .
-  case 1 show ?case
-    by (unfold_locales; (fact PasUpdates_assms)?)
-qed
-
-
-context Arch begin
-
-crunch arch_perform_invocation, arch_post_modify_registers, init_arch_objects,
-         arch_invoke_irq_control, arch_invoke_irq_handler, handle_arch_fault_reply
-  for domain_fields[PasUpdates_assms, wp]: "domain_fields P"
-  (wp: syscall_valid crunch_wps mapME_x_inv_wp
-   simp: crunch_simps check_cap_at_def detype_def mapM_x_defsym
-   ignore: check_cap_at syscall
-   ignore_del: set_domain set_priority possible_switch_to
-   rule: transfer_caps_loop_pres)
-
-declare init_arch_objects_inv[PasUpdates_assms]
-
 lemma state_asids_to_policy_aux_pasSubject_update:
   "state_asids_to_policy_aux (aag\<lparr>pasSubject := x\<rparr>) caps asid vrefs =
    state_asids_to_policy_aux aag caps asid vrefs"
@@ -106,9 +74,6 @@ lemma state_asids_to_policy_pasMayEditReadyQueues_update[PasUpdates_assms]:
   "state_asids_to_policy (aag\<lparr>pasMayEditReadyQueues := x\<rparr>) s =
    state_asids_to_policy aag s"
   by (simp add: state_asids_to_policy_aux_pasMayEditReadyQueues_update)
-
-declare arch_post_set_flags_inv[PasUpdates_assms]
-declare arch_prepare_set_domain_inv[PasUpdates_assms]
 
 end
 

--- a/proof/infoflow/AARCH64/ArchRetype_IF.thy
+++ b/proof/infoflow/AARCH64/ArchRetype_IF.thy
@@ -12,13 +12,41 @@ context Arch begin global_naming AARCH64
 
 named_theorems Retype_IF_assms
 
+crunch clearMemory, freeMemory
+  for vcpu_state[wp]: "\<lambda>ms. P (vcpu_state ms)"
+  and fpu_state[wp]:  "\<lambda>ms. P (fpu_state ms)"
+  (wp: mapM_x_wp_inv ignore_del: storeWord clearMemory)
+
+lemma machine_op_lift_no_hyp[Retype_IF_assms,wp]:
+  "no_hyp (machine_op_lift mop)"
+  by wp
+
+lemma machine_op_lift_no_fpu[Retype_IF_assms,wp]:
+  "no_fpu (machine_op_lift mop)"
+  by wp
+
+lemma clearMemory_no_hyp[Retype_IF_assms,wp]:
+  "no_hyp (clearMemory ptr bits)"
+  by wp
+
+lemma freeMemory_no_hyp[Retype_IF_assms,wp]:
+  "no_hyp (freeMemory ptr bits)"
+  by wp
+
+lemma clearMemory_no_fpu[Retype_IF_assms,wp]:
+  "no_fpu (clearMemory ptr bits)"
+  by wp
+
+lemma freeMemory_no_fpu[Retype_IF_assms,wp]:
+  "no_fpu (freeMemory ptr bits)"
+  by wp
+
 lemma do_ipc_transfer_valid_arch_no_caps[wp]:
   "do_ipc_transfer s ep bg grt r \<lbrace>valid_arch_state\<rbrace>"
   by (wpsimp wp: valid_arch_state_lift_aobj_at_no_caps do_ipc_transfer_aobj_at)
 
 lemma create_cap_valid_arch_state_no_caps[wp]:
-  "\<lbrace>valid_arch_state \<rbrace> create_cap tp sz p dev ref
-   \<lbrace>\<lambda>rv. valid_arch_state\<rbrace>"
+  "create_cap tp sz p dev ref \<lbrace>valid_arch_state\<rbrace>"
   by (wp valid_arch_state_lift_aobj_at_no_caps create_cap_aobj_at)
 
 lemma modify_underlying_memory_update_0_ev:
@@ -109,15 +137,15 @@ lemma get_pt_revg:
   done
 
 lemma store_pte_reads_respects:
-  "reads_respects aag l (K (is_subject aag (ptr && ~~ mask pt_bits))) (store_pte ptr pte)"
+  "reads_respects aag l (K (is_subject aag (table_base pt_t ptr))) (store_pte pt_t ptr pte)"
   unfolding store_pte_def fun_app_def
   apply (wp set_pt_reads_respects get_pt_rev)
   apply (clarsimp)
   done
 
 lemma store_pte_globals_equiv:
-  "\<lbrace>globals_equiv s and (\<lambda> s. ptr && ~~ mask pt_bits \<noteq> arm_us_global_vspace (arch_state s))\<rbrace>
-   store_pte ptr pde
+  "\<lbrace>globals_equiv s and (\<lambda> s. table_base pt_t ptr \<noteq> arm_us_global_vspace (arch_state s))\<rbrace>
+   store_pte pt_t ptr pde
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding store_pte_def
   apply (wp set_pt_globals_equiv)
@@ -125,14 +153,14 @@ lemma store_pte_globals_equiv:
   done
 
 lemma store_pte_reads_respects_g:
-  "reads_respects_g aag l (\<lambda>s. is_subject aag (ptr && ~~ mask pt_bits) \<and>
-                               ptr && ~~ mask pt_bits \<noteq> arm_us_global_vspace (arch_state s))
-                    (store_pte ptr pte)"
+  "reads_respects_g aag l (\<lambda>s. is_subject aag (table_base pt_t ptr) \<and>
+                               table_base pt_t ptr \<noteq> arm_us_global_vspace (arch_state s))
+                    (store_pte pt_t ptr pte)"
   by (fastforce intro: equiv_valid_guard_imp[OF reads_respects_g] doesnt_touch_globalsI
                        store_pte_reads_respects store_pte_globals_equiv)
 
 lemma get_pte_rev:
-  "reads_equiv_valid_inv A aag (K (is_subject aag (ptr && ~~ mask pt_bits))) (get_pte ptr)"
+  "reads_equiv_valid_inv A aag (K (is_subject aag (table_base pt_t ptr))) (get_pte pt_t ptr)"
   unfolding gets_map_def fun_app_def
   apply (subst gets_apply)
   apply (wpsimp wp: gets_apply_ev)
@@ -140,8 +168,8 @@ lemma get_pte_rev:
   done
 
 lemma get_pte_revg:
-  "reads_equiv_valid_g_inv A aag (\<lambda>s. (ptr && ~~ mask pt_bits) = arm_us_global_vspace (arch_state s))
-                                 (get_pte ptr)"
+  "reads_equiv_valid_g_inv A aag (\<lambda>s. (table_base pt_t ptr) = arm_us_global_vspace (arch_state s))
+                                 (get_pte pt_t ptr)"
   apply (unfold gets_map_def)
   apply (subst gets_apply)
   apply (wp gets_apply_ev')
@@ -151,36 +179,6 @@ lemma get_pte_revg:
     apply assumption
    apply simp
   apply (auto simp: reads_equiv_g_def globals_equiv_def opt_map_def ptes_of_def obind_def)
-  done
-
-lemma copy_global_mappings_reads_respects_g:
-  "reads_respects_g aag l
-     ((\<lambda>s. x \<noteq> arm_us_global_vspace (arch_state s)) and pspace_aligned and valid_global_arch_objs
-                                                and K (is_aligned x pt_bits \<and> is_subject aag x))
-     (copy_global_mappings x)"
-  unfolding copy_global_mappings_def
-  apply (rule gen_asm_ev)
-  apply clarsimp
-  apply (rule bind_ev_pre)
-     prefer 3
-     apply (rule_tac P'="\<lambda>s. is_subject aag x \<and> x \<noteq> arm_us_global_vspace (arch_state s) \<and>
-                            pspace_aligned s \<and> valid_global_arch_objs s" in hoare_weaken_pre)
-      apply (rule gets_sp)
-     apply (assumption)
-    apply (wp mapM_x_ev store_pte_reads_respects_g get_pte_revg)
-     apply (simp only: pt_index_def)
-     apply (subst table_base_offset_id)
-       apply clarsimp
-      apply (clarsimp simp: pte_bits_def word_size_bits_def pt_bits_def
-                            table_size_def ptTranslationBits_def mask_def)
-      apply (word_bitwise, fastforce)
-     apply (erule ssubst[OF table_base_offset_id])
-      apply (clarsimp simp: pte_bits_def word_size_bits_def pt_bits_def
-                            table_size_def ptTranslationBits_def mask_def)
-      apply (word_bitwise, fastforce)
-     apply clarsimp
-    apply (wpsimp wp: get_pte_inv store_pte_aligned)+
-  apply (fastforce dest: reads_equiv_gD simp: globals_equiv_def)
   done
 
 lemma dmo_no_mem_globals_equiv:
@@ -193,7 +191,6 @@ lemma dmo_no_mem_globals_equiv:
   apply atomize
   apply (erule_tac x="(=) (underlying_memory (machine_state sa))" in allE)
   apply (erule_tac x="(=) (device_state (machine_state sa))" in allE)
-  apply (erule_tac x="(=) (exclusive_state (machine_state sa))" in allE)
   apply (fastforce simp: valid_def globals_equiv_def idle_equiv_def)
   done
 
@@ -237,26 +234,10 @@ lemma dmo_freeMemory_globals_equiv[Retype_IF_assms]:
 
 lemma init_arch_objects_reads_respects_g:
   "reads_respects_g aag l \<top> (init_arch_objects new_type dev ptr num_objects obj_sz refs)"
-  unfolding init_arch_objects_def by wp
-
-lemma copy_global_mappings_globals_equiv:
-  "\<lbrace>globals_equiv s and (\<lambda>s. x \<noteq> arm_us_global_vspace (arch_state s) \<and> is_aligned x pt_bits)\<rbrace>
-   copy_global_mappings x
-   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding copy_global_mappings_def including classic_wp_pre
-  apply simp
-  apply wp
-   apply (rule_tac Q'="\<lambda>_. globals_equiv s and (\<lambda>s. x \<noteq> arm_us_global_vspace (arch_state s) \<and>
-                                                   is_aligned x pt_bits)" in hoare_strengthen_post)
-    apply (wp mapM_x_wp[OF _ subset_refl] store_pte_globals_equiv)
-    apply (simp only: pt_index_def)
-    apply (subst table_base_offset_id)
-      apply clarsimp
-     apply (clarsimp simp: pte_bits_def word_size_bits_def pt_bits_def
-                           table_size_def ptTranslationBits_def mask_def)
-     apply (word_bitwise, fastforce)
-  apply (simp_all)
-  done
+  unfolding init_arch_objects_def cleanCacheRange_RAM_def cleanCacheRange_PoU_def
+  by (wpsimp wp: reads_respects_g do_machine_op_reads_respects
+                 equiv_valid_guard_imp[OF machine_op_lift_ev]
+                 doesnt_touch_globalsI mapM_x_ev mapM_x_wp_inv)
 
 (* FIXME: cleanup this proof *)
 lemma retype_region_globals_equiv[Retype_IF_assms]:
@@ -423,7 +404,6 @@ lemma reset_untyped_cap_reads_respects_g:
         apply (clarsimp simp: valid_cap_simps cap_aligned_def field_simps
                               free_index_of_def invs_valid_global_objs)
        apply (simp add: aligned_add_aligned is_aligned_shiftl)
-       apply (clarsimp simp: Kernel_Config.resetChunkBits_def)
        apply (rule hoare_pre)
         apply (wp preemption_point_inv' set_untyped_cap_invs_simple set_cap_cte_wp_at
                   set_cap_no_overlap only_timer_irq_inv_pres[where Q=\<top>, OF _ set_cap_domain_sep_inv]
@@ -459,24 +439,21 @@ lemma reset_untyped_cap_reads_respects_g:
   apply (drule ex_cte_cap_protects[OF _ _ _ _ order_refl], erule caps_of_state_cteD)
      apply (clarsimp simp: descendants_range_def2 empty_descendants_range_in)
     apply clarsimp+
-  apply (fastforce dest: invs_valid_global_arch_objs valid_global_arch_objs_global_ptD
+  apply (fastforce dest: invs_valid_global_arch_objs
                    simp: untyped_min_bits_def ptr_range_def)
   done
 
-lemma retype_region_ret_pt_aligned:
-  "\<lbrace>K (range_cover ptr sz (obj_bits_api tp us) num_objects)\<rbrace>
-   retype_region ptr num_objects us tp dev
-   \<lbrace>\<lambda>rv. K (\<forall>ref \<in> set rv. tp = ArchObject PageTableObj \<longrightarrow> is_aligned ref pt_bits)\<rbrace>"
-  apply (rule hoare_strengthen_post)
-   apply (rule hoare_weaken_pre)
-    apply (rule retype_region_aligned_for_init)
-   apply simp
-  apply (clarsimp simp: obj_bits_api_def default_arch_object_def pt_bits_def pageBits_def)
-  done
+crunch init_arch_objects
+  for valid_global_objs[wp]: valid_global_objs
+  (wp: crunch_wps)
 
 lemma post_retype_invs_valid_global_objsI:
   "post_retype_invs ty rv s \<Longrightarrow> valid_global_objs s"
   by (clarsimp simp: post_retype_invs_def invs_def valid_state_def split: if_split_asm)
+
+lemma invs_cur_vcpu[simp]:
+  "invs s \<Longrightarrow> cur_vcpu s"
+  by (auto simp: invs_def valid_state_def valid_arch_state_def)
 
 lemma invoke_untyped_reads_respects_g_wcap[Retype_IF_assms]:
   notes blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff
@@ -506,7 +483,6 @@ lemma invoke_untyped_reads_respects_g_wcap[Retype_IF_assms]:
                      for sz in hoare_strengthen_post)
           apply (wp retype_region_ret_is_subject[where sz=sz, simplified]
                     retype_region_global_refs_disjoint[where sz=sz]
-                    retype_region_ret_pt_aligned[where sz=sz]
                     retype_region_aligned_for_init[where sz=sz]
                     retype_region_post_retype_invs_spec[where sz=sz])
          apply clarsimp
@@ -583,11 +559,14 @@ lemma invoke_untyped_reads_respects_g_wcap[Retype_IF_assms]:
     apply (clarsimp simp: field_simps mask_out_sub_mask shiftl_t2n)
    apply blast
   apply (clarsimp simp: cte_wp_at_caps_of_state authorised_untyped_inv_def)
+  apply (rule conjI; clarsimp)
   apply (strengthen refl)
   apply (frule(1) cap_auth_caps_of_state)
   apply (simp add: aag_cap_auth_def untyped_range_def
                    aag_has_Control_iff_owns ptr_range_def[symmetric])
-  apply (erule disjE, simp_all)[1]
+  apply (frule(1) cap_auth_caps_of_state)
+  apply (simp add: aag_cap_auth_def untyped_range_def
+                   aag_has_Control_iff_owns ptr_range_def[symmetric])
   done
 
 lemma delete_objects_globals_equiv[wp]:
@@ -620,7 +599,6 @@ lemma reset_untyped_cap_globals_equiv:
                  preemption_point_inv | simp add: if_apply_def2)+
     apply (clarsimp simp: is_cap_simps ptr_range_def[symmetric]
                           cap_aligned_def bits_of_def free_index_of_def)
-    apply (clarsimp simp: Kernel_Config.resetChunkBits_def)
     apply (strengthen invs_valid_global_objs invs_arch_state)
     apply (wp delete_objects_invs_ex hoare_vcg_const_imp_lift get_cap_wp)+
   apply (clarsimp simp: cte_wp_at_caps_of_state descendants_range_def2 is_cap_simps bits_of_def
@@ -630,9 +608,13 @@ lemma reset_untyped_cap_globals_equiv:
   apply (frule valid_global_refsD2, clarsimp+)
   apply (clarsimp simp: ptr_range_def[symmetric] global_refs_def)
   apply (strengthen empty_descendants_range_in)
-  apply (cases slot)
-  apply (fastforce dest: valid_global_arch_objs_global_ptD[OF invs_valid_global_arch_objs])
+  apply (cases slot, fastforce)
   done
+
+lemma init_arch_objects_globals_equiv[wp]:
+  "init_arch_objects tp dev ptr n us refs \<lbrace>globals_equiv st\<rbrace>"
+  unfolding init_arch_objects_def cleanCacheRange_RAM_def cleanCacheRange_PoU_def
+  by (wpsimp wp: mapM_x_wp_inv)
 
 lemma invoke_untyped_globals_equiv:
   notes blah[simp del] = untyped_range.simps usable_untyped_range.simps atLeastAtMost_iff

--- a/proof/infoflow/AARCH64/ArchScheduler_IF.thy
+++ b/proof/infoflow/AARCH64/ArchScheduler_IF.thy
@@ -70,17 +70,22 @@ lemma arch_scheduler_affects_equiv_ready_queues_update[Scheduler_IF_assms, simp]
 
 crunch arch_switch_to_thread, arch_switch_to_idle_thread
   for idle_thread[Scheduler_IF_assms, wp]: "\<lambda>s :: det_state. P (idle_thread s)"
-  and kheap[Scheduler_IF_assms, wp]: "\<lambda>s :: det_state. P (kheap s)"
   (wp: crunch_wps simp: crunch_simps)
+
+declare arch_prepare_next_domain_idle_thread[Scheduler_IF_assms]
 
 crunch arch_switch_to_thread, arch_switch_to_idle_thread
   for cur_domain[Scheduler_IF_assms, wp]: "\<lambda>s. P (cur_domain s)"
   and domain_fields[Scheduler_IF_assms, wp]: "domain_fields P"
 
-crunch arch_switch_to_idle_thread
-  for globals_equiv[Scheduler_IF_assms, wp]: "globals_equiv st"
-  and states_equiv_for[Scheduler_IF_assms, wp]: "states_equiv_for P Q R S st"
-  and work_units_completed[Scheduler_IF_assms, wp]: "\<lambda>s. P (work_units_completed s)"
+lemma arch_switch_to_idle_thread_globals_equiv[Scheduler_IF_assms,wp]:
+  "\<lbrace>valid_arch_state and globals_equiv st\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding arch_switch_to_idle_thread_def
+  by wpsimp
+
+lemma arch_switch_to_idle_thread_work_units_completed[Scheduler_IF_assms,wp]:
+  "arch_switch_to_idle_thread \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace>"
+  by wp
 
 crunch arch_activate_idle_thread
   for cur_domain[Scheduler_IF_assms, wp]: "\<lambda>s. P (cur_domain s)"
@@ -129,7 +134,7 @@ lemma equiv_asid_equiv_update[Scheduler_IF_assms]:
      \<Longrightarrow> equiv_asid asid st (s\<lparr>kheap := (kheap s)(x \<mapsto> TCB y')\<rparr>)"
   by (clarsimp simp: equiv_asid_def obj_at_def get_tcb_def)
 
-declare arch_prepare_next_domain_inv[Scheduler_IF_assms]
+declare arch_activate_idle_thread_domain_fields_invs[Scheduler_IF_assms]
 
 end
 
@@ -147,7 +152,124 @@ proof goal_cases
 qed
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
+
+(* scheduler_affects_equiv - states_equiv_for_labels *)
+definition scheduler_affects_inv where
+  "scheduler_affects_inv aag l st s \<equiv>
+     (reads_scheduler_cur_domain aag l st \<or> reads_scheduler_cur_domain aag l s \<longrightarrow>
+      cur_thread st = cur_thread s \<and>
+      scheduler_action st = scheduler_action s \<and>
+      work_units_completed st = work_units_completed s \<and>
+      scheduler_globals_frame_equiv st s \<and>
+      idle_thread st = idle_thread s \<and>
+      (cur_thread st \<noteq> idle_thread s \<longrightarrow> arch_scheduler_affects_equiv st s))"
+
+definition scheduler_inv where
+  "scheduler_inv aag l s s' \<equiv>
+     scheduler_equiv aag s s' \<and> scheduler_affects_inv aag l s s'"
+
+abbreviation (input) scheduler_can_read where
+  "scheduler_can_read aag l \<equiv> \<lambda>l'. l' \<in> reads_scheduler aag l"
+
+lemma domains_distinct_states_equiv_for_labels:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows "states_equiv_for_labels aag L s s' = states_equiv_but_for_labels aag (not L) s s'"
+  apply (rule iffI)
+   apply (erule states_equiv_for_guard_imp)
+      apply clarsimp+
+   apply (insert domains_distinct, fastforce simp: pas_domains_distinct_def)
+   apply (erule states_equiv_for_guard_imp)
+      apply clarsimp+
+  apply (insert domains_distinct, clarsimp simp: pas_domains_distinct_def)
+  apply (erule_tac x=x in allE)
+  apply clarsimp
+  done
+
+lemma scheduler_affects_equiv_def2:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows
+  "scheduler_affects_equiv aag l s s' \<equiv>
+   states_equiv_but_for_labels aag (not scheduler_can_read aag l) s s' \<and> scheduler_affects_inv aag l s s'"
+  apply (rule eq_reflection)
+  apply (simp only: domains_distinct_states_equiv_for_labels[OF domains_distinct,symmetric])
+  apply (auto simp: scheduler_affects_equiv_def scheduler_affects_inv_def)
+  done
+
+lemma scheduler_inv_def2:
+  "scheduler_inv aag l s s' \<equiv>
+     domain_fields_equiv s s' \<and> idle_thread s = idle_thread s' \<and>
+     globals_equiv_scheduler s s' \<and> silc_dom_equiv aag s s' \<and>
+     irq_state_of_state s = irq_state_of_state s' \<and>
+     (reads_scheduler_cur_domain aag l s \<or> reads_scheduler_cur_domain aag l s'
+      \<longrightarrow> (cur_thread s = cur_thread s' \<and> scheduler_action s = scheduler_action s' \<and>
+           work_units_completed s = work_units_completed s' \<and>
+           scheduler_globals_frame_equiv s s' \<and>
+           (cur_thread s \<noteq> idle_thread s' \<longrightarrow> arch_scheduler_affects_equiv s s')))"
+  apply (rule eq_reflection)
+  apply (auto simp: scheduler_inv_def scheduler_equiv_def scheduler_affects_inv_def)
+  done
+
+lemma reads_respects_scheduler_def2:
+  "reads_respects_scheduler aag l P f \<equiv>
+   equiv_valid_inv (scheduler_inv aag l) (states_equiv_for_labels aag (scheduler_can_read aag l)) P f"
+  apply (rule eq_reflection)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (rule iff_allI)+
+  apply (rule iffI; clarsimp)
+   apply (drule mp)
+    apply (clarsimp simp: scheduler_equiv_def scheduler_affects_equiv_def scheduler_inv_def2 )
+   apply (drule (1) bspec, clarsimp)+
+   apply (clarsimp simp: scheduler_equiv_def scheduler_affects_equiv_def scheduler_inv_def2 )
+  apply (drule mp)
+   apply (clarsimp simp: scheduler_equiv_def scheduler_affects_equiv_def scheduler_inv_def2 )
+  apply (drule (1) bspec, clarsimp)+
+  apply (clarsimp simp: scheduler_equiv_def scheduler_affects_equiv_def scheduler_inv_def2 )
+  done
+
+lemma domain_fields_equiv_sym:
+  "domain_fields_equiv st s = domain_fields_equiv s st"
+  by (auto simp: domain_fields_equiv_def)
+
+lemma reads_respects_scheduler_from_labels:
+  assumes ev: "\<And>L. reads_respects_l aag L P f"
+    and inv: "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (cur_domain s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (cur_thread s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (cur_thread s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (idle_thread s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (idle_thread s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (scheduler_action s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (scheduler_action s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (work_units_completed s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (work_units_completed s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (irq_state_of_state s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
+             "\<And>P st. \<lbrace>\<lambda>s. P (domain_fields_equiv st s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (domain_fields_equiv st s)\<rbrace>"
+             "\<And>P st. \<lbrace>\<lambda>s. P (globals_equiv_scheduler st s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (globals_equiv_scheduler st s)\<rbrace>"
+             "\<And>P st. \<lbrace>\<lambda>s. P (scheduler_globals_frame_equiv st s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (scheduler_globals_frame_equiv st s)\<rbrace>"
+             "\<And>P st. \<lbrace>\<lambda>s. P (silc_dom_equiv aag st s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (silc_dom_equiv aag st s)\<rbrace>"
+  shows "reads_respects_scheduler aag l (P and Q) f"
+  apply (simp add: reads_respects_scheduler_def2)
+  apply (rule equiv_valid_inv_split)
+   apply (rule equiv_valid_rv_inv_lift)
+  unfolding scheduler_inv_def2
+     apply (rule hoare_weaken_pre)
+      apply clarsimp
+      apply (rule hoare_lift_Pf2_pre_conj[where f=cur_domain, rotated], wp inv)
+      apply (rule hoare_lift_Pf2_pre_conj[where f=cur_thread, rotated], wp inv)
+      apply (rule hoare_lift_Pf2_pre_conj[where f=idle_thread, rotated], wp inv)
+      apply (rule hoare_lift_Pf2_pre_conj[where f=idle_thread, rotated], wp inv)
+      apply (rule hoare_lift_Pf2_pre_conj[where f=scheduler_action, rotated], wp inv)
+      apply (rule hoare_lift_Pf2_pre_conj[where f=work_units_completed, rotated], wp inv)
+      apply (rule hoare_lift_Pf2_pre_conj[where f=irq_state_of_state, rotated], wp inv)
+      apply (rule hoare_lift_Pf2_pre_conj[where f=idle_thread, rotated], wp inv)
+      apply (rule_tac f="domain_fields_equiv st" in hoare_lift_Pf2_pre_conj[rotated], wp inv)
+      apply (rule_tac f="globals_equiv_scheduler st" in hoare_lift_Pf2_pre_conj[rotated], wp inv)
+      apply (rule_tac f="scheduler_globals_frame_equiv st" in hoare_lift_Pf2_pre_conj[rotated], wp inv)
+      apply (rule_tac f="silc_dom_equiv aag st" in hoare_lift_Pf2_pre_conj[rotated], wp inv)
+      apply (clarsimp simp: arch_scheduler_affects_equiv_def)
+      apply wp
+     apply (clarsimp simp: arch_scheduler_affects_equiv_def)
+    apply (auto simp: domain_fields_equiv_sym globals_equiv_scheduler_sym silc_dom_equiv_sym
+                      scheduler_globals_frame_equiv_sym arch_scheduler_affects_equiv_sym)[2]
+  apply (insert ev)
+  apply (fastforce elim: wp_pre)
+  done
 
 definition swap_things where
   "swap_things s t \<equiv>
@@ -172,12 +294,23 @@ lemma globals_equiv_scheduler_inv'[Scheduler_IF_assms]:
                          arch_globals_equiv_scheduler_def arch_scheduler_affects_equiv_def)+
   done
 
+crunch vcpu_switch
+  for global_pt[wp]: "\<lambda>s. P (global_pt s)"
+  (wp: valid_global_arch_objs_lift)
+
+crunch vcpu_switch
+  for valid_global_arch_objs[wp]: "valid_global_arch_objs"
+  (wp: valid_global_arch_objs_lift)
+
 lemma arch_switch_to_thread_globals_equiv_scheduler[Scheduler_IF_assms]:
   "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
    arch_switch_to_thread thread
    \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
   unfolding arch_switch_to_thread_def storeWord_def
-  by (wpsimp wp: dmo_wp modify_wp thread_get_wp' globals_equiv_scheduler_inv'[where P="\<top>"])
+  apply (wpsimp wp: dmo_wp modify_wp thread_get_wp' lazy_fpu_restore_globals_equiv
+                    globals_equiv_scheduler_inv'[where P="invs"])
+   apply (auto intro: sym_refs_VCPU_hyp_live)
+  done
 
 crunch arch_activate_idle_thread
   for silc_dom_equiv[Scheduler_IF_assms, wp]: "silc_dom_equiv aag st"
@@ -193,7 +326,7 @@ lemmas set_vm_root_scheduler_affects_equiv[wp] =
                                           set_vm_root_arch_scheduler_affects_equiv]
 
 lemma set_vm_root_reads_respects_scheduler[wp]:
-  "reads_respects_scheduler aag l \<top> (set_vm_root thread)"
+  "reads_respects_scheduler aag l valid_global_arch_objs (set_vm_root thread)"
   apply (rule reads_respects_scheduler_unobservable'[OF scheduler_equiv_lift'
                                                           [OF globals_equiv_scheduler_inv']])
   apply (wp silc_dom_equiv_states_equiv_lift set_vm_root_states_equiv_for | simp)+
@@ -201,7 +334,7 @@ lemma set_vm_root_reads_respects_scheduler[wp]:
 
 lemma store_cur_thread_fragment_midstrength_reads_respects:
   "equiv_valid (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
-               (scheduler_affects_equiv aag l) invs
+               (scheduler_affects_equiv aag l) \<top>
                (do x \<leftarrow> modify (cur_thread_update (\<lambda>_. t));
                    set_scheduler_action resume_cur_thread
                 od)"
@@ -215,77 +348,465 @@ lemma store_cur_thread_fragment_midstrength_reads_respects:
                  simp del: split_paired_All)
   done
 
-lemma arch_switch_to_thread_globals_equiv_scheduler':
+lemma set_vm_root_globals_equiv_scheduler:
   "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
    set_vm_root t
    \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
   by (rule globals_equiv_scheduler_inv', wpsimp)
 
-lemma arch_switch_to_thread_reads_respects_scheduler[wp]:
-  "reads_respects_scheduler aag l
-     ((\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)) and invs)
-     (arch_switch_to_thread t)"
-  apply (rule reads_respects_scheduler_cases)
-     apply (simp add: arch_switch_to_thread_def)
-     apply wp
-    apply (clarsimp simp: scheduler_equiv_def globals_equiv_scheduler_def)
-   apply (simp add: arch_switch_to_thread_def)
-   apply wp
+thm equiv_valid_inv_split
+lemma equiv_valid_inv_split':
+  "\<lbrakk> equiv_valid_inv I B P f; equiv_valid_rv_inv I C \<top>\<top> P f; \<And>s t. A s t \<longleftrightarrow> B s t \<and> C s t \<rbrakk>
+     \<Longrightarrow> equiv_valid_inv I A P f"
+  apply (rule equiv_valid_conseq[where I'=I and A'="\<lambda>s s'. B s s' \<and> C s s'" and B'="\<lambda>s s'. B s s' \<and> C s s'" and P'=P])
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (erule_tac x=s in allE, erule_tac x=s in allE)
+  apply (erule_tac x=t in allE, erule_tac x=t in allE)
+    apply fastforce+
+  done
+
+lemma equiv_valid_inv_A_conjI:
+  "\<lbrakk> equiv_valid_inv I A P f; equiv_valid_rv_inv I A' \<top>\<top> P f \<rbrakk>
+     \<Longrightarrow> equiv_valid_inv I (\<lambda>s s'. A s s' \<and> A' s s') P f"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (erule_tac x=s in allE, erule_tac x=s in allE)
+  apply (erule_tac x=t in allE, erule_tac x=t in allE)
+  apply fastforce
+  done
+
+lemma scheduler_globals_frame_equiv_triv[simp]:
+  "scheduler_globals_frame_equiv st s"
+  by (clarsimp simp: scheduler_globals_frame_equiv_def)
+
+lemma midstrength_reads_respects_scheduler_from_labels:
+  assumes ev: "\<And>L. reads_respects_l aag L P f"
+    and inv: "\<And>P. \<lbrace>\<lambda>s. P (idle_thread s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (idle_thread s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (irq_state_of_state s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (work_units_completed s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (work_units_completed s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (cur_domain s)\<rbrace>"
+             "\<And>st. \<lbrace>\<lambda>s. domain_fields_equiv st s \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. domain_fields_equiv st s\<rbrace>"
+             "\<And>st. \<lbrace>\<lambda>s. globals_equiv_scheduler st s \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. globals_equiv_scheduler st s\<rbrace>"
+             "\<And>st. \<lbrace>\<lambda>s. silc_dom_equiv aag st s \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. silc_dom_equiv aag st s\<rbrace>"
+  shows "equiv_valid_inv (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l) (P and Q) f"
+  apply (rule equiv_valid_inv_split)
+   apply (rule equiv_valid_rv_inv_lift)
+  unfolding scheduler_equiv_def
+     apply (wpsimp wp: inv)
+    apply (auto simp: domain_fields_equiv_sym globals_equiv_scheduler_sym silc_dom_equiv_sym)[2]
+  unfolding midstrength_scheduler_affects_equiv_def
+  apply (rule equiv_valid_inv_A_conjI)
+   apply (rule_tac Q=P in equiv_valid_guard_imp)
+    apply (insert ev)[1]
+    apply fastforce
+   apply simp
+  apply (rule_tac Q=Q and Q'=Q in equiv_valid_2_guard_imp)
+    apply (rule equiv_valid_rv_inv_lift)
+      apply (wpsimp wp: inv hoare_vcg_imp_lift)+
+    apply auto
+  done
+
+lemma weak_reads_respects_scheduler_from_labels:
+  assumes ev: "\<And>L. reads_respects_l aag L P f"
+    and inv: "\<And>P. \<lbrace>\<lambda>s. P (idle_thread s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (idle_thread s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (irq_state_of_state s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (cur_domain s)\<rbrace>"
+             "\<And>st. \<lbrace>\<lambda>s. domain_fields_equiv st s \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. domain_fields_equiv st s\<rbrace>"
+             "\<And>st. \<lbrace>\<lambda>s. globals_equiv_scheduler st s \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. globals_equiv_scheduler st s\<rbrace>"
+             "\<And>st. \<lbrace>\<lambda>s. silc_dom_equiv aag st s \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. silc_dom_equiv aag st s\<rbrace>"
+  shows "equiv_valid_inv (scheduler_equiv aag) (weak_scheduler_affects_equiv aag l) (P and Q) f"
+  apply (rule equiv_valid_inv_split)
+   apply (rule equiv_valid_rv_inv_lift)
+  unfolding scheduler_equiv_def
+     apply (wpsimp wp: inv)
+    apply (auto simp: domain_fields_equiv_sym globals_equiv_scheduler_sym silc_dom_equiv_sym)[2]
+  unfolding weak_scheduler_affects_equiv_def
+  apply (rule_tac Q=P in equiv_valid_guard_imp)
+   apply (insert ev)[1]
+   apply fastforce
   apply simp
   done
 
 lemmas globals_equiv_scheduler_inv = globals_equiv_scheduler_inv'[where P="\<top>",simplified]
 
-lemma arch_switch_to_thread_midstrength_reads_respects_scheduler[Scheduler_IF_assms, wp]:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "midstrength_reads_respects_scheduler aag l
-           (invs and pas_refined aag and (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
-           (do _ <- arch_switch_to_thread t;
-               _ <- modify (cur_thread_update (\<lambda>_. t));
-               modify (scheduler_action_update (\<lambda>_. resume_cur_thread))
-            od)"
-  apply (rule equiv_valid_guard_imp)
-   apply (rule midstrength_reads_respects_scheduler_cases[
-                    where Q="(invs and pas_refined aag and
-                                  (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))",
-                    OF domains_distinct])
-       apply (simp add: arch_switch_to_thread_def bind_assoc)
-       apply (rule bind_ev_general)
-         apply (fold set_scheduler_action_def)
-         apply (rule store_cur_thread_fragment_midstrength_reads_respects)
-        apply (rule_tac P="\<top>" and P'="\<top>" in equiv_valid_inv_unobservable)
-            apply (rule hoare_pre)
-             apply (rule scheduler_equiv_lift'[where P=\<top>])
-                  apply (wp globals_equiv_scheduler_inv silc_dom_lift | simp)+
-           apply (wp midstrength_scheduler_affects_equiv_unobservable set_vm_root_states_equiv_for
-                  | simp)+
-          apply (wp cur_thread_update_not_subject_reads_respects_scheduler | simp | fastforce)+
+lemmas set_global_user_vspace_globals_equiv_scheduler[wp] =
+  globals_equiv_scheduler_inv[OF set_global_user_vspace_globals_equiv]
+
+lemma set_vcpu_silc_dom_equiv:
+  "\<lbrace>silc_dom_equiv aag st and valid_silc_label aag\<rbrace> set_vcpu ptr vcpu \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
+  unfolding set_vcpu_def
+  by (wpsimp wp: set_object_silc_dom_equiv simp: is_cap_table_def)
+
+crunch vcpu_save_reg
+  for silc_dom_equiv[wp]: "silc_dom_equiv aag st"
+  (wp: crunch_wps valid_silc_label_lift simp: crunch_simps)
+
+lemma vcpu_save_reg_range_silc_dom_equiv[wp]:
+  "\<lbrace>silc_dom_equiv aag st and valid_silc_label aag\<rbrace>
+   vcpu_save_reg_range vr from to
+   \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
+  unfolding vcpu_save_reg_range_def
+  apply (rule hoare_strengthen_post)
+   apply (rule mapM_x_wp_inv)
+   apply (wpsimp wp: valid_silc_label_lift)+
   done
+
+crunch vcpu_save, vcpu_restore
+  for silc_dom_equiv: "silc_dom_equiv aag st"
+  (wp: crunch_wps valid_silc_label_lift simp: crunch_simps)
+
+crunch vcpu_switch
+  for silc_dom_equiv[wp]: "silc_dom_equiv aag st"
+  (wp: crunch_wps valid_silc_label_lift simp: crunch_simps)
+
+crunch arch_switch_to_idle_thread
+   for silc_dom_equiv[wp]: "silc_dom_equiv aag st"
+  (wp: crunch_wps valid_silc_label_lift simp: crunch_simps)
+
+crunch arch_switch_to_thread
+   for silc_dom_equiv[wp]: "silc_dom_equiv aag st"
+  (wp: crunch_wps valid_silc_label_lift simp: crunch_simps)
+
+crunch arch_prepare_next_domain
+  for silc_dom_equiv[wp]: "silc_dom_equiv aag st"
+  and typ_at[wp]: "\<lambda>s. P (typ_at T ptr s)"
+  (wp: crunch_wps valid_silc_label_lift simp: crunch_simps)
+
+lemma next_domain_snippet_cur_vcpu_in_cur_domain:
+  "\<lbrace>\<top>\<rbrace> do y <- arch_prepare_next_domain;
+          next_domain
+       od
+   \<lbrace>\<lambda>_. cur_vcpu_in_cur_domain\<rbrace>"
+  unfolding arch_prepare_next_domain_def
+  by wpsimp
+
+lemma next_domain_snippet_cur_fpu_in_cur_domain:
+  "\<lbrace>\<top>\<rbrace> do y <- arch_prepare_next_domain;
+          next_domain
+       od
+   \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
+  unfolding arch_prepare_next_domain_def
+  by wpsimp
+
+lemmas [Scheduler_IF_assms] =
+  arch_switch_to_thread_silc_dom_equiv
+  arch_switch_to_idle_thread_silc_dom_equiv
+  set_scheduler_action_cur_vcpu_in_cur_domain
+  set_scheduler_action_cur_fpu_in_cur_domain
+  tcb_sched_action_cur_vcpu_in_cur_domain
+  tcb_sched_action_cur_fpu_in_cur_domain
+  next_domain_snippet_cur_vcpu_in_cur_domain
+  next_domain_snippet_cur_fpu_in_cur_domain
+  arch_prepare_next_domain_silc_dom_equiv
+  arch_prepare_next_domain_typ_at
+
+
+lemma vcpu_switch_globals_equiv_scheduler[wp]:
+  "\<lbrace>valid_arch_state and globals_equiv_scheduler s\<rbrace> vcpu_switch vr \<lbrace>\<lambda>_. globals_equiv_scheduler s\<rbrace>"
+  by (wp globals_equiv_scheduler_inv' vcpu_switch_globals_equiv | fastforce)+
+
+lemma vcpu_switch_midstrength_reads_respects_scheduler:
+  "equiv_valid_inv (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+     (valid_arch_state and valid_silc_label aag) (vcpu_switch vopt)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule midstrength_reads_respects_scheduler_from_labels)
+          apply (rule vcpu_switch_reads_respects_l)
+         apply (wpsimp wp: domain_fields_equiv_lift | erule conjunct1)+
+  done
+
+lemma set_global_user_vspace_states_equiv_for[wp]:
+  "set_global_user_vspace \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+  unfolding set_global_user_vspace_def setVSpaceRoot_def
+  by (wpsimp wp: do_machine_op_mol_states_equiv_for)
+
+lemma set_global_user_vspace_midstrength_reads_respects:
+  "equiv_valid_inv (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+                   \<top> set_global_user_vspace"
+  apply (rule equiv_valid_inv_unobservable)
+      apply (rule hoare_pre)
+       apply (rule scheduler_equiv_lift')
+            apply wpsimp+
+     apply (wp midstrength_scheduler_affects_equiv_unobservable
+                    | simp | wps)+
+     apply (auto simp: scheduler_equiv_sym midstrength_scheduler_affects_equiv_sym)
+  done
+
+lemma arch_switch_to_idle_thread_midstrength_reads_respects[Scheduler_IF_assms]:
+  "equiv_valid_inv (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+                   (valid_arch_state and valid_silc_label aag) arch_switch_to_idle_thread"
+  unfolding arch_switch_to_idle_thread_def
+  by (wp set_global_user_vspace_midstrength_reads_respects vcpu_switch_midstrength_reads_respects_scheduler)
 
 lemma arch_switch_to_idle_thread_globals_equiv_scheduler[Scheduler_IF_assms, wp]:
   "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
    arch_switch_to_idle_thread
    \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
   unfolding arch_switch_to_idle_thread_def storeWord_def
-  by (wp dmo_wp modify_wp thread_get_wp' arch_switch_to_thread_globals_equiv_scheduler')
+  apply (wp dmo_wp modify_wp thread_get_wp' set_vm_root_globals_equiv_scheduler)
+  apply fastforce
+  done
+
+lemma states_equiv_but_for_labels_equiv_for_lift:
+  assumes "\<And>st. \<lbrace>\<lambda>s. equiv_but_for_labels aag {l. L l} st s \<and> Q s\<rbrace> f \<lbrace>\<lambda>_. equiv_but_for_labels aag {l. L l} st\<rbrace>"
+  shows "\<lbrace>\<lambda>s. states_equiv_but_for_labels aag L st s \<and> Q s\<rbrace> f \<lbrace>\<lambda>_. states_equiv_but_for_labels aag L st\<rbrace>"
+  apply (clarsimp simp: valid_def)
+  apply (prop_tac "equiv_but_for_labels aag {l. L l} s s")
+   apply (clarsimp simp: equiv_but_for_labels_def states_equiv_for_refl)
+  apply (insert assms)
+  apply (erule_tac x=s in meta_allE)
+  apply (drule use_valid)
+    apply assumption
+   apply simp
+  apply (clarsimp simp: equiv_but_for_labels_def)
+  apply (erule (1) states_equiv_for_trans)
+  done
+
+lemma vcpu_switch_equiv_but_for_labels:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and>
+        (\<forall>vr. vopt = Some vr \<longrightarrow> pasObjectAbs aag vr \<in> L) \<and>
+        (\<forall>vr b. current_vcpu s = Some (vr,b) \<longrightarrow> pasObjectAbs aag vr \<in> L)\<rbrace>
+   vcpu_switch vopt
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vcpu_switch_def
+  apply (wpc | wp modify_current_vcpu_equiv_but_for_labels)+
+  apply clarsimp
+  apply (rule conjI)
+   apply (auto simp: cur_vcpu_of_def cur_vcpu_for_def)[1]
+  apply clarsimp
+  apply (rule conjI)
+   apply (auto simp: cur_vcpu_of_def cur_vcpu_for_def)[1]
+  apply clarsimp
+  apply (case_tac b)
+   apply (auto simp: cur_vcpu_of_def cur_vcpu_for_def)[1]
+  apply clarsimp
+  apply (case_tac "a = x")
+   apply (auto simp: cur_vcpu_of_def cur_vcpu_for_def)[1]
+  apply clarsimp
+  apply (clarsimp simp: cur_vcpu_for_Some)
+  done
+
+lemma vcpu_switch_None_equiv_but_for_labels:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and>
+        (\<forall>vr b. current_vcpu s = Some (vr,True) \<longrightarrow> pasObjectAbs aag vr \<in> L)\<rbrace>
+   vcpu_switch None
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vcpu_switch_def
+  apply (wpc | wp modify_current_vcpu_equiv_but_for_labels)+
+  apply (auto simp: cur_vcpu_of_def cur_vcpu_for_def)[1]
+  done
+
+lemma tcb_invisible:
+  "\<lbrakk> \<not> reads_scheduler_cur_domain aag l s; pas_refined aag s; in_cur_domain t s; tcb_at t s \<rbrakk>
+    \<Longrightarrow> pasObjectAbs aag t \<notin> reads_scheduler aag l"
+  apply (drule tcb_at_ko_at, clarsimp)
+  apply (drule ko_at_etcbD)
+  apply (frule (1) tcb_domain_wellformed)
+  apply (prop_tac "etcb_domain (etcb_of tcb) = cur_domain s")
+   apply (clarsimp simp: in_cur_domain_def)
+   apply (clarsimp simp: etcbs_of'_def etcb_at'_def split: option.splits kernel_object.splits)
+  apply simp
+  by blast
+
+lemma vcpu_controls_associated_tcb:
+  "\<lbrakk> pas_refined aag s; vcpus_of s v = Some vcpu; vcpu_tcb vcpu = Some t \<rbrakk>
+     \<Longrightarrow> (v, Control, t) \<in> state_objs_to_policy s"
+  by (fastforce simp: sbta_href state_objs_to_policy_def state_hyp_refs_of_def opt_map_def
+                dest: pas_refined_mem is_subject_trans split: option.splits)+
+
+lemma vcpu_invisible:
+  assumes nrs: "\<not> reads_scheduler_cur_domain aag l s"
+  and pwn: "pas_wellformed_noninterference aag"
+  shows
+  "\<lbrakk> pas_refined aag s; valid_silc_label aag s;
+     invs s; current_vcpu s = Some (vr,b); cur_vcpu_in_cur_domain s \<rbrakk>
+    \<Longrightarrow> pasObjectAbs aag vr \<notin> reads_scheduler aag l"
+  apply (prop_tac "cur_vcpu s")
+   apply (erule invs_cur_vcpu)
+  apply (clarsimp simp: cur_vcpu_def opt_pred_def split: option.splits)
+  apply (clarsimp simp: cur_vcpu_in_cur_domain_def cur_vcpu_tcb_def)
+  apply (clarsimp simp: opt_map_def split: option.splits)
+  apply (rename_tac t vcpu)
+  apply (prop_tac "tcb_at t s")
+   apply (drule invs_valid_objs)
+   apply (erule (1) valid_objsE)
+   apply (clarsimp simp: valid_obj_def valid_vcpu_def obj_at_def)
+  apply (frule (2) tcb_invisible[OF nrs])
+  apply (frule_tac vcpu=vcpu in vcpu_controls_associated_tcb)
+    apply (fastforce simp: opt_map_def split: option.splits)
+   apply simp
+  apply (prop_tac "pasObjectAbs aag vr \<noteq> SilcLabel")
+   apply (fastforce simp: valid_silc_label_def obj_at_def is_cap_table_def)
+  apply (drule (1) pas_refined_mem)
+  apply (drule aag_wellformed_Control)
+  using pwn apply (fastforce simp: pas_wellformed_noninterference_def)
+  apply simp
+  done
 
 lemma arch_switch_to_idle_thread_unobservable[Scheduler_IF_assms]:
-  "\<lbrace>(\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l = {}) and
-    scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and invs\<rbrace>
-   arch_switch_to_idle_thread
-   \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
+  assumes wellformed: "pas_wellformed_noninterference aag"
+  notes domains_distinct = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows
+    "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
+      scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and
+      invs and cur_vcpu_in_cur_domain and valid_silc_label aag and pas_refined aag\<rbrace>
+     arch_switch_to_idle_thread
+     \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
   apply (simp add: arch_switch_to_idle_thread_def)
   apply wp
-  apply (clarsimp simp add: scheduler_equiv_def domain_fields_equiv_def invs_def valid_state_def)
+    apply (rule scheduler_affects_equiv_unobservable)
+          apply wpsimp+
+    apply (unfold arch_scheduler_affects_equiv_def)[1]
+    apply wpsimp
+   apply (unfold scheduler_affects_equiv_def2[OF domains_distinct])
+   apply (wp states_equiv_but_for_labels_equiv_for_lift)
+    apply (wp vcpu_switch_None_equiv_but_for_labels)
+   apply (simp add: scheduler_affects_inv_def arch_scheduler_affects_equiv_def)
+   apply wps
+   apply wpsimp
+  using wellformed apply (clarsimp simp: vcpu_invisible)
+  done
+
+lemma lazy_fpu_restore_equiv_but_for_labels:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> (\<forall>t. cur_fpu_of s t \<longrightarrow> pasObjectAbs aag t \<in> L) \<and>
+        pasObjectAbs aag t \<in> L \<and> valid_cur_fpu s\<rbrace>
+   lazy_fpu_restore t
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding lazy_fpu_restore_def
+  apply wpsimp
+     apply (wp switch_local_fpu_owner_equiv_but_for_labels)
+    apply wpsimp+
+   apply (wp thread_get_wp')
+  apply clarsimp
+  done
+
+lemma cur_fpu_invisible:
+  "\<lbrakk> pas_refined aag s; \<not> reads_scheduler_cur_domain aag l s; cur_fpu_in_cur_domain s;
+     valid_cur_fpu s; current_fpu s = Some t \<rbrakk>
+    \<Longrightarrow> pasObjectAbs aag t \<notin> reads_scheduler aag l"
+  apply (clarsimp simp: cur_fpu_in_cur_domain_def)
+  apply (frule current_fpu_owner_Some_tcb_at, fastforce)
+  apply (drule tcb_at_ko_at, clarsimp)
+  apply (drule ko_at_etcbD)
+  apply (frule (1) tcb_domain_wellformed)
+  apply (prop_tac "etcb_domain (etcb_of tcb) = cur_domain s")
+   apply (clarsimp simp: in_cur_domain_def)
+   apply (clarsimp simp: etcbs_of'_def etcb_at'_def split: option.splits kernel_object.splits)
+  apply simp
+  by blast
+
+lemma states_equiv_for_helper:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows
+    "states_equiv_for (\<lambda>x. pasObjectAbs aag x \<in> reads_scheduler aag l)
+                      (\<lambda>x. pasIRQAbs aag x \<in> reads_scheduler aag l)
+                      (\<lambda>x. pasASIDAbs aag x \<in> reads_scheduler aag l)
+                      (\<lambda>x. \<exists>la\<in>pasDomainAbs aag x. la \<in> reads_scheduler aag l)
+                      st s =
+     states_equiv_but_for_labels aag (\<lambda>l'. l' \<notin> reads_scheduler aag l) st s"
+  apply clarsimp
+  apply (rule iffI; erule rsubst[where P="\<lambda>x. states_equiv_for _ _ _ x _ _"]; rule ext)
+   using domains_distinct
+   apply (clarsimp simp: pas_domains_distinct_def)
+   apply (erule_tac x=x in allE)
+   apply clarsimp
+  using domains_distinct
+  apply (clarsimp simp: pas_domains_distinct_def)
+  apply (erule_tac x=x in allE)
+  apply clarsimp
+  done
+
+lemma lazy_fpu_restore_scheduler_affects_equiv:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows
+  "\<lbrace>\<lambda>s. scheduler_affects_equiv aag l st s \<and> pas_refined aag s \<and>
+        \<not> reads_scheduler_cur_domain aag l s \<and> pasObjectAbs aag t \<notin> reads_scheduler aag l \<and>
+        cur_fpu_in_cur_domain s \<and> valid_cur_fpu s\<rbrace>
+   lazy_fpu_restore t
+   \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
+  apply (rule wp_pre)
+  unfolding scheduler_affects_equiv_def
+   apply (rule hoare_vcg_conj_lift)
+    defer
+    apply (clarsimp simp: arch_scheduler_affects_equiv_def)
+    apply (wpsimp wp: hoare_vcg_imp_lift' simp: scheduler_globals_frame_equiv_def)
+   apply (rule conjI)
+    prefer 2
+    apply clarsimp
+   defer
+   apply (rule_tac Q'="\<lambda>_. states_equiv_but_for_labels aag (\<lambda>l'. l' \<notin> reads_scheduler aag l) st"
+                in hoare_strengthen_post[rotated])
+    apply (clarsimp simp:)
+    apply (subst states_equiv_for_helper[OF domains_distinct])
+    apply (clarsimp simp: equiv_but_for_labels_def)
+   apply (wp states_equiv_but_for_labels_equiv_for_lift)
+   apply (wp lazy_fpu_restore_equiv_but_for_labels)
+  apply (subst (asm) states_equiv_for_helper[OF domains_distinct])
+  apply (clarsimp simp: equiv_but_for_labels_def)
+  apply (clarsimp simp: cur_fpu_invisible)
+  done
+
+lemma vcpu_switch_scheduler_affects_equiv:
+  assumes wellformed: "pas_wellformed_noninterference aag"
+  notes domains_distinct = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows
+    "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
+      K (\<forall>vr. vopt = Some vr \<longrightarrow> pasObjectAbs aag vr \<notin> reads_scheduler aag l) and
+      scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and
+      invs and cur_vcpu_in_cur_domain and valid_silc_label aag and pas_refined aag\<rbrace>
+     vcpu_switch vopt
+     \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
+  apply (unfold scheduler_affects_equiv_def2[OF domains_distinct])
+  apply (wp states_equiv_but_for_labels_equiv_for_lift)
+    apply (wp vcpu_switch_equiv_but_for_labels)
+   apply (unfold scheduler_affects_inv_def arch_scheduler_affects_equiv_def)
+   apply simp
+   apply wps
+   apply wpsimp
+  apply simp
+  using wellformed apply (clarsimp simp: vcpu_invisible)
+  done
+
+lemma tcb_controls_associated_vcpu:
+  "\<lbrakk> pas_refined aag s; get_tcb t s = Some tcb; tcb_vcpu (tcb_arch tcb) = Some v \<rbrakk>
+     \<Longrightarrow> (t, Control, v) \<in> state_objs_to_policy s"
+  by (fastforce simp: sbta_href state_objs_to_policy_def state_hyp_refs_of_def get_tcb_def
+                dest: pas_refined_mem is_subject_trans split: option.splits kernel_object.splits)+
+
+lemma associated_vcpu_invisible:
+  assumes nrs: "\<not> reads_scheduler_cur_domain aag l s"
+  and pwn: "pas_wellformed_noninterference aag"
+  shows
+  "\<lbrakk> pasObjectAbs aag t \<notin> reads_scheduler aag l;
+     pas_refined aag s; valid_silc_label aag s; invs s;
+     get_tcb t s = Some tcb; tcb_vcpu (tcb_arch tcb) = Some vr \<rbrakk>
+    \<Longrightarrow> pasObjectAbs aag vr \<notin> reads_scheduler aag l"
+  apply (frule (2) tcb_controls_associated_vcpu)
+  apply (prop_tac "pasObjectAbs aag t \<noteq> SilcLabel")
+   apply (fastforce simp: valid_silc_label_def obj_at_def is_cap_table_def get_tcb_Some)
+  apply (drule (1) pas_refined_mem)
+  apply (drule aag_wellformed_Control)
+  using pwn apply (fastforce simp: pas_wellformed_noninterference_def)
+  apply simp
   done
 
 lemma arch_switch_to_thread_unobservable[Scheduler_IF_assms]:
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows
   "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
-    scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and invs\<rbrace>
+    (\<lambda>s. pasObjectAbs aag t \<notin> reads_scheduler aag l) and
+    scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and
+    invs and cur_vcpu_in_cur_domain and cur_fpu_in_cur_domain and
+    valid_silc_label aag and pas_refined aag\<rbrace>
    arch_switch_to_thread t
    \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
   apply (simp add: arch_switch_to_thread_def)
-  apply (wp set_vm_root_scheduler_affects_equiv | simp)+
+  apply (wp set_vm_root_scheduler_affects_equiv lazy_fpu_restore_scheduler_affects_equiv
+            vcpu_switch_scheduler_affects_equiv | simp)+
+  apply clarsimp
+  apply (rule conjI)
+   prefer 2
+   apply fastforce
+  using wellformed apply (clarsimp simp: associated_vcpu_invisible)
   done
 
 (* Can split, but probably more effort to generalise *)
@@ -301,7 +822,7 @@ lemma next_domain_midstrength_equiv_scheduler[Scheduler_IF_assms]:
   apply (clarsimp simp: equiv_for_def equiv_asid_def equiv_asids_def Let_def scheduler_equiv_def
                         globals_equiv_scheduler_def silc_dom_equiv_def domain_fields_equiv_def
                         weak_scheduler_affects_equiv_def midstrength_scheduler_affects_equiv_def
-                        states_equiv_for_def idle_equiv_def)
+                        states_equiv_for_def idle_equiv_def equiv_hyp_def equiv_fpu_def cur_fpu_for_def get_tcb_def)
   done
 
 lemma resetTimer_irq_state[wp]:
@@ -309,6 +830,26 @@ lemma resetTimer_irq_state[wp]:
   apply (simp add: resetTimer_def machine_op_lift_def machine_rest_lift_def)
   apply (wp | wpc| simp)+
   done
+
+lemma dmo_resetTimer_underlying_memory[wp]:
+  "do_machine_op resetTimer \<lbrace>\<lambda>s. P (underlying_memory (machine_state s))\<rbrace>"
+  by (wpsimp wp: dmo_wp)
+
+lemma dmo_resetTimer_device_state[wp]:
+  "do_machine_op resetTimer \<lbrace>\<lambda>s. P (device_state (machine_state s))\<rbrace>"
+  by (wpsimp wp: dmo_wp)
+
+lemma dmo_resetTimer_vcpu_state[wp]:
+  "do_machine_op resetTimer \<lbrace>\<lambda>s. P (vcpu_state (machine_state s))\<rbrace>"
+  by (wpsimp wp: dmo_wp)
+
+lemma dmo_resetTimer_fpu_state[wp]:
+  "do_machine_op resetTimer \<lbrace>\<lambda>s. P (fpu_state (machine_state s))\<rbrace>"
+  by (wpsimp wp: dmo_wp)
+
+lemma dmo_resetTimer_tcb_cur_fpu_of[wp]:
+  "do_machine_op resetTimer \<lbrace>\<lambda>s. P (tcb_cur_fpu_of s)\<rbrace>"
+  by (wpsimp wp: dmo_wp simp: comp_def)
 
 lemma dmo_resetTimer_reads_respects_scheduler[Scheduler_IF_assms]:
   "reads_respects_scheduler aag l \<top> (do_machine_op resetTimer)"
@@ -318,9 +859,9 @@ lemma dmo_resetTimer_reads_respects_scheduler[Scheduler_IF_assms]:
         apply (wpsimp wp: dmo_wp)
        apply ((wp silc_dom_lift dmo_wp | simp)+)[5]
   apply (rule scheduler_affects_equiv_unobservable)
-        apply (simp add: states_equiv_for_def[abs_def] equiv_for_def equiv_asids_def equiv_asid_def)
-        apply (rule hoare_pre)
-         apply (wp  | simp add: arch_scheduler_affects_equiv_def | wp dmo_wp)+
+  unfolding states_equiv_for_def[abs_def]
+        apply (wp equiv_for_lift equiv_machine_state_lift equiv_asids_lift equiv_hyp_lift equiv_fpu_lift)+
+  apply (wpsimp wp: dmo_wp simp: arch_scheduler_affects_equiv_def)
   done
 
 lemma ackInterrupt_reads_respects_scheduler[Scheduler_IF_assms]:
@@ -354,44 +895,686 @@ lemma thread_set_scheduler_affects_equiv[Scheduler_IF_assms, wp]:
    apply (clarsimp simp: arch_scheduler_affects_equiv_def)
    apply (elim states_equiv_forE equiv_forE)
    apply (rule states_equiv_forI,simp_all add: equiv_for_def equiv_asids_def equiv_asid_def)
-   apply (clarsimp simp: obj_at_def)
+    apply (clarsimp simp: obj_at_def)
+   apply (clarsimp simp: equiv_fpu_def equiv_for_def cur_fpu_for_def get_tcb_def)
   apply (clarsimp simp: idle_context_def get_tcb_def
                   split: option.splits kernel_object.splits)
   apply (subst arch_tcb_update_aux)
   apply simp
   apply (subgoal_tac "s = (s\<lparr>kheap := (kheap s)(idle_thread s \<mapsto> TCB y)\<rparr>)", simp)
   apply (rule state.equality)
-            apply (rule ext)
-            apply simp+
+                  apply (rule ext)
+                  apply simp+
   done
 
-lemma set_object_reads_respects_scheduler[Scheduler_IF_assms, wp]:
-  "reads_respects_scheduler aag l \<top> (set_object ptr obj)"
-  unfolding equiv_valid_def2 equiv_valid_2_def
-  by (auto simp: set_object_def bind_def get_def put_def return_def get_object_def assert_def
-                 fail_def gets_def scheduler_equiv_def domain_fields_equiv_def equiv_for_def
-                 globals_equiv_scheduler_def arch_globals_equiv_scheduler_def silc_dom_equiv_def
-                 scheduler_affects_equiv_def arch_scheduler_affects_equiv_def
-                 scheduler_globals_frame_equiv_def identical_kheap_updates_def
-          intro: states_equiv_for_identical_kheap_updates idle_equiv_identical_kheap_updates)
+
+lemma thread_set_reads_respects_scheduler[Scheduler_IF_assms]:
+  "reads_respects_scheduler aag l (valid_arch_state and K (valid_tcb_context_update f))
+                                  (thread_set f t)"
+  apply (rule gen_asm_ev)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  unfolding thread_set_def gets_the_def gets_def get_def put_def return_def fail_def
+            set_object_def get_object_def assert_def assert_opt_def
+  apply (clarsimp simp: bind_def split: option.splits if_splits)
+  apply (clarsimp simp: get_tcb_ko_at obj_at_def)
+  unfolding valid_tcb_context_update_def
+  apply (rename_tac s' tcb tcb')
+  apply (erule_tac x=tcb in allE)
+  apply (erule_tac x=tcb' in allE)
+  apply (rule conjI)
+   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def)
+   apply (intro conjI)
+     apply (clarsimp simp: valid_global_arch_objs_def arch_globals_equiv_scheduler_def)
+    apply (clarsimp simp: idle_equiv_def tcb_at_def get_tcb_def arch_tcb_context_get_def)
+   apply (clarsimp simp: silc_dom_equiv_def equiv_for_def)
+  apply (clarsimp simp: scheduler_affects_equiv_def)
+  apply (intro conjI)
+  apply (clarsimp simp: states_equiv_for_def equiv_for_def)
+  apply (intro conjI; clarsimp?)
+    apply (clarsimp simp: equiv_asids_def equiv_asid_def obj_at_def)
+   apply (clarsimp simp: equiv_fpu_def equiv_for_def cur_fpu_for_def get_tcb_def arch_tcb_context_set_def arch_tcb_context_get_def)
+  apply (clarsimp simp: scheduler_globals_frame_equiv_def arch_scheduler_affects_equiv_def)
+  done
 
 lemma arch_activate_idle_thread_reads_respects_scheduler[Scheduler_IF_assms, wp]:
   "reads_respects_scheduler aag l \<top> (arch_activate_idle_thread rv)"
   unfolding arch_activate_idle_thread_def by wpsimp
 
-lemma arch_prepare_next_domain_ev[Scheduler_IF_assms]:
-  "equiv_valid_inv I A (\<lambda>_. True) arch_prepare_next_domain"
-  unfolding arch_prepare_next_domain_def by wp
+lemma tcb_visible:
+  "\<lbrakk> reads_scheduler_cur_domain aag l s; pas_refined aag s;
+     pas_domains_distinct aag; in_cur_domain t s; tcb_at t s \<rbrakk>
+    \<Longrightarrow> pasObjectAbs aag t \<in> reads_scheduler aag l"
+  apply (drule tcb_at_ko_at, clarsimp)
+  apply (drule ko_at_etcbD)
+  apply (frule (1) tcb_domain_wellformed)
+  apply (prop_tac "etcb_domain (etcb_of tcb) = cur_domain s")
+   apply (clarsimp simp: in_cur_domain_def)
+   apply (clarsimp simp: etcbs_of'_def etcb_at'_def split: option.splits kernel_object.splits)
+  apply (clarsimp simp: pas_domains_distinct_def)
+  apply (erule_tac x="cur_domain s" in allE)
+  apply clarsimp
+  done
+
+lemma associated_vcpu_visible:
+  assumes nrs: "reads_scheduler_cur_domain aag l s"
+  and pwn: "pas_wellformed_noninterference aag"
+  shows
+  "\<lbrakk> pasObjectAbs aag t \<in> reads_scheduler aag l;
+     pas_refined aag s; valid_silc_label aag s; invs s;
+     get_tcb t s = Some tcb; tcb_vcpu (tcb_arch tcb) = Some vr \<rbrakk>
+    \<Longrightarrow> pasObjectAbs aag vr \<in> reads_scheduler aag l"
+  apply (frule (2) tcb_controls_associated_vcpu)
+  apply (prop_tac "pasObjectAbs aag t \<noteq> SilcLabel")
+   apply (fastforce simp: valid_silc_label_def obj_at_def is_cap_table_def get_tcb_Some)
+  apply (drule (1) pas_refined_mem)
+  apply (drule aag_wellformed_Control)
+  using pwn apply (fastforce simp: pas_wellformed_noninterference_def)
+  apply simp
+  done
+
+lemma vcpu_visible:
+  assumes rs: "reads_scheduler_cur_domain aag l s"
+  and wellformed: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows
+  "\<lbrakk> pas_refined aag s; valid_silc_label aag s;
+     invs s; current_vcpu s = Some (vr,b); cur_vcpu_in_cur_domain s \<rbrakk>
+    \<Longrightarrow> pasObjectAbs aag vr \<in> reads_scheduler aag l"
+  apply (prop_tac "cur_vcpu s")
+   apply (erule invs_cur_vcpu)
+  apply (clarsimp simp: cur_vcpu_def opt_pred_def split: option.splits)
+  apply (clarsimp simp: cur_vcpu_in_cur_domain_def cur_vcpu_tcb_def)
+  apply (clarsimp simp: opt_map_def split: option.splits)
+  apply (rename_tac t vcpu)
+  apply (prop_tac "tcb_at t s")
+   apply (drule invs_valid_objs)
+   apply (erule (1) valid_objsE)
+   apply (clarsimp simp: valid_obj_def valid_vcpu_def obj_at_def)
+  apply (frule (2) tcb_visible[OF rs _ domains_distinct])
+  apply (frule_tac vcpu=vcpu in vcpu_controls_associated_tcb)
+    apply (fastforce simp: opt_map_def split: option.splits)
+   apply simp
+  apply (prop_tac "pasObjectAbs aag vr \<noteq> SilcLabel")
+   apply (fastforce simp: valid_silc_label_def obj_at_def is_cap_table_def)
+  apply (drule (1) pas_refined_mem)
+  apply (drule aag_wellformed_Control)
+  using wellformed apply (fastforce simp: pas_wellformed_noninterference_def)
+  apply simp
+  done
+
+lemma gets_current_vcpu_weak_reads_respects_scheduler:
+  assumes wellformed[simp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows
+  "weak_reads_respects_scheduler aag l
+     (reads_scheduler_cur_domain aag l and pas_refined aag and valid_silc_label aag
+                                       and invs and cur_vcpu_in_cur_domain)
+     (gets (arm_current_vcpu \<circ> arch_state))"
+  apply (wp gets_ev'')
+   prefer 2
+   apply assumption
+  apply clarsimp
+  apply (prop_tac "equiv_for (\<lambda>vr. pasObjectAbs aag vr \<in> reads_scheduler aag l) cur_vcpu_of s t")
+   apply (clarsimp simp: weak_scheduler_affects_equiv_def states_equiv_for_def equiv_hyp_def)
+  apply (case_tac "\<exists>vr b. current_vcpu s = Some (vr,b)", clarsimp)
+   apply (subgoal_tac "pasObjectAbs aag vr \<in> reads_scheduler aag l")
+    apply (fastforce simp: equiv_for_def cur_vcpu_of_def split: if_splits option.splits)
+   apply (erule vcpu_visible)
+        apply simp+
+  apply (case_tac "\<exists>vr b. current_vcpu t = Some (vr,b)", clarsimp)
+   apply (subgoal_tac "pasObjectAbs aag vr \<in> reads_scheduler aag l")
+    apply (fastforce simp: equiv_for_def cur_vcpu_of_def split: if_splits option.splits)
+  apply (erule_tac s=t in vcpu_visible)
+        apply simp+
+  done
+
+lemma vcpu_disable_None_reads_respects_l:
+  "reads_respects_l aag l (\<lambda>s. \<exists>vr. current_vcpu s = Some (vr,True)) (vcpu_disable None)"
+  apply (simp only: vcpu_disable_def fun_app_def bind_assoc_helper vcpu_save_vgic_defs[symmetric] vcpu_save_lrs_helper)
+  apply (clarsimp simp: dmo_distr)
+  apply wpsimp
+  done
+
+lemma vcpu_disable_globals_equiv_scheduler[wp]:
+  "\<lbrace>valid_arch_state and globals_equiv_scheduler s\<rbrace> vcpu_disable vr \<lbrace>\<lambda>_. globals_equiv_scheduler s\<rbrace>"
+  by (wp globals_equiv_scheduler_inv' | fastforce)+
+
+lemma vcpu_disable_None_weak_reads_respects_scheduler:
+  "weak_reads_respects_scheduler aag l
+     (\<lambda>s. valid_arch_state s \<and> valid_silc_label aag s \<and> (\<exists>vr. current_vcpu s = Some (vr,True)))
+     (vcpu_disable None)"
+  apply (rule equiv_valid_guard_imp)
+  apply (rule weak_reads_respects_scheduler_from_labels[where Q="valid_arch_state and valid_silc_label aag"])
+         apply (rule vcpu_disable_None_reads_respects_l)
+        apply (wpsimp wp: domain_fields_equiv_lift)+
+  done
+
+lemma modify_current_vcpu_None_reads_respects_l[wp]:
+  "reads_respects_l aag l \<top> (modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_current_vcpu := None\<rparr>\<rparr>))"
+  apply (wpsimp wp: modify_ev)
+  apply (clarsimp simp: states_equiv_for_def equiv_for_def)
+  apply (intro conjI)
+    apply (auto simp: equiv_asids_def equiv_asid_def)[1]
+   apply (clarsimp simp: equiv_hyp_def equiv_for_def cur_vcpu_of_def split: option.split)
+  apply (auto simp: equiv_fpu_def equiv_for_def cur_fpu_for_def get_tcb_def)
+  done
+
+lemma disable_current_vcpu_weak_reads_respects_scheduler:
+  "weak_reads_respects_scheduler aag l \<top> (modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_current_vcpu := None\<rparr>\<rparr>))"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule weak_reads_respects_scheduler_from_labels)
+  by (wpsimp wp: domain_fields_equiv_lift simp: globals_equiv_scheduler_def arch_globals_equiv_scheduler_def)+
+
+lemma vcpu_disable_None_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+   vcpu_disable None \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vcpu_disable_def
+  apply (clarsimp simp: dmo_distr)
+  apply wpsimp
+  done
+
+lemma modify_current_vcpu_equiv_but_for_labels'':
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<notin> L) s = None\<rbrace>
+   modify (\<lambda>s. s\<lparr>arch_state := arch_state s\<lparr>arm_current_vcpu := None\<rparr>\<rparr>)
+   \<lbrace>\<lambda>_ s. equiv_but_for_labels aag L st s\<rbrace>"
+  apply wp
+  apply (clarsimp simp: cur_vcpu_for_def equiv_but_for_labels_def states_equiv_for_def equiv_for_def)
+  apply (intro conjI)
+    apply (clarsimp simp: equiv_asids_def equiv_asid_def)
+   defer
+   apply (clarsimp simp: equiv_fpu_def equiv_for_def cur_fpu_for_def get_tcb_def)
+  apply (clarsimp simp: equiv_hyp_def equiv_for_def)
+  apply (intro context_conjI; clarsimp)
+  apply (erule_tac x=x in allE)+
+  apply clarsimp
+  apply (case_tac "\<exists>b. current_vcpu s = Some (x, b)")
+   apply clarsimp
+  apply (fastforce simp: cur_vcpu_of_def split: option.splits if_splits)
+  done
+
+lemma vcpu_invalidate_active_unobservable:
+  assumes wellformed: "pas_wellformed_noninterference aag"
+  notes domains_distinct = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows
+    "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
+      scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and
+      invs and cur_vcpu_in_cur_domain and valid_silc_label aag and pas_refined aag\<rbrace>
+     vcpu_invalidate_active
+     \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
+  apply (simp add: vcpu_invalidate_active_def)
+  apply (unfold scheduler_affects_equiv_def2[OF domains_distinct])
+  supply modify_wp[wp del]
+  apply (wp states_equiv_but_for_labels_equiv_for_lift modify_current_vcpu_equiv_but_for_labels'' | wpc)+
+    apply clarsimp
+    apply (clarsimp simp: cur_vcpu_for_def del: notI)
+    apply (prop_tac "cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<in> reads_scheduler aag l) s = None")
+     apply assumption
+    apply (clarsimp simp: cur_vcpu_for_def)
+   prefer 2
+   apply (rule conjI)
+    defer 2
+    apply clarsimp
+    apply (case_tac "current_vcpu s")
+     apply (clarsimp simp: cur_vcpu_for_def split: option.splits)
+    apply (clarsimp simp: cur_vcpu_for_def del: notI)
+    apply (rule vcpu_invisible[OF _ wellformed])
+         apply simp+
+   apply (simp add: scheduler_affects_inv_def arch_scheduler_affects_equiv_def)
+   apply (wpsimp wp: modify_wp hoare_vcg_imp_lift)
+  apply clarsimp
+  done
+
+lemma vcpu_invalidate_active_weak_scheduler_reads_respects:
+  assumes wellformed[wp,simp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows
+  "weak_reads_respects_scheduler aag l
+     (invs and ct_in_cur_domain and valid_cur_vcpu and pas_refined aag
+           and cur_vcpu_in_cur_domain and valid_silc_label aag)
+     vcpu_invalidate_active"
+  apply (rule equiv_valid_cases[where P="\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {}"])
+    prefer 3
+    apply (simp add: scheduler_equiv_def domain_fields_equiv_def)
+   prefer 2
+   defer
+   apply (unfold vcpu_invalidate_active_def)[1]
+   apply (rule equiv_valid_guard_imp)
+    apply (wpc | wp disable_current_vcpu_weak_reads_respects_scheduler
+                    vcpu_disable_None_weak_reads_respects_scheduler
+                    gets_current_vcpu_weak_reads_respects_scheduler)+
+   apply clarsimp
+  apply (rule equiv_valid_guard_imp)
+   apply (rule_tac weak_cur_domain_unobservable)
+   apply (rule reads_respects_scheduler_unobservable'')
+     apply (rule wp_pre)
+      apply (rule scheduler_equiv_lift' [OF globals_equiv_scheduler_inv'])
+           apply (wpsimp | erule conjunct1)+
+    apply (rule wp_pre)
+     apply (wp vcpu_invalidate_active_unobservable)
+    apply clarsimp
+    apply (clarsimp simp: scheduler_equiv_def scheduler_affects_equiv_def domain_fields_equiv_def)
+    apply assumption
+   apply clarsimp
+   apply assumption
+  apply clarsimp
+  apply auto
+  done
+
+lemma gets_arm_current_vcpu_reads_respects_l:
+  "reads_respects_l aag l (\<lambda>s. cur_vcpu_for (l o pasObjectAbs aag) s \<noteq> None)
+                        (gets (arm_current_vcpu \<circ> arch_state))"
+  apply (wp gets_ev'')
+   prefer 2
+   apply assumption
+  apply clarsimp
+  apply (clarsimp simp: states_equiv_for_def equiv_hyp_def equiv_for_def)
+  apply (fastforce simp: equiv_hyp_def equiv_for_def cur_vcpu_of_def split: if_splits option.splits)
+  done
+
+lemma vcpu_save_weak_reads_respects_scheduler:
+  "weak_reads_respects_scheduler aag l
+     (\<lambda>s. current_vcpu s = cv \<and> valid_arch_state s \<and> valid_silc_label aag s) (vcpu_save cv)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule weak_reads_respects_scheduler_from_labels)
+         apply (rule vcpu_save_reads_respects_l)
+        apply (wpsimp wp: domain_fields_equiv_lift globals_equiv_scheduler_inv' vcpu_save_silc_dom_equiv | erule conjunct1)+
+  apply (clarsimp simp: valid_arch_state_def)
+  done
+
+crunch vcpu_save
+  for pas_refined[wp]: "pas_refined aag"
+  (simp: pas_refined_def state_objs_to_policy_def ignore: vcpu_save)
+
+crunch vcpu_save
+  for cur_vcpu_in_cur_domain[wp]: cur_vcpu_in_cur_domain
+  (wp: cur_vcpu_in_cur_domain_lift)
+
+lemma vcpu_invalidate_active_unobservable':
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows
+    "\<lbrace>\<lambda>s. \<not> reads_scheduler_cur_domain aag l s \<and>
+           scheduler_affects_equiv aag l st s \<and>
+           cur_domain st = cur_domain s \<and>
+           cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<in> reads_scheduler aag l) s = None\<rbrace>
+     vcpu_invalidate_active
+     \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
+  apply (simp add: vcpu_invalidate_active_def)
+  apply (unfold scheduler_affects_equiv_def2[OF domains_distinct])
+  supply modify_wp[wp del]
+  apply (wp states_equiv_but_for_labels_equiv_for_lift modify_current_vcpu_equiv_but_for_labels'' | wpc)+
+    apply clarsimp
+    apply (clarsimp simp: cur_vcpu_for_def del: notI)
+    apply (prop_tac "cur_vcpu_for (\<lambda>x. pasObjectAbs aag x \<in> reads_scheduler aag l) s = None")
+     apply assumption
+    apply (clarsimp simp: cur_vcpu_for_def)
+   prefer 2
+   apply (rule conjI)
+    defer 2
+    apply clarsimp
+   apply (simp add: scheduler_affects_inv_def arch_scheduler_affects_equiv_def)
+   apply (wpsimp wp: modify_wp hoare_vcg_imp_lift)
+  apply clarsimp
+  done
+
+lemma vcpu_save_unobservable:
+  assumes domains_distinct: "pas_domains_distinct aag"
+  shows
+    "\<lbrace>\<lambda>s. \<not> reads_scheduler_cur_domain aag l s \<and>
+           scheduler_affects_equiv aag l st s \<and>
+           cur_domain st = cur_domain s \<and>
+          current_vcpu s = vopt \<and>
+          (\<exists>vr b. vopt = Some (vr,b) \<and> pasObjectAbs aag vr \<notin> reads_scheduler aag l)
+          \<rbrace>
+     vcpu_save vopt
+     \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
+  apply (unfold scheduler_affects_equiv_def2[OF domains_distinct])
+  supply modify_wp[wp del]
+  apply (wp states_equiv_but_for_labels_equiv_for_lift modify_current_vcpu_equiv_but_for_labels'' | wpc)+
+   apply (simp add: scheduler_affects_inv_def arch_scheduler_affects_equiv_def)
+   apply (wpsimp wp: modify_wp hoare_vcg_imp_lift)
+  apply clarsimp
+  done
+
+lemma vcpu_flush_unobservable:
+  assumes wellformed: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows
+    "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
+      scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and
+      invs and cur_vcpu_in_cur_domain and valid_silc_label aag and pas_refined aag\<rbrace>
+      vcpu_flush
+      \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
+  unfolding vcpu_flush_def
+  apply (wpsimp wp: vcpu_invalidate_active_unobservable' vcpu_save_unobservable)
+  apply (rule context_conjI)
+   prefer 2
+   apply (clarsimp simp: cur_vcpu_for_Some)
+  using wellformed apply (clarsimp simp: vcpu_invisible)
+  done
+
+lemma vcpu_flush_weak_scheduler_reads_respects:
+  assumes wellformed[wp,simp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows
+    "weak_reads_respects_scheduler aag l
+       (pas_refined aag and valid_silc_label aag and invs and ct_in_cur_domain
+                        and valid_cur_vcpu and cur_vcpu_in_cur_domain)
+       vcpu_flush"
+  apply (rule equiv_valid_cases[where P="\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {}"])
+    prefer 3
+    apply (simp add: scheduler_equiv_def domain_fields_equiv_def)
+   apply (simp add: vcpu_flush_def)
+   apply wp
+      apply (wpsimp wp: ct_in_cur_domain_lift when_ev valid_silc_label_lift
+                        vcpu_invalidate_active_weak_scheduler_reads_respects
+                        vcpu_save_weak_reads_respects_scheduler
+                        gets_current_vcpu_weak_reads_respects_scheduler)
+     apply (wp gets_current_vcpu_weak_reads_respects_scheduler)
+    apply wp
+   apply clarsimp
+  apply (rule equiv_valid_guard_imp)
+   apply (rule_tac weak_cur_domain_unobservable)
+   apply (rule reads_respects_scheduler_unobservable'')
+     apply (rule wp_pre)
+      apply (rule scheduler_equiv_lift' [OF globals_equiv_scheduler_inv'])
+           apply (wpsimp | erule conjunct1)+
+    apply (rule wp_pre)
+     apply (wp vcpu_flush_unobservable)
+    apply clarsimp
+    apply (clarsimp simp: scheduler_equiv_def scheduler_affects_equiv_def domain_fields_equiv_def)
+    apply assumption
+   apply clarsimp
+   apply assumption
+  apply clarsimp
+  apply auto
+  done
+
+lemma switch_local_fpu_owner_globals_equiv_scheduler[wp]:
+  "\<lbrace>invs and globals_equiv_scheduler s\<rbrace> switch_local_fpu_owner vr \<lbrace>\<lambda>_. globals_equiv_scheduler s\<rbrace>"
+  by (wp globals_equiv_scheduler_inv' switch_local_fpu_owner_globals_equiv | fastforce)+
+
+lemma vcpu_flush_globals_equiv_scheduler[wp]:
+  "\<lbrace>valid_arch_state and globals_equiv_scheduler s\<rbrace> vcpu_flush \<lbrace>\<lambda>_. globals_equiv_scheduler s\<rbrace>"
+  by (wp globals_equiv_scheduler_inv' vcpu_flush_globals_equiv | fastforce)+
+
+lemma arch_prepare_next_domain_globals_equiv_scheduler[Scheduler_IF_assms]:
+  "\<lbrace>invs and globals_equiv_scheduler st\<rbrace> arch_prepare_next_domain \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
+  unfolding arch_prepare_next_domain_def
+  by wpsimp
+
+lemma vcpu_invalidate_active_reads_respects_l:
+  "reads_respects_l aag l (\<lambda>s. cur_vcpu_for (l o pasObjectAbs aag) s \<noteq> None) vcpu_invalidate_active"
+  unfolding vcpu_invalidate_active_def
+  apply wp
+      apply (wpsimp wp: vcpu_disable_None_reads_respects_l)
+     apply wpsimp
+    apply (rule gets_arm_current_vcpu_reads_respects_l)
+   apply wpsimp
+  apply clarsimp
+  done
+
+lemma vcpu_invalidate_active_equiv_but_for_labels[wp]:
+  "\<lbrace>\<lambda>s. equiv_but_for_labels aag L st s \<and> (\<forall>vr b. current_vcpu s = Some (vr,b) \<longrightarrow> pasObjectAbs aag vr \<in> L)\<rbrace>
+   vcpu_invalidate_active
+   \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  unfolding vcpu_invalidate_active_def
+  apply (wpsimp wp: modify_current_vcpu_equiv_but_for_labels'')
+  apply (auto simp: cur_vcpu_for_def)
+  done
+
+lemma vcpu_flush_reads_respects_l[wp]:
+  "reads_respects_l aag l (valid_numlistregs) vcpu_flush"
+  apply (rule_tac P="\<lambda>s. cur_vcpu_for (l o pasObjectAbs aag) s \<noteq> None" in equiv_valid_cases)
+    prefer 3
+    apply (prop_tac "equiv_for (l o pasObjectAbs aag) cur_vcpu_of s t")
+     apply (clarsimp simp: states_equiv_for_def equiv_for_def equiv_hyp_def)
+    apply (rule iffI; clarsimp simp: equiv_for_def)
+     apply (erule_tac x=ptr in allE, clarsimp simp: cur_vcpu_of_def split: option.splits if_splits)
+    apply (erule_tac x=ptr in allE, clarsimp simp: cur_vcpu_of_def split: option.splits if_splits)
+  unfolding vcpu_flush_def
+   apply wp
+      apply (wpsimp wp: when_ev vcpu_invalidate_active_reads_respects_l)
+     apply (rule gets_arm_current_vcpu_reads_respects_l)
+    apply wpsimp
+   apply clarsimp
+  apply (subst pred_conj_comm)
+  apply (rule reads_respects_l_invisible[OF modifies_at_mostI])
+    apply wpsimp
+   apply wpsimp
+  apply clarsimp
+  done
+
+lemma invs_valid_numlistregs [elim!]:
+  "invs s \<Longrightarrow> valid_numlistregs s"
+  apply (drule invs_arch_state)
+  apply (simp add: valid_arch_state_def)
+  done
+
+lemma arch_prepare_next_domain_reads_respects_l:
+  "reads_respects_l aag l invs arch_prepare_next_domain"
+  unfolding arch_prepare_next_domain_def
+  apply wpsimp
+  apply fastforce
+  done
+
+crunch arch_prepare_next_domain
+  for domain_time[wp]: "\<lambda>s. P (domain_time s)"
+  and domain_index[wp]: "\<lambda>s. P (domain_index s)"
+  (simp : crunch_simps wp: crunch_wps)
+
+crunch arch_prepare_next_domain
+  for globals_equiv[wp]: "globals_equiv st"
+  (wp: valid_silc_label_lift)
+
+lemma arch_prepare_next_domain_weak_scheduler_reads_respects[Scheduler_IF_assms]:
+  "weak_reads_respects_scheduler aag l (invs and valid_silc_label aag) arch_prepare_next_domain"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule_tac Q="invs and valid_silc_label aag" in weak_reads_respects_scheduler_from_labels)
+         apply (rule arch_prepare_next_domain_reads_respects_l)
+        apply (wpsimp wp: domain_fields_equiv_lift  globals_equiv_scheduler_inv'[where P="invs"])+
+  done
+
+lemma gets_cur_fpu_of_reads_respects_l:
+  "reads_respects_l aag l (valid_cur_fpu and K (l (pasObjectAbs aag t))) (gets (\<lambda>s. cur_fpu_of s t))"
+  apply (wpsimp wp: gets_ev'')
+   prefer 2
+   apply (rule conjI)
+    apply assumption+
+  apply (prop_tac "equiv_fpu (\<lambda>x. l (pasObjectAbs aag x)) x xa")
+   apply (clarsimp simp: states_equiv_for_def)
+  apply (clarsimp simp: equiv_fpu_def2)
+  done
+
+lemma thread_get_reads_respects_l:
+  "reads_respects_l aag l (K (l (pasObjectAbs aag thread))) (thread_get f thread)"
+  unfolding thread_get_def fun_app_def
+  apply (wp gets_the_ev)
+  apply (auto simp: states_equiv_for_def equiv_for_def get_tcb_def)
+  done
+
+lemma lazy_fpu_restore_reads_respects_l[wp]:
+  "reads_respects_l aag l (valid_cur_fpu and K (l (pasObjectAbs aag t))) (lazy_fpu_restore t)"
+  unfolding lazy_fpu_restore_def
+  apply (subst gets_comp)
+  apply (unfold comp_def)
+  apply (wpsimp wp: gets_cur_fpu_of_reads_respects_l thread_get_reads_respects_l thread_get_wp')
+  done
+
+lemma set_vm_root_reads_respects_l[wp]:
+  "reads_respects_l aag l \<top> (set_vm_root t)"
+  apply (rule reads_respects_l_unobservable_unit_return)
+  apply (wp set_vm_root_states_equiv_for)
+  done
+
+lemma arch_switch_to_thread_reads_respects_l:
+  "reads_respects_l aag l (invs and  K (l (pasObjectAbs aag t))) (arch_switch_to_thread t)"
+  unfolding arch_switch_to_thread_def
+  apply (wpsimp wp: vcpu_switch_reads_respects_l)
+  apply (auto simp: states_equiv_for_def get_tcb_def equiv_for_def)
+  done
+
+lemma midstrength_reads_respects_scheduler_from_labels':
+  assumes ev: "\<And>L. reads_respects_l aag L (P (L o pasObjectAbs aag)) f"
+    and inv: "\<And>P. \<lbrace>\<lambda>s. P (idle_thread s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (idle_thread s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (irq_state_of_state s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (irq_state_of_state s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (work_units_completed s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (work_units_completed s)\<rbrace>"
+             "\<And>P. \<lbrace>\<lambda>s. P (cur_domain s) \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. P (cur_domain s)\<rbrace>"
+             "\<And>st. \<lbrace>\<lambda>s. domain_fields_equiv st s \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. domain_fields_equiv st s\<rbrace>"
+             "\<And>st. \<lbrace>\<lambda>s. globals_equiv_scheduler st s \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. globals_equiv_scheduler st s\<rbrace>"
+             "\<And>st. \<lbrace>\<lambda>s. silc_dom_equiv aag st s \<and> Q s\<rbrace> f \<lbrace>\<lambda>_ s. silc_dom_equiv aag st s\<rbrace>"
+  shows "equiv_valid_inv (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+                         (P (\<lambda>x. pasObjectAbs aag x \<in> reads_scheduler aag l) and Q) f"
+  apply (rule equiv_valid_inv_split)
+   apply (rule equiv_valid_rv_inv_lift)
+  unfolding scheduler_equiv_def
+     apply (wpsimp wp: inv)
+    apply (auto simp: domain_fields_equiv_sym globals_equiv_scheduler_sym silc_dom_equiv_sym)[2]
+  unfolding midstrength_scheduler_affects_equiv_def
+  apply (rule equiv_valid_inv_A_conjI)
+   apply (rule_tac equiv_valid_guard_imp)
+    apply (insert ev)[1]
+    apply fastforce
+   apply (clarsimp simp: comp_def)
+  apply (rule_tac Q=Q and Q'=Q in equiv_valid_2_guard_imp)
+    apply (rule equiv_valid_rv_inv_lift)
+      apply (wpsimp wp: inv hoare_vcg_imp_lift)+
+    apply auto
+  done
+
+lemma lazy_fpu_restore_unobservable:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows
+  "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
+    (\<lambda>s. pasObjectAbs aag t \<notin> reads_scheduler aag l) and
+    scheduler_equiv aag st and scheduler_affects_equiv aag l st and
+    invs and cur_fpu_in_cur_domain and valid_silc_label aag and pas_refined aag\<rbrace>
+   lazy_fpu_restore t
+   \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
+  by (wpsimp wp: set_vm_root_scheduler_affects_equiv
+                 lazy_fpu_restore_scheduler_affects_equiv
+                 vcpu_switch_scheduler_affects_equiv)
+
+lemma midstrength_cur_domain_unobservable':
+  "reads_respects_scheduler aag l (P and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)) f
+   \<Longrightarrow> equiv_valid_inv (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+         ((\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and P) f"
+  apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def scheduler_affects_equiv_def
+                        equiv_valid_def2 equiv_valid_2_def  midstrength_scheduler_affects_equiv_def)
+  apply (drule_tac x=s in spec)
+  apply (drule_tac x=t in spec)
+  apply clarsimp
+  apply (drule_tac x="(a,b)" in bspec,clarsimp+)
+  apply (drule_tac x="(aa,ba)" in bspec,clarsimp+)
+  done
+
+lemma lazy_fpu_restore_midstrength_scheduler_reads_respects:
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows
+  "equiv_valid_inv (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+                   ((\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)) and invs and
+                    pas_refined aag and valid_silc_label aag and cur_fpu_in_cur_domain)
+                   (lazy_fpu_restore t)"
+  apply (rule_tac P="reads_scheduler_cur_domain aag l" in equiv_valid_cases)
+    apply (rule equiv_valid_guard_imp)
+     apply (rule_tac Q="invs and valid_silc_label aag" in midstrength_reads_respects_scheduler_from_labels')
+            apply (rule equiv_valid_guard_imp)
+             apply (rule lazy_fpu_restore_reads_respects_l)
+            apply (clarsimp simp: comp_def)
+            apply assumption
+           apply (wpsimp wp: domain_fields_equiv_lift lazy_fpu_restore_globals_equiv globals_equiv_scheduler_inv' | erule conjunct1)+
+    apply (rule conjI)
+     apply clarsimp
+    apply (insert domains_distinct)
+    apply (clarsimp simp: pas_domains_distinct_def)
+    apply (erule_tac x="cur_domain s" in allE, clarsimp)
+   apply (rule midstrength_cur_domain_unobservable')
+   apply (rule reads_respects_scheduler_unobservable'')
+     apply (wp_pre)
+      apply (rule_tac P="invs and valid_silc_label aag" in scheduler_equiv_lift')
+           apply (wpsimp wp: arch_switch_to_thread_globals_equiv_scheduler
+                             lazy_fpu_restore_globals_equiv globals_equiv_scheduler_inv'
+                  | erule conjunct1)+
+    apply (wp lazy_fpu_restore_unobservable)
+    apply clarsimp
+    apply assumption
+   apply clarsimp
+   apply (rule conjI)
+    apply simp
+   apply (clarsimp simp: pas_domains_distinct_def)
+   apply (erule_tac x="cur_domain s" in allE, clarsimp)
+  apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def)
+  done
+
+lemma arch_switch_to_thread_midstrength_reads_respects_scheduler':
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows
+    "equiv_valid_inv (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+       ((\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)) and invs and pas_refined aag and
+        valid_silc_label aag and cur_vcpu_in_cur_domain and cur_fpu_in_cur_domain)
+       (arch_switch_to_thread t)"
+  apply (rule_tac P="reads_scheduler_cur_domain aag l" in equiv_valid_cases)
+    apply (rule equiv_valid_guard_imp)
+     apply (rule_tac Q="invs and valid_silc_label aag" in midstrength_reads_respects_scheduler_from_labels')
+            apply (rule equiv_valid_guard_imp)
+             apply (rule arch_switch_to_thread_reads_respects_l)
+            apply (clarsimp simp: comp_def)
+            apply assumption
+           apply (wpsimp wp: domain_fields_equiv_lift arch_switch_to_thread_globals_equiv_scheduler)+
+    apply (insert domains_distinct)
+    apply (clarsimp simp: pas_domains_distinct_def)
+    apply (erule_tac x="cur_domain s" in allE, clarsimp)
+   prefer 2
+   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def)
+  apply (rule midstrength_cur_domain_unobservable')
+  apply (rule reads_respects_scheduler_unobservable'')
+    apply (wp_pre)
+     apply (rule_tac P="invs and valid_silc_label aag" in scheduler_equiv_lift')
+          apply (wpsimp wp: arch_switch_to_thread_globals_equiv_scheduler globals_equiv_scheduler_inv'
+                 | erule conjunct1)+
+   apply (wp arch_switch_to_thread_unobservable)
+   apply clarsimp
+   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def)
+   apply assumption
+  apply clarsimp
+  apply (rule conjI, simp)
+  apply (clarsimp simp: pas_domains_distinct_def)
+  apply (erule_tac x="cur_domain s" in allE, clarsimp)
+  done
+
+lemma arch_switch_to_thread_midstrength_reads_respects_scheduler[Scheduler_IF_assms, wp]:
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+    shows "midstrength_reads_respects_scheduler aag l
+           (invs and pas_refined aag and valid_silc_label aag
+                 and cur_vcpu_in_cur_domain and cur_fpu_in_cur_domain
+                 and (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
+           (do _ <- arch_switch_to_thread t;
+               _ <- modify (cur_thread_update (\<lambda>_. t));
+               modify (scheduler_action_update (\<lambda>_. resume_cur_thread))
+            od)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule bind_ev_general)
+     apply (fold set_scheduler_action_def)
+     apply (rule store_cur_thread_fragment_midstrength_reads_respects)
+    apply (rule arch_switch_to_thread_midstrength_reads_respects_scheduler')
+    apply wpsimp+
+  done
+
+definition cur_hyp_in_cur_domain where
+  "cur_hyp_in_cur_domain \<equiv> cur_vcpu_in_cur_domain"
 
 end
 
+arch_requalify_consts cur_hyp_in_cur_domain cur_fpu_in_cur_domain
+
 
 global_interpretation Scheduler_IF_2?:
-  Scheduler_IF_2 arch_globals_equiv_scheduler arch_scheduler_affects_equiv
+  Scheduler_IF_2 arch_globals_equiv_scheduler arch_scheduler_affects_equiv _ cur_hyp_in_cur_domain cur_fpu_in_cur_domain
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Scheduler_IF_assms)?)
+    by (unfold_locales; (unfold cur_hyp_in_cur_domain_def)?; (fact Scheduler_IF_assms)?)
 qed
 
 

--- a/proof/infoflow/AARCH64/ArchSyscall_IF.thy
+++ b/proof/infoflow/AARCH64/ArchSyscall_IF.thy
@@ -8,6 +8,8 @@ theory ArchSyscall_IF
 imports Syscall_IF
 begin
 
+(* FIXME AARCH64 IF: clean and refactor theory *)
+
 context Arch begin global_naming AARCH64
 
 named_theorems Syscall_IF_assms
@@ -65,18 +67,125 @@ lemma arch_mask_irq_signal_globals_equiv[Syscall_IF_assms, wp]:
   "arch_mask_irq_signal irq \<lbrace>globals_equiv st\<rbrace>"
   by wpsimp
 
+lemma vppi_update_valid_objs[wp]:
+  "vcpu_update vr (\<lambda>vcpu. vcpu\<lparr>vcpu_vppi_masked := f vcpu\<rparr>) \<lbrace>valid_objs\<rbrace>"
+  unfolding vcpu_update_def
+  by (wpsimp simp: valid_vcpu_def)
+
+lemma vppi_update_valid_arch_state[wp]:
+  "vcpu_update vr (\<lambda>vcpu. vcpu\<lparr>vcpu_vppi_masked := f vcpu\<rparr>) \<lbrace>valid_arch_state\<rbrace>"
+  unfolding vcpu_update_def
+  apply (wpsimp wp: set_vcpu_valid_arch_eq_hyp get_vcpu_wp)
+  apply (auto simp: obj_at_def opt_map_def vcpu_tcb_refs_def split: option.splits)
+  done
+
+lemma vgic_update_valid_objs[wp]:
+  "vcpu_update vr (\<lambda>vcpu. vcpu\<lparr>vcpu_vgic := f vcpu\<rparr>) \<lbrace>valid_objs\<rbrace>"
+  unfolding vcpu_update_def
+  by (wpsimp simp: valid_vcpu_def)
+
+lemma vgic_update_valid_arch_state[wp]:
+  "vcpu_update vr (\<lambda>vcpu. vcpu\<lparr>vcpu_vgic := f vcpu\<rparr>) \<lbrace>valid_arch_state\<rbrace>"
+  unfolding vcpu_update_def
+  apply (wpsimp wp: set_vcpu_valid_arch_eq_hyp get_vcpu_wp)
+  apply (auto simp: obj_at_def opt_map_def vcpu_tcb_refs_def split: option.splits)
+  done
+
+crunch vcpu_update
+  for valid_global_objs[wp]: valid_global_objs
+  (wp: crunch_wps  simp: crunch_simps)
+
+lemma vppi_event_globals_equiv[wp]:
+  "\<lbrace>globals_equiv st and invs\<rbrace> vppi_event irq \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding vppi_event_def
+  apply (wpsimp wp: handle_fault_globals_equiv gts_wp hoare_vcg_all_lift hoare_drop_imps
+              simp: crunch_simps split_del: if_split)
+  apply (auto simp: valid_fault_def)
+  done
+
+lemma vgic_maintenance_globals_equiv[wp]:
+  "\<lbrace>globals_equiv st and invs\<rbrace> vgic_maintenance \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding vgic_maintenance_def vgic_update_lr_def vgic_update_def
+  apply (wpsimp wp: handle_fault_globals_equiv gts_wp hoare_vcg_all_lift hoare_drop_imps dmo_globals_equiv
+         split_del: if_split simp: crunch_simps valid_fault_def)
+  apply auto
+  done
+
 lemma handle_reserved_irq_globals_equiv[Syscall_IF_assms, wp]:
-  "handle_reserved_irq irq \<lbrace>globals_equiv st\<rbrace>"
-  unfolding handle_reserved_irq_def by wpsimp
+  "\<lbrace>globals_equiv st and invs\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding handle_reserved_irq_def
+  by wpsimp
+
+lemma gets_compE:
+  "doE x <- liftE (gets f);
+      m (g x)
+   odE =
+   doE x <- liftE (gets (g \<circ> f));
+      m x
+    odE"
+  by (clarsimp simp: liftE_def bind_bindE_assoc gets_def return_bindE)
+
+definition is_subject_cur_vcpu_2 where
+  "is_subject_cur_vcpu_2 aag cf \<equiv> \<forall>ptr. cf = Some (ptr,True) \<longrightarrow> is_subject aag ptr"
+
+locale_abbrev is_subject_cur_vcpu where
+  "is_subject_cur_vcpu aag \<equiv> \<lambda>s. is_subject_cur_vcpu_2 aag (arm_current_vcpu (arch_state s))"
+
+lemmas is_subject_cur_vcpu_def = is_subject_cur_vcpu_2_def
+
+lemma active_vcpu_is_subject:
+  "\<lbrakk> pas_refined aag s; is_subject aag (cur_thread s);
+     valid_cur_vcpu s; schact_is_rct s; ct_in_cur_domain s \<rbrakk>
+     \<Longrightarrow> is_subject_cur_vcpu aag s"
+  apply (prop_tac "arch_tcb_at (\<lambda>itcb. itcb_vcpu itcb = active_cur_vcpu_of s) (cur_thread s) s")
+   apply (clarsimp simp: valid_cur_vcpu_def schact_is_rct_def)
+   apply (case_tac "cur_thread s = idle_thread s")
+    apply (auto simp: ct_in_cur_domain_resume_cur_thread_not_idle)[2]
+  apply (clarsimp simp: pred_tcb_at_def obj_at_def is_subject_cur_vcpu_def)
+  apply (clarsimp simp: active_cur_vcpu_of_def split: option.splits)
+  apply (erule associated_vcpu_is_subject)
+    apply (fastforce simp: get_tcb_ko_at obj_at_def)
+   apply auto
+  done
+
+lemma gets_current_vcpu_reads_respects:
+  "reads_respects aag l (\<lambda>s. pas_refined aag s \<and> valid_cur_vcpu s \<and> schact_is_rct s
+                                               \<and> ct_in_cur_domain s \<and> is_subject aag (cur_thread s))
+                        (gets ((\<lambda>a. \<exists>v. a = Some (v, True)) \<circ> (arm_current_vcpu \<circ> arch_state)))"
+  (is "reads_respects aag l ?P _")
+  apply (wpsimp wp: gets_ev''[where P="?P"])
+   apply (prop_tac "equiv_hyp (aag_can_read aag) s t")
+    apply (clarsimp simp: reads_equiv_def2 states_equiv_for_def equiv_hyp_def equiv_for_def)
+   apply (drule (4) active_vcpu_is_subject)+
+   apply (clarsimp simp: equiv_hyp_def equiv_for_def is_subject_cur_vcpu_def)
+   apply (rule iffI; erule ex_forward)
+    apply (erule_tac x=v in allE)+
+    apply (clarsimp simp: cur_vcpu_of_def split: option.splits if_splits)
+   apply (erule_tac x=v in allE)+
+   apply (clarsimp simp: cur_vcpu_of_def split: option.splits if_splits)
+  apply simp
+  done
 
 lemma handle_vm_fault_reads_respects[Syscall_IF_assms]:
-  "reads_respects aag l (K (is_subject aag thread)) (handle_vm_fault thread vmfault_type)"
-  unfolding handle_vm_fault_def
-  by (cases vmfault_type; wpsimp wp: dmo_read_stval_reads_respects)
+  "reads_respects aag l (pas_refined aag and valid_cur_hyp and schact_is_rct and ct_in_cur_domain
+                                         and is_subject aag \<circ> cur_thread and K (is_subject aag thread))
+                  (handle_vm_fault thread vmfault_type)"
+  unfolding handle_vm_fault_def fun_app_def valid_cur_hyp_def
+  apply (cases vmfault_type; clarsimp; subst gets_compE)
+  by (wpsimp wp: gets_current_vcpu_reads_respects as_user_reads_respects
+                    dmo_getESR_reads_respects dmo_getFAR_reads_respects
+                    dmo_addressTranslateS1_reads_respects
+              simp: det_getRestartPC)+
 
 lemma handle_hypervisor_fault_reads_respects[Syscall_IF_assms]:
-  "reads_respects aag l \<top> (handle_hypervisor_fault thread hypfault_type)"
-  by (cases hypfault_type; wpsimp)
+  assumes pas_domains_distinct[wp]: "pas_domains_distinct (aag :: 'a subject_label PAS)"
+  shows "reads_respects aag l (invs and pas_refined aag and pas_cur_domain aag
+                                    and is_subject aag \<circ> cur_thread and K (is_subject aag thread))
+                              (handle_hypervisor_fault thread hypfault_type)"
+  apply (cases hypfault_type)
+  apply (wpsimp wp: handle_fault_reads_respects dmo_getESR_reads_respects split_del: if_split)
+  apply (auto simp: valid_fault_def)
+  done
 
 lemma handle_vm_fault_globals_equiv[Syscall_IF_assms]:
   "\<lbrace>globals_equiv st and valid_arch_state and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
@@ -86,8 +195,11 @@ lemma handle_vm_fault_globals_equiv[Syscall_IF_assms]:
   by (cases vmfault_type; wpsimp wp: dmo_no_mem_globals_equiv)
 
 lemma handle_hypervisor_fault_globals_equiv[Syscall_IF_assms]:
-  "handle_hypervisor_fault thread hypfault_type \<lbrace>globals_equiv st\<rbrace>"
-  by (cases hypfault_type; wpsimp)
+  "\<lbrace>globals_equiv st and invs\<rbrace> handle_hypervisor_fault thread hypfault_type \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  apply (cases hypfault_type)
+  apply (wpsimp wp: handle_fault_globals_equiv split_del: if_split)+
+  apply (auto simp: valid_fault_def)
+  done
 
 crunch arch_activate_idle_thread, handle_spurious_irq
   for globals_equiv[Syscall_IF_assms, wp]: "globals_equiv st"
@@ -111,19 +223,42 @@ lemma decode_asid_pool_invocation_authorised_for_globals:
          and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)\<rbrace>
    decode_asid_pool_invocation label msg slot cap excaps
    \<lbrace>authorised_for_globals_arch_inv\<rbrace>, -"
-  unfolding authorised_for_globals_arch_inv_def decode_asid_pool_invocation_def
-  apply (simp add: split_def Let_def cong: if_cong split del: if_split)
-  apply wpsimp
-  done
+  unfolding authorised_for_globals_arch_inv_def decode_asid_pool_invocation_def Let_def
+  by wpsimp
 
 lemma decode_asid_control_invocation_authorised_for_globals:
   "\<lbrace>invs and cte_wp_at ((=) (ArchObjectCap cap)) slot
          and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)\<rbrace>
    decode_asid_control_invocation label msg slot cap excaps
    \<lbrace>authorised_for_globals_arch_inv\<rbrace>, -"
-  unfolding authorised_for_globals_arch_inv_def decode_asid_control_invocation_def
-  apply (simp add: split_def Let_def cong: if_cong split del: if_split)
-  apply wpsimp
+  unfolding authorised_for_globals_arch_inv_def decode_asid_control_invocation_def Let_def
+  by wpsimp
+
+definition is_pt_cap_typ :: "cap \<Rightarrow> pt_type \<Rightarrow> bool" where
+  "is_pt_cap_typ cap pt_t \<equiv>
+     arch_cap_fun_lift (\<lambda>acap. is_PageTableCap acap \<and> acap_pt_type acap = pt_t) False cap"
+
+(* FIXME AARCH64 IF: consolidate with pt_lookup_slot_cap_to *)
+lemma pt_lookup_slot_cap_to_lvl:
+  "\<lbrakk> invs s; \<exists>\<rhd>(max_pt_level, pt) s; is_aligned pt (pt_bits VSRootPT_T); vptr \<in> user_region;
+     pt_lookup_slot pt vptr (ptes_of s) = Some (level, slot) \<rbrakk>
+   \<Longrightarrow> \<exists>p cap. caps_of_state s p = Some cap \<and> is_pt_cap_typ cap (level_type level) \<and>
+               obj_refs cap = {table_base level slot} \<and> s \<turnstile> cap \<and> cap_asid cap \<noteq> None"
+  apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def)
+  apply (frule pt_walk_max_level)
+  apply (rename_tac pt_ptr asid vref)
+  apply (subgoal_tac "vs_lookup_table level asid vptr s = Some (level, pt_ptr)")
+   prefer 2
+   apply (drule pt_walk_level)
+   apply (clarsimp simp: vs_lookup_table_def in_omonad)
+  apply (frule_tac level=level in valid_vspace_objs_strongD[rotated]; clarsimp)
+  apply (drule vs_lookup_table_target[where level=level], simp)
+  apply (drule valid_vs_lookupD, erule vref_for_level_user_region; clarsimp)
+  apply (frule (1) cap_to_pt_is_pt_cap_and_type, simp)
+   apply (fastforce intro: valid_objs_caps)
+  apply (frule pts_of_Some_alignedD, fastforce)
+  apply (frule caps_of_state_valid, fastforce)
+  apply (fastforce simp: cap_asid_def is_cap_simps is_pt_cap_typ_def)
   done
 
 lemma decode_frame_invocation_authorised_for_globals:
@@ -132,40 +267,35 @@ lemma decode_frame_invocation_authorised_for_globals:
    decode_frame_invocation label msg slot cap excaps
    \<lbrace>authorised_for_globals_arch_inv\<rbrace>, -"
   unfolding authorised_for_globals_arch_inv_def authorised_for_globals_page_inv_def
-             decode_frame_invocation_def decode_fr_inv_map_def
-  apply (simp add: split_def Let_def cong: arch_cap.case_cong if_cong split del: if_split)
-  apply (wpsimp wp: check_vp_wpR)
-  apply (subgoal_tac
-          "(\<exists>a b. cte_wp_at (parent_for_refs (make_user_pte (addrFromPPtr x)
-                                                            (attribs_from_word (msg ! 2))
-                                                            (mask_vm_rights xa
-                                                               (data_to_rights (msg ! Suc 0))),
-                                              ba)) (a, b) s)", clarsimp)
+            decode_frame_invocation_def decode_fr_inv_map_def
+  apply (case_tac "invocation_type label = ArchInvocationLabel ARMPageMap \<and> is_FrameCap cap")
+   defer
+   apply (wpsimp simp: isPageFlushLabel_def Let_def decode_fr_inv_flush_def)
+  apply (simp add: is_FrameCap_def Let_def cong: arch_cap.case_cong if_cong)
+  apply (wpsimp wp: check_vp_wpR whenE_throwError_wp)
+  apply (prop_tac "\<not> user_vtop < msg ! 0 + mask (pageBitsForSize xb) \<longrightarrow> msg ! 0 \<in> user_region")
+   apply (clarsimp simp: user_region_def not_le)
+   apply (rule user_vtop_leq_canonical_user)
+   apply (simp add: vmsz_aligned_def not_less)
+   apply (drule is_aligned_no_overflow_mask)
+   apply simp
+  apply (case_tac "msg ! 0 \<in> user_region")
+   prefer 2
+   apply (fastforce dest: cte_wp_valid_cap simp: valid_cap_def wellformed_mapdata_def)
   apply (clarsimp simp: parent_for_refs_def cte_wp_at_caps_of_state)
   apply (frule vspace_for_asid_vs_lookup)
-  apply (frule_tac vptr="msg ! 0" in pt_lookup_slot_cap_to)
-      apply fastforce
-     apply (fastforce elim: vs_lookup_table_is_aligned)
-    apply (drule not_le_imp_less)
-    apply (frule order.strict_implies_order[where b=user_vtop])
-    apply (drule order.strict_trans[OF _ user_vtop_pptr_base])
-    apply (drule canonical_below_pptr_base_user)
-     apply (erule below_user_vtop_canonical)
-    apply (clarsimp simp: vmsz_aligned_def)
-    apply (drule is_aligned_no_overflow_mask)
-    apply (clarsimp simp: user_region_def)
-    apply (erule (1) dual_order.trans)
-   apply assumption
-  apply (fastforce simp: is_pt_cap_def is_PageTableCap_def split: option.splits)
-  done
+  using pt_lookup_slot_cap_to_lvl[where vptr="msg ! 0"]
+  by (fastforce dest: vs_lookup_table_is_aligned
+                simp: is_pt_cap_typ_def is_PageTableCap_def
+               split: option.splits)
 
 lemma decode_page_table_invocation_authorised_for_globals:
   "\<lbrace>invs and cte_wp_at ((=) (ArchObjectCap cap)) slot
          and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)\<rbrace>
    decode_page_table_invocation label msg slot cap excaps
    \<lbrace>authorised_for_globals_arch_inv\<rbrace>, -"
-  unfolding authorised_for_globals_arch_inv_def authorised_for_globals_page_table_inv_def
-            decode_page_table_invocation_def decode_pt_inv_map_def
+  unfolding decode_page_table_invocation_def decode_pt_inv_map_def
+            authorised_for_globals_arch_inv_def authorised_for_globals_page_table_inv_def
   apply (simp add: split_def Let_def cong: arch_cap.case_cong if_cong split del: if_split)
   apply (wpsimp cong: if_cong wp: hoare_vcg_if_lift2)
   apply (clarsimp simp: pt_lookup_slot_from_level_def pt_lookup_slot_def)
@@ -175,14 +305,38 @@ lemma decode_page_table_invocation_authorised_for_globals:
   apply (subgoal_tac "msg ! 0 \<in> user_region")
    apply (frule reachable_page_table_not_global; clarsimp?)
    apply (frule vs_lookup_table_is_aligned; clarsimp?)
-   apply (fastforce dest: global_pt_in_global_refs invs_arch_state simp: valid_arch_state_def)
-  apply (drule not_le_imp_less)
-  apply (frule order.strict_implies_order[where b=user_vtop])
-  apply (drule order.strict_trans[OF _ user_vtop_pptr_base])
-  apply (drule canonical_below_pptr_base_user)
-   apply (erule below_user_vtop_canonical)
-  apply clarsimp
+  apply (fastforce intro: user_vtop_leq_canonical_user simp: user_region_def)
   done
+
+lemma decode_sgi_signal_invocation_authorised_for_globals:
+  "\<lbrace>\<top>\<rbrace> decode_sgi_signal_invocation cap
+   \<lbrace>authorised_for_globals_arch_inv\<rbrace>, -"
+  unfolding decode_sgi_signal_invocation_def authorised_for_globals_arch_inv_def
+  by wpsimp
+
+lemma decode_smc_invocation_authorised_for_globals:
+  "\<lbrace>\<top>\<rbrace> decode_smc_invocation label args acap
+   \<lbrace>authorised_for_globals_arch_inv\<rbrace>, -"
+  unfolding decode_smc_invocation_def authorised_for_globals_arch_inv_def
+  by wpsimp
+
+lemma decode_vspace_invocation_authorised_for_globals:
+  "\<lbrace>invs and cte_wp_at ((=) (ArchObjectCap cap)) slot
+         and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)\<rbrace>
+   decode_vspace_invocation label msg slot cap excaps
+   \<lbrace>authorised_for_globals_arch_inv\<rbrace>, -"
+  unfolding decode_vspace_invocation_def decode_vs_inv_flush_def
+  by (wpsimp simp: Let_def authorised_for_globals_arch_inv_def)
+
+lemma decode_vcpu_invocation_authorised_for_globals:
+  "\<lbrace>invs and cte_wp_at ((=) (ArchObjectCap cap)) slot
+         and (\<lambda>s. \<forall>(cap, slot) \<in> set excaps. cte_wp_at ((=) cap) slot s)\<rbrace>
+   decode_vcpu_invocation label msg cap excaps
+   \<lbrace>authorised_for_globals_arch_inv\<rbrace>, -"
+  unfolding decode_vcpu_invocation_def decode_vcpu_set_tcb_def decode_vcpu_inject_irq_def
+            decode_vcpu_read_register_def decode_vcpu_write_register_def decode_vcpu_ack_vppi_def
+            range_check_def arch_check_irq_def authorised_for_globals_arch_inv_def
+  by (wpc | wpsimp wp: whenE_throwError_wp)+
 
 lemma decode_arch_invocation_authorised_for_globals[Syscall_IF_assms]:
   "\<lbrace>invs and cte_wp_at ((=) (ArchObjectCap cap)) slot
@@ -190,12 +344,27 @@ lemma decode_arch_invocation_authorised_for_globals[Syscall_IF_assms]:
    arch_decode_invocation label msg x_slot slot cap excaps
    \<lbrace>authorised_for_globals_arch_inv\<rbrace>, -"
   unfolding arch_decode_invocation_def
-  by (wpsimp wp: decode_asid_pool_invocation_authorised_for_globals
+  by (wpsimp wp: decode_sgi_signal_invocation_authorised_for_globals
+                 decode_smc_invocation_authorised_for_globals
+                 decode_vspace_invocation_authorised_for_globals
+                 decode_vcpu_invocation_authorised_for_globals
+                 decode_asid_pool_invocation_authorised_for_globals
                  decode_asid_control_invocation_authorised_for_globals
                  decode_frame_invocation_authorised_for_globals
                  decode_page_table_invocation_authorised_for_globals, fastforce)
 
-declare arch_prepare_set_domain_inv[Syscall_IF_assms]
+crunch vcpu_flush_if_current
+  for globals_equiv[wp]: "globals_equiv st"
+  (wp: crunch_wps simp: crunch_simps invs_arch_state)
+
+lemma arch_prepare_set_domain_globals_equiv[Syscall_IF_assms]:
+  "\<lbrace>globals_equiv st and invs\<rbrace> arch_prepare_set_domain t new_dom \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding arch_prepare_set_domain_def
+  by (wpsimp wp: fpu_release_globals_equiv)
+
+crunch arch_prepare_set_domain
+  for valid_arch_state[Syscall_IF_assms,wp]: valid_arch_state
+  (wp: hoare_drop_imps)
 
 end
 

--- a/proof/infoflow/AARCH64/ArchTcb_IF.thy
+++ b/proof/infoflow/AARCH64/ArchTcb_IF.thy
@@ -31,7 +31,6 @@ lemma cap_ne_global_pt:
   apply (unfold global_refs_def)
   apply clarsimp
   apply (unfold cap_range_def)
-  apply (drule valid_global_arch_objs_global_ptD)
   apply blast
   done
 
@@ -64,9 +63,23 @@ lemma arch_post_modify_registers_reads_respects_f[Tcb_IF_assms, wp]:
   "reads_respects_f aag l \<top> (arch_post_modify_registers cur t)"
   by wpsimp
 
+lemma reads_equiv_valid_inv_f:
+  assumes a: "reads_equiv_valid_inv A aag P f"
+  assumes b: "\<And>P. \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. P\<rbrace>"
+  shows "equiv_valid_inv (reads_equiv_f aag) A P f"
+  supply equiv_valid_2_def[simp] equiv_valid_def2[simp]
+  apply (clarsimp simp: reads_equiv_f_def)
+  apply (insert a, clarsimp)
+  apply (drule_tac x=s in spec, drule_tac x=t in spec, clarsimp)
+  apply (drule (1) bspec, clarsimp)
+  apply (drule (1) bspec, clarsimp)
+  apply (drule state_unchanged[OF b])+
+  by simp
+
 lemma arch_get_sanitise_register_info_reads_respects_f[Tcb_IF_assms, wp]:
-  "reads_respects_f aag l \<top> (arch_get_sanitise_register_info rv)"
-  by wpsimp
+  "reads_respects_f aag l (K (aag_can_read_or_affect aag l rv)) (arch_get_sanitise_register_info rv)"
+  unfolding arch_get_sanitise_register_info_def
+  by (wpsimp wp: reads_equiv_valid_inv_f)
 
 end
 
@@ -86,8 +99,8 @@ lemma valid_ipc_buffer_cap_is_nondevice_page_cap:
   by (clarsimp simp: valid_ipc_buffer_cap_def split: cap.splits arch_cap.splits)
 
 lemma is_valid_vtable_root_def2:
-  "is_valid_vtable_root c = (\<exists>r a. c = ArchObjectCap (PageTableCap r (Some a)))"
-  by (auto simp: is_valid_vtable_root_def split: cap.splits arch_cap.splits option.splits)
+  "is_valid_vtable_root c = (\<exists>r a. c = ArchObjectCap (PageTableCap r VSRootPT_T (Some a)))"
+  by (auto simp: is_valid_vtable_root_def split: cap.splits arch_cap.splits option.splits pt_type.splits)
 
 (* FIXME: Pretty general. Probably belongs somewhere else *)
 lemma invoke_tcb_thread_preservation[Tcb_IF_assms]:
@@ -246,15 +259,190 @@ lemma tc_reads_respects_f[Tcb_IF_assms]:
   apply (clarsimp cong: conj_cong)
   apply (intro conjI impI allI)
   (* slow *)
-  by (clarsimp simp: is_cap_simps is_cnode_or_valid_arch_def is_valid_vtable_root_def
-                     det_setRegister option.disc_eq_case[symmetric]
-              split: cap.splits arch_cap.splits option.split)+
+ by (clarsimp simp: is_cap_simps is_cnode_or_valid_arch_def is_valid_vtable_root_def
+                    det_setRegister option.disc_eq_case[symmetric]
+             split: cap.splits arch_cap.splits option.split pt_type.splits)+
+
+crunch lazy_fpu_restore
+  for cdt[wp]: "\<lambda>s. P (cdt s)"
+  and is_original_cap[wp]: "\<lambda>s. P (is_original_cap s)"
+  and interrupt_states[wp]: "\<lambda>s. P (interrupt_states s)"
+  and interrupt_irq_node[wp]: "\<lambda>s. P (interrupt_irq_node s)"
+  and ready_queues[wp]: "\<lambda>s. P (ready_queues s)"
+  and asid_pools_of[wp]: "\<lambda>s. P (asid_pools_of s)"
+  and asid_table[wp]: "\<lambda>s. P (asid_table s)"
+  and numlistregs[wp]: "\<lambda>s. P (numlistregs s)"
+  and vcpu_state[wp]: "\<lambda>s. P (vcpu_state (machine_state s))"
+  and underlying_memory[wp]: "\<lambda>s. P (underlying_memory (machine_state s))"
+  and device_state[wp]: "\<lambda>s. P (device_state (machine_state s))"
+  (wp: dmo_wp crunch_wps ignore: arch_thread_set)
+
+(* FIXME AARCH64 IF: consolidate cur_fpu_of and is_arch_cur_fpu *)
+lemma equiv_kheap_equiv_cur_fpu_of:
+  "cur_fpu_of s t = cur_fpu_for ((=) t) s"
+  by (clarsimp simp: cur_fpu_for_def is_arch_cur_fpu_def)
+
+lemma equiv_but_for_labels_guard_imp:
+  "\<lbrakk> equiv_but_for_labels aag L' st s; L' \<subseteq> L \<rbrakk>
+     \<Longrightarrow> equiv_but_for_labels aag L st s"
+  by (auto simp: equiv_but_for_labels_def elim!: states_equiv_for_guard_imp)
+
+definition is_subject_cur_fpu_2 where
+  "is_subject_cur_fpu_2 aag cf \<equiv> \<forall>ptr. cf = Some ptr \<longrightarrow> is_subject aag ptr"
+
+locale_abbrev is_subject_cur_fpu where
+  "is_subject_cur_fpu aag \<equiv> \<lambda>s. is_subject_cur_fpu_2 aag (arm_current_fpu_owner (arch_state s))"
+
+lemmas is_subject_cur_fpu_def = is_subject_cur_fpu_2_def
+
+lemma dmo_enableFpu_reads_respects[wp]:
+  "reads_respects aag l \<top> (do_machine_op enableFpu)"
+  unfolding enableFpu_def dmo_distr
+  apply wpsimp
+     apply (rule use_spec_ev)
+     apply (wpsimp wp: do_machine_op_reads_respects modify_ev)
+        apply (clarsimp simp: equiv_for_def)
+    apply (wpsimp wp: dmo_mol_reads_respects)+
+  done
+
+lemma dmo_disableFpu_reads_respects[wp]:
+  "reads_respects aag l \<top> (do_machine_op disableFpu)"
+  unfolding disableFpu_def dmo_distr
+  apply wpsimp
+     apply (rule use_spec_ev)
+     apply (wpsimp wp: do_machine_op_reads_respects modify_ev)
+        apply (clarsimp simp: equiv_for_def)
+    apply (wpsimp wp: dmo_mol_reads_respects)+
+  done
+
+lemma lazy_fpu_restore_reads_respects:
+  "reads_respects aag l (valid_cur_fpu and K (is_subject aag t)) (lazy_fpu_restore t)"
+  unfolding lazy_fpu_restore_def
+  apply (subst gets_comp)
+  apply (case_tac "aag_can_read_or_affect aag l t")
+     apply (wpsimp simp: lazy_fpu_restore_def wp: thread_get_reads_respects gets_ev'')
+     apply (prop_tac "valid_cur_fpu xa")
+      apply assumption
+     apply (prop_tac "valid_cur_fpu xb")
+      apply assumption
+     apply clarsimp
+     apply (prop_tac "equiv_for (aag_can_read_or_affect aag l) kheap xa xb")
+      apply (clarsimp simp: reads_equiv_def2 affects_equiv_def2 states_equiv_for_def equiv_for_disj)
+     apply (rename_tac s s')
+     apply (clarsimp simp: equiv_kheap_equiv_cur_fpu_of)
+     apply (rule equiv_kheap_equiv_cur_fpu_for)
+       apply (fastforce simp: equiv_for_def)
+      apply clarsimp+
+    apply wpsimp
+   apply (wpsimp wp: thread_get_reads_respects)
+  apply (wpsimp wp: thread_get_wp')
+   apply clarsimp
+  apply (rule gen_asm_ev)
+  apply clarsimp
+  done
 
 lemma arch_post_set_flags_reads_respects_f[Tcb_IF_assms]:
-  "reads_respects_f aag l \<top> (arch_post_set_flags t flags)"
-  unfolding arch_post_set_flags_def by wpsimp
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects_f aag l (silc_inv aag st and valid_cur_fpu and K (is_subject aag t)) (arch_post_set_flags t flags)"
+  unfolding arch_post_set_flags_def
+  apply (rule equiv_valid_guard_imp)
+   apply (wpsimp wp: when_ev reads_respects_f[OF fpu_release_reads_respects]
+                     reads_respects_f[OF lazy_fpu_restore_reads_respects])
+  apply fastforce
+  done
 
-declare arch_post_set_flags_inv[Tcb_IF_assms]
+lemma arch_tcb_context_get_cur_fpu_update[simp]:
+  "arch_tcb_context_get (tcb_arch tcb\<lparr>tcb_cur_fpu := fpu\<rparr>) = arch_tcb_context_get (tcb_arch tcb)"
+  by (simp add: arch_tcb_context_get_def)
+
+lemma globals_equiv_fpu_owner_update[simp]:
+  "globals_equiv st (s\<lparr>arch_state := arch_state s\<lparr>arm_current_fpu_owner := t\<rparr>\<rparr>)  =
+   globals_equiv st s"
+  by (auto simp add: globals_equiv_def idle_equiv_def)
+
+lemma set_arm_current_fpu_owner_globals_equiv[wp]:
+  "\<lbrace>globals_equiv st and valid_arch_state\<rbrace>
+   set_arm_current_fpu_owner t
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding set_arm_current_fpu_owner_def arch_thread_set_is_thread_set
+  by (wpsimp wp: thread_set_globals_equiv thread_set_valid_arch_state hoare_vcg_all_lift hoare_drop_imps
+       | fastforce simp: ran_tcb_cap_cases)+
+
+lemma dmo_enableFpu_globals_equiv[wp]:
+  "do_machine_op enableFpu \<lbrace>globals_equiv st\<rbrace>"
+  apply (clarsimp simp: enableFpu_def dmo_distr dmo_modify_distr)
+  apply (rule bind_wp_skip)
+   apply (unfold globals_equiv_def arch_globals_equiv_def idle_equiv_def enableFpu_def)[1]
+   apply wpsimp
+  apply wpsimp
+  done
+
+lemma dmo_disableFpu_globals_equiv[wp]:
+  "do_machine_op disableFpu \<lbrace>globals_equiv st\<rbrace>"
+  apply (clarsimp simp: disableFpu_def dmo_distr dmo_modify_distr)
+  apply (rule bind_wp_skip)
+   apply (unfold globals_equiv_def arch_globals_equiv_def idle_equiv_def enableFpu_def)[1]
+   apply wpsimp
+  apply wpsimp
+  done
+
+lemma dmo_state_assert_inv[wp]:
+  "do_machine_op (state_assert f) \<lbrace>P\<rbrace>"
+  unfolding state_assert_def
+  by (wpsimp wp: dmo_wp)
+
+lemma dmo_readFpuState_globals_equiv[wp]:
+  "do_machine_op readFpuState \<lbrace>globals_equiv st\<rbrace>"
+  by (wpsimp simp: readFpuState_def dmo_distr dmo_modify_distr)
+
+lemma dmo_writeFpuState_globals_equiv[wp]:
+  "do_machine_op (writeFpuState fpustate) \<lbrace>globals_equiv st\<rbrace>"
+  apply (clarsimp simp: writeFpuState_def dmo_distr dmo_modify_distr)
+  apply wpsimp
+  apply (clarsimp simp: globals_equiv_def idle_equiv_def)
+  done
+
+lemma as_user_getRestart_inv[wp]:
+  "as_user t getFPUState \<lbrace>P\<rbrace>"
+  unfolding getFPUState_def
+  by (wpsimp wp: as_user_inv)
+
+lemma load_fpu_state_globals_equiv[wp]:
+  "load_fpu_state t \<lbrace>globals_equiv st\<rbrace>"
+  unfolding load_fpu_state_def
+  by wpsimp
+
+lemma save_fpu_state_globals_equiv[wp]:
+  "\<lbrace>globals_equiv st and valid_arch_state and (\<lambda>s. t \<noteq> idle_thread s)\<rbrace>
+   save_fpu_state t
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding save_fpu_state_def
+  by wpsimp
+
+crunch load_fpu_state, save_fpu_state
+  for valid_arch_state[wp]: "valid_arch_state"
+
+lemma switch_local_fpu_owner_globals_equiv:
+  "\<lbrace>globals_equiv st and invs\<rbrace>
+   switch_local_fpu_owner new_owner
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding switch_local_fpu_owner_def
+  apply (wpsimp wp: hoare_vcg_all_lift hoare_weak_lift_imp)
+  apply (fastforce simp: invs_def valid_state_def valid_pspace_def valid_cur_fpu_def
+                         is_tcb_cur_fpu_def live_def arch_tcb_live_def
+                   dest: idle_no_ex_cap if_live_then_nonz_capD)
+  done
+
+lemma lazy_fpu_restore_globals_equiv:
+  "\<lbrace>globals_equiv st and invs\<rbrace>
+   lazy_fpu_restore t
+   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
+  unfolding lazy_fpu_restore_def
+  by (wpsimp wp: switch_local_fpu_owner_globals_equiv hoare_drop_imps)
+
+crunch arch_post_set_flags
+  for globals_equiv[Tcb_IF_assms]: "globals_equiv st"
+  (simp: crunch_simps)
 
 end
 

--- a/proof/infoflow/AARCH64/ArchUserOp_IF.thy
+++ b/proof/infoflow/AARCH64/ArchUserOp_IF.thy
@@ -100,6 +100,18 @@ lemma arch_globals_equiv_device_state_update[UserOp_IF_assms, simp]:
    arch_globals_equiv ct it kh kh' as as' ms ms'"
   by auto
 
+lemma no_hyp_modify[UserOp_IF_assms]:
+  "\<And>f. no_hyp (modify (\<lambda>ms. ms\<lparr>underlying_memory := f ms\<rparr>))"
+  "\<And>f. no_hyp (modify (\<lambda>ms. ms\<lparr>device_state := f ms\<rparr>))"
+  "\<And>f. no_hyp (modify (\<lambda>ms. ms\<lparr>machine_state_rest := f ms\<rparr>))"
+  by wpsimp+
+
+lemma no_fpu_modify[UserOp_IF_assms]:
+  "\<And>f. no_fpu (modify (\<lambda>ms. ms\<lparr>underlying_memory := f ms\<rparr>))"
+  "\<And>f. no_fpu (modify (\<lambda>ms. ms\<lparr>device_state := f ms\<rparr>))"
+  "\<And>f. no_fpu (modify (\<lambda>ms. ms\<lparr>machine_state_rest := f ms\<rparr>))"
+  by wpsimp+
+
 end
 
 
@@ -142,7 +154,7 @@ lemma requiv_get_pt_entry_eq:
   done
 
 lemma requiv_get_page_info_eq:
-  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; invs s; is_subject aag pt; x \<notin> kernel_mappings;
+  "\<lbrakk> reads_equiv aag s s'; pas_refined aag s; invs s; is_subject aag pt;
      \<exists>asid. vs_lookup_table max_pt_level asid x s = Some (max_pt_level, pt) \<rbrakk>
      \<Longrightarrow> get_page_info (aobjs_of s) pt x = get_page_info (aobjs_of s') pt x"
   apply (clarsimp simp: get_page_info_def obind_def)
@@ -150,12 +162,10 @@ lemma requiv_get_page_info_eq:
    apply (clarsimp split: option.splits)
    apply (case_tac "pt_lookup_slot pt x (ptes_of s') = Some (a, b)"; clarsimp)
    apply (frule_tac ptr=b in ptes_of_reads_equiv[rotated])
-    apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def)
-    apply (prop_tac "ba = bb", clarsimp simp: pt_slot_offset_def)
-    apply (frule pt_walk_is_aligned)
-     apply (erule vs_lookup_table_is_aligned; clarsimp simp: canonical_not_kernel_is_user)
-    apply (erule pt_walk_is_subject, (fastforce simp: canonical_not_kernel_is_user)+)
-  apply (rule requiv_get_pt_entry_eq; fastforce simp: canonical_not_kernel_is_user)
+    apply (clarsimp simp: pt_lookup_slot_def)
+    apply (rule_tac pt_lookup_slot_from_level_is_subject)
+            apply fastforce+
+  apply (rule requiv_get_pt_entry_eq; fastforce)
   done
 
 lemma requiv_vspace_of_thread_global_pt:
@@ -166,18 +176,19 @@ lemma requiv_vspace_of_thread_global_pt:
   apply (erule equiv_forE)
   apply (prop_tac "aag_can_read aag (cur_thread s)", simp)
   apply (clarsimp simp: get_vspace_of_thread_def
-                 split: option.split kernel_object.splits cap.splits arch_cap.splits)
-  apply (rename_tac tcb word word' word'')
-  apply (subgoal_tac "aag_can_read_asid aag word'")
-   apply (subgoal_tac "s \<turnstile> ArchObjectCap (PageTableCap word (Some (word',word'')))")
+                 split: option.split kernel_object.splits cap.splits arch_cap.splits pt_type.splits)
+  apply (rename_tac tcb pt asid vref)
+  apply (subgoal_tac "aag_can_read_asid aag asid")
+   apply (subgoal_tac "s \<turnstile> ArchObjectCap (PageTableCap pt VSRootPT_T (Some (asid,vref)))")
     apply (clarsimp simp: equiv_asids_def equiv_asid_def valid_cap_def obind_def
                           vspace_for_asid_def vspace_for_pool_def pool_for_asid_def)
     apply (clarsimp simp: word_gt_0 typ_at_eq_kheap_obj)
-    apply (drule_tac x=word' in spec)
-    apply (case_tac "word' = 0"; clarsimp)
-    apply (clarsimp simp: asid_pools_of_ko_at obj_at_def asid_low_bits_of_def opt_map_def
+    apply (drule_tac x=asid in spec)
+    apply (case_tac "asid = 0"; clarsimp)
+    apply (clarsimp simp: asid_pools_of_ko_at obj_at_def)
+    apply (clarsimp simp: asid_low_bits_of_def opt_map_def
+                          entry_for_asid_def entry_for_pool_def pool_for_asid_def obind_def
                    split: option.splits)
-    apply (frule valid_global_arch_objs_global_ptD[OF invs_valid_global_arch_objs])
     apply (drule invs_valid_global_refs)
     apply (drule_tac ptr="((cur_thread s), tcb_cnode_index 1)" in valid_global_refsD2[rotated])
      apply (subst caps_of_state_tcb_cap_cases)
@@ -187,7 +198,7 @@ lemma requiv_vspace_of_thread_global_pt:
     apply (simp add: cap_range_def global_refs_def)
    apply (cut_tac s=s and t="cur_thread s" and tcb=tcb in objs_valid_tcb_vtable)
      apply (fastforce simp: invs_valid_objs get_tcb_def)+
-  apply (subgoal_tac "(pasObjectAbs aag (cur_thread s), Control, pasASIDAbs aag word')
+  apply (subgoal_tac "(pasObjectAbs aag (cur_thread s), Control, pasASIDAbs aag asid)
                         \<in> state_asids_to_policy aag s")
    apply (frule pas_refined_Control_into_is_subject_asid)
     apply (fastforce simp: pas_refined_def)
@@ -201,7 +212,7 @@ lemma vspace_for_asid_get_vspace_of_thread:
   "get_vspace_of_thread (kheap s) (arch_state s) ct \<noteq> global_pt s
    \<Longrightarrow> \<exists>asid. vspace_for_asid asid s = Some (get_vspace_of_thread (kheap s) (arch_state s) ct)"
   by (fastforce simp: get_vspace_of_thread_def
-               split: option.splits kernel_object.splits cap.splits arch_cap.splits)
+               split: option.splits kernel_object.splits cap.splits arch_cap.splits pt_type.splits)
 
 lemma pt_of_thread_same_agent:
   "\<lbrakk> pas_refined aag s; is_subject aag tcb_ptr;
@@ -228,27 +239,13 @@ lemma requiv_ptable_rights_eq:
      \<Longrightarrow> ptable_rights_s s = ptable_rights_s s'"
   apply (simp add: ptable_rights_s_def)
   apply (rule ext)
-  apply (case_tac "x \<in> kernel_mappings")
-   apply (clarsimp simp: ptable_rights_def split: option.splits)
-   apply (rule conjI; clarsimp)
-    apply (frule some_get_page_info_kmapsD;
-           fastforce dest: invs_arch_state vspace_for_asid_get_vspace_of_thread
-                     simp: valid_arch_state_def kernel_mappings_canonical)
-   apply (frule some_get_page_info_kmapsD)
-              apply (auto dest: invs_arch_state vspace_for_asid_get_vspace_of_thread
-                          simp: valid_arch_state_def kernel_mappings_canonical)[12]
-   apply (frule_tac r=b in some_get_page_info_kmapsD)
-              apply (auto dest: invs_arch_state vspace_for_asid_get_vspace_of_thread
-                          simp: valid_arch_state_def kernel_mappings_canonical)[12]
-  apply (case_tac "get_vspace_of_thread (kheap s) (arch_state s) (cur_thread s) =
-                   arm_us_global_vspace (arch_state s)")
+  apply (case_tac "get_vspace_of_thread (kheap s) (arch_state s) (cur_thread s) = global_pt s")
    apply (frule requiv_vspace_of_thread_global_pt)
        apply (auto)[4]
-   apply (fastforce dest: get_page_info_gpd_kmaps[rotated, rotated]
+   apply (fastforce dest: get_page_info_gpd_kmaps[rotated 3]
                     simp: ptable_rights_def invs_valid_global_objs invs_arch_state
                    split: option.splits)+
-  apply (case_tac "get_vspace_of_thread (kheap s') (arch_state s') (cur_thread s') =
-                   arm_us_global_vspace (arch_state s')")
+  apply (case_tac "get_vspace_of_thread (kheap s') (arch_state s') (cur_thread s') = global_pt s'")
    apply (drule reads_equiv_sym)
    apply (frule requiv_vspace_of_thread_global_pt; fastforce simp: reads_equiv_def)
   apply (simp add: ptable_rights_def)
@@ -265,16 +262,6 @@ lemma requiv_ptable_attrs_eq:
      is_subject aag (cur_thread s); invs s; invs s'; ptable_rights_s s x \<noteq> {} \<rbrakk>
      \<Longrightarrow> ptable_attrs_s s x = ptable_attrs_s s' x"
   apply (simp add: ptable_attrs_s_def ptable_rights_s_def)
-  apply (case_tac "x \<in> kernel_mappings")
-   apply (clarsimp simp: ptable_attrs_def split: option.splits)
-   apply (rule conjI)
-    apply clarsimp
-    apply (frule some_get_page_info_kmapsD)
-               apply (auto simp: vspace_for_asid_get_vspace_of_thread ptable_rights_def)[12]
-   apply clarsimp
-   apply (frule some_get_page_info_kmapsD)
-              apply (auto dest: invs_arch_state vspace_for_asid_get_vspace_of_thread
-                          simp: valid_arch_state_def kernel_mappings_canonical ptable_rights_def)[12]
   apply (case_tac "get_vspace_of_thread (kheap s) (arch_state s) (cur_thread s) =
                    arm_us_global_vspace (arch_state s)")
    apply (frule requiv_vspace_of_thread_global_pt)
@@ -282,15 +269,15 @@ lemma requiv_ptable_attrs_eq:
    apply (clarsimp simp: ptable_attrs_def split: option.splits)
    apply (rule conjI)
     apply clarsimp
-    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+    apply (frule get_page_info_gpd_kmaps[rotated 3])
+      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[4]
    apply clarsimp
    apply (rule conjI)
-    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+    apply (frule get_page_info_gpd_kmaps[rotated 3])
+      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[4]
    apply clarsimp
-   apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-     apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+   apply (frule get_page_info_gpd_kmaps[rotated 3])
+     apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[4]
   apply (case_tac "get_vspace_of_thread (kheap s') (arch_state s') (cur_thread s') =
                    arm_us_global_vspace (arch_state s')")
    apply (drule reads_equiv_sym)
@@ -309,16 +296,6 @@ lemma requiv_ptable_lift_eq:
      invs s'; is_subject aag (cur_thread s); ptable_rights_s s x \<noteq> {} \<rbrakk>
      \<Longrightarrow> ptable_lift_s s x = ptable_lift_s s' x"
   apply (simp add: ptable_lift_s_def ptable_rights_s_def)
-  apply (case_tac "x \<in> kernel_mappings")
-   apply (clarsimp simp: ptable_lift_def split: option.splits)
-   apply (rule conjI)
-    apply clarsimp
-    apply (frule some_get_page_info_kmapsD)
-               apply (auto simp: vspace_for_asid_get_vspace_of_thread ptable_rights_def)[12]
-   apply clarsimp
-   apply (frule some_get_page_info_kmapsD)
-              apply (auto dest: invs_arch_state vspace_for_asid_get_vspace_of_thread
-                          simp: valid_arch_state_def kernel_mappings_canonical ptable_rights_def)[12]
   apply (case_tac "get_vspace_of_thread (kheap s) (arch_state s) (cur_thread s) =
                    arm_us_global_vspace (arch_state s)")
    apply (frule requiv_vspace_of_thread_global_pt)
@@ -326,15 +303,15 @@ lemma requiv_ptable_lift_eq:
    apply (clarsimp simp: ptable_lift_def split: option.splits)
    apply (rule conjI)
     apply clarsimp
-    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+    apply (frule get_page_info_gpd_kmaps[rotated 3])
+      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[4]
    apply clarsimp
    apply (rule conjI)
-    apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+    apply (frule get_page_info_gpd_kmaps[rotated 3])
+      apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[4]
    apply clarsimp
-   apply (frule get_page_info_gpd_kmaps[rotated, rotated])
-     apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[3]
+   apply (frule get_page_info_gpd_kmaps[rotated 3])
+     apply ((fastforce simp: invs_valid_global_objs invs_arch_state)+)[4]
   apply (case_tac "get_vspace_of_thread (kheap s') (arch_state s') (cur_thread s') =
                    arm_us_global_vspace (arch_state s')")
    apply (drule reads_equiv_sym)
@@ -440,11 +417,12 @@ proof -
       apply (simp add: obj_bits_def)+
      apply (simp add: mask_lower_twice ptrFromPAddr_mask_simp)
      apply (rule arg_cong[where f = ptrFromPAddr])
-     apply (subst (asm) is_aligned_ptrFromPAddr_n_eq[OF pageBitsForSize_le_canonical_bit])
-     apply (subst neg_mask_add_aligned[OF _ and_mask_less'])
-       apply simp
-      apply (fastforce simp: pbfs_less_wb'[unfolded word_bits_def,simplified])
-     apply (simp add: is_aligned_neg_mask_eq)
+     apply (subgoal_tac "is_aligned base (pageBitsForSize sz')")
+      apply (subst neg_mask_add_aligned[OF _ and_mask_less'])
+        apply simp
+       apply (fastforce simp: pbfs_less_wb'[unfolded word_bits_def,simplified])
+      apply simp
+     apply (metis is_aligned_addD2 is_aligned_pptrBaseOffset ptrFromPAddr_def)
     apply (drule not_sym)
     apply (erule(5) data_at_disjoint_equiv)
     apply (unfold obj_range_def)
@@ -452,15 +430,16 @@ proof -
      apply (simp add: obj_bits_def is_aligned_neg_mask)+
     apply (simp add: mask_lower_twice ptrFromPAddr_mask_simp)
     apply (rule arg_cong[where f = ptrFromPAddr])
-    apply (subst (asm) is_aligned_ptrFromPAddr_n_eq[OF pageBitsForSize_le_canonical_bit])
-    apply (rule sym)
-    apply (subst mask_lower_twice[symmetric])
-     apply (erule less_imp_le_nat)
-    apply (rule arg_cong[where f = "\<lambda>x. x && ~~ mask z" for z])
-    apply (subst neg_mask_add_aligned[OF _ and_mask_less'])
-      apply simp
-     apply (fastforce simp: pbfs_less_wb'[unfolded word_bits_def,simplified])
-    apply simp
+    apply (subgoal_tac "is_aligned base (pageBitsForSize sz')")
+     apply (rule sym)
+     apply (subst mask_lower_twice[symmetric])
+      apply (erule less_imp_le_nat)
+     apply (rule arg_cong[where f = "\<lambda>x. x && ~~ mask z" for z])
+     apply (subst neg_mask_add_aligned[OF _ and_mask_less'])
+       apply simp
+      apply (fastforce simp: pbfs_less_wb'[unfolded word_bits_def,simplified])
+     apply simp
+    apply (metis is_aligned_addD2 is_aligned_pptrBaseOffset ptrFromPAddr_def)
     done
 qed
 
@@ -475,11 +454,27 @@ lemma level_le_2_cases:
    apply (drule meta_mp)
     apply (erule order.strict_implies_not_eq)
    apply (drule meta_mp)
-    apply (rule bit0.minus_one_leq_less)
+    apply (rule bit1.minus_one_leq_less)
      apply (erule order.strict_implies_order)
-    apply (erule bit0.zero_least)
+    apply (erule bit1.zero_least)
    apply clarsimp
   apply clarsimp
+  done
+
+lemma pt_walk_vref_for_levelD:
+  "\<lbrakk> pt_walk top_level bot_level pt vref ptes = Some (level,ptr);
+     level \<le> top_level; top_level \<le> max_pt_level \<rbrakk>
+     \<Longrightarrow> pt_walk top_level bot_level pt (vref_for_level vref level) ptes = Some (level,ptr)"
+  apply (induct top_level arbitrary: pt)
+   apply (simp add: pt_walk.simps Let_def oapply_def)
+  apply (case_tac "top_level=bot_level")
+   apply (simp add: pt_walk.simps)
+  apply (erule_tac x= "pptr_from_pte (the (ptes (level_type top_level) (pt_slot_offset top_level pt vref)))" in meta_allE)
+  apply (subst (asm) pt_walk.simps)
+  apply (subst pt_walk.simps)
+  apply (simp add: Let_def vm_level.leq_minus1_less)
+  apply (clarsimp simp: obind_def split: if_splits option.splits)
+  apply (meson pt_walk_max_level vm_level.leq_minus1_less vm_level.zero_least)
   done
 
 lemma ptable_lift_data_consistant:
@@ -487,7 +482,6 @@ lemma ptable_lift_data_consistant:
   and pt_lift: "ptable_lift t s x = Some ptr"
   and dat: "data_at sz ((ptrFromPAddr ptr) && ~~ mask (pageBitsForSize sz)) s"
   and misc: "get_vspace_of_thread (kheap s) (arch_state s) t \<noteq> arm_us_global_vspace (arch_state s)"
-            "x \<notin> kernel_mappings"
   shows "ptable_lift t s (x && ~~ mask (pageBitsForSize sz)) =
          Some (ptr && ~~ mask (pageBitsForSize sz))"
 proof -
@@ -503,7 +497,7 @@ proof -
     apply (case_tac pde; clarsimp simp: pte_info_def)
     apply (frule pt_lookup_slot_max_pt_level)
     apply (frule vspace_for_asid_vs_lookup)
-    apply (frule canonical_not_kernel_is_user[OF misc(2)])
+    apply (clarsimp split: if_splits)
     apply (frule_tac level=level in valid_vspace_objs_pte)
       apply clarsimp
      apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def)
@@ -515,39 +509,41 @@ proof -
      apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def in_omonad pt_walk.simps)
      apply (clarsimp split: if_splits)
       apply (fastforce dest: pt_walk_max_level simp: max_pt_level_def2)
-     apply (subst (asm) table_index_max_level_slots; clarsimp?)
-     apply (fastforce dest: vs_lookup_table_is_aligned valid_arch_state_asid_table)
+     apply clarsimp
     apply (clarsimp simp: valid_pte_def)
-    apply (frule data_at_same_size; simp?)
+    apply (frule data_at_same_size[symmetric]; simp?)
+    apply (simp add: pageBitsForSize_pt_bits_left)
+    apply (fold vref_for_level_def)
+    apply (prop_tac "level_of_vmsize (vmsize_of_level level) = level")
+     apply (metis data_at_level pageBitsForSize_pt_bits_left)
+    apply clarsimp
     apply (prop_tac "pt_lookup_slot (get_vspace_of_thread (kheap s) (arch_state s) t)
                                     (vref_for_level x level) (ptes_of s) = Some (level, pt)")
-     apply (case_tac "level = max_pt_level"; clarsimp)
-      apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def in_omonad)
-      apply (subst (asm) pt_lookup_vs_lookup_eq)
-        apply clarsimp
-       apply (clarsimp simp: vspace_for_asid_def)
-      apply (clarsimp simp: pt_walk.simps)
-      apply (fastforce dest: pt_walk_max_level simp: max_pt_level_def2 in_omonad)
-     apply (fold vref_for_level_def)
      apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def in_omonad)
-     apply (rule exI)
-     apply (subst pt_walk_vref_for_level_eq[where vref'=x])
-       apply (fastforce dest: level_le_2_cases le_neq_trans simp: max_pt_level_def2 max_def)
-      apply clarsimp
-     apply fastforce
+     apply (fastforce dest: pt_walk_vref_for_levelD)
+    using vref_for_level_user_region
     apply (fastforce simp: vref_for_level_def is_aligned_mask_out_add_eq mask_AND_NOT_mask
-                           pt_bits_left_le_canonical is_aligned_ptrFromPAddr_n_eq
-                     elim: canonical_vref_for_levelI[unfolded vref_for_level_def]
+                           is_aligned_ptrFromPAddr_n_eq
                      dest: data_at_aligned)
     done
 qed
+
+(* FIXME AARCH64 IF: override in ArchRetype_AI *)
+lemma valid_vspace_objs_pte:
+  "\<lbrakk> ptes_of s pt_t p = Some pte; valid_vspace_objs s; \<exists>\<rhd> (level, table_base pt_t p) s \<rbrakk>
+   \<Longrightarrow> valid_pte level pte s"
+  apply (clarsimp simp: ptes_of_def in_opt_map_eq)
+  apply (drule (2) valid_vspace_objsD)
+   apply (fastforce simp: in_opt_map_eq)
+  apply simp
+  done
 
 lemma ptable_rights_data_consistant:
   assumes vs: "valid_state s"
   and pt_lift: "ptable_lift t s x = Some ptr"
   and dat: "data_at sz ((ptrFromPAddr ptr) && ~~ mask (pageBitsForSize sz)) s"
   and misc: "get_vspace_of_thread (kheap s) (arch_state s) t \<noteq>
-             arm_us_global_vspace (arch_state s)" "x \<notin> kernel_mappings"
+             arm_us_global_vspace (arch_state s)"
   shows "ptable_rights t s (x && ~~ mask (pageBitsForSize sz)) = ptable_rights t s x"
 proof -
   have vs': "valid_objs s \<and> valid_arch_state s \<and> valid_vspace_objs s
@@ -556,48 +552,33 @@ proof -
   thus ?thesis
     using pt_lift dat vs'
     apply (clarsimp simp: ptable_rights_def ptable_lift_def split: option.splits)
-    apply (clarsimp simp: get_page_info_def simp: obind_def split: option.splits)
+    apply (clarsimp simp: get_page_info_def simp: obind_def split: option.splits if_splits)
     apply (rule exE[OF vspace_for_asid_get_vspace_of_thread[OF misc(1)]])
     apply (rename_tac level pt pde asid)
     apply (case_tac pde; clarsimp simp: pte_info_def)
     apply (frule pt_lookup_slot_max_pt_level)
     apply (frule vspace_for_asid_vs_lookup)
-    apply (frule canonical_not_kernel_is_user[OF misc(2)])
     apply (frule_tac level=level in valid_vspace_objs_pte)
       apply clarsimp
      apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def)
      apply (fastforce simp: table_base_pt_slot_offset[OF vs_lookup_table_is_aligned]
                       dest: valid_arch_state_asid_table dest!: pt_lookup_vs_lookupI
                      intro: vs_lookup_level)
-    apply (erule disjE[OF _  _ FalseE])
-     prefer 2
-     apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def in_omonad pt_walk.simps)
-     apply (clarsimp split: if_splits)
-      apply (fastforce dest: pt_walk_max_level simp: max_pt_level_def2)
-     apply (subst (asm) table_index_max_level_slots; clarsimp?)
-     apply (fastforce dest: vs_lookup_table_is_aligned valid_arch_state_asid_table)
     apply (clarsimp simp: valid_pte_def)
-    apply (frule data_at_same_size; simp?)
+    apply (frule data_at_same_size[symmetric]; simp?)
+    apply (simp add: pageBitsForSize_pt_bits_left)
+    apply (prop_tac "level_of_vmsize (vmsize_of_level level) = level")
+     apply (metis data_at_level pageBitsForSize_pt_bits_left)
+    apply clarsimp
+    apply (fold vref_for_level_def)
     apply (prop_tac "pt_lookup_slot (get_vspace_of_thread (kheap s) (arch_state s) t)
                                     (vref_for_level x level) (ptes_of s) = Some (level, pt)")
-     apply (case_tac "level = max_pt_level"; clarsimp)
-      apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def in_omonad)
-      apply (subst (asm) pt_lookup_vs_lookup_eq)
-        apply clarsimp
-       apply (clarsimp simp: vspace_for_asid_def)
-      apply (clarsimp simp: pt_walk.simps)
-      apply (fastforce dest: pt_walk_max_level simp: max_pt_level_def2 in_omonad)
-     apply (fold vref_for_level_def)
      apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def in_omonad)
-     apply (rule exI)
-     apply (subst pt_walk_vref_for_level_eq[where vref'=x])
-       apply (fastforce dest: level_le_2_cases le_neq_trans simp: max_pt_level_def2 max_def)
-      apply clarsimp
-     apply fastforce
-    apply (clarsimp simp: vref_for_level_def)
-    apply (fastforce dest: canonical_vref_for_levelI[unfolded vref_for_level_def]
-                     simp: pt_bits_left_le_canonical )
-    done
+     apply (fastforce dest: pt_walk_vref_for_levelD)
+    apply (rule conjI)
+     apply (fastforce)
+    apply clarsimp
+    using vref_for_level_user_region by fastforce
 qed
 
 
@@ -607,20 +588,14 @@ lemma user_op_access_data_at:
      auth \<in> vspace_cap_rights_to_auth (ptable_rights tcb s x) \<rbrakk>
      \<Longrightarrow> (pasObjectAbs aag tcb, auth,
           pasObjectAbs aag (ptrFromPAddr (ptr && ~~ mask (pageBitsForSize sz)))) \<in> pasPolicy aag"
-  apply (case_tac "x \<in> kernel_mappings")
-   apply (clarsimp simp: ptable_lift_def ptable_rights_def split: option.splits)
-   apply (frule some_get_page_info_kmapsD)
-              apply (fastforce dest: invs_arch_state invs_equal_kernel_mappings
-                               simp: valid_arch_state_def vspace_for_asid_get_vspace_of_thread
-                                     kernel_mappings_canonical vspace_cap_rights_to_auth_def)+
   apply (case_tac "get_vspace_of_thread (kheap s) (arch_state s) tcb = arm_us_global_vspace (arch_state s)")
    apply (clarsimp simp: ptable_lift_def ptable_rights_def split: option.splits)
-   apply (frule get_page_info_gpd_kmaps[rotated, rotated])
+   apply (frule get_page_info_gpd_kmaps[rotated 3])
      apply (fastforce simp: invs_valid_global_objs invs_arch_state)+
-  apply (frule (2) ptable_lift_data_consistant[rotated 2])
+  apply (frule (1) ptable_lift_data_consistant[rotated 2])
     apply fastforce
    apply fastforce
-  apply (frule (2) ptable_rights_data_consistant[rotated 2])
+  apply (frule (1) ptable_rights_data_consistant[rotated 2])
     apply fastforce
    apply fastforce
   apply (erule (3) user_op_access)

--- a/proof/infoflow/AARCH64/Example_Valid_State.thy
+++ b/proof/infoflow/AARCH64/Example_Valid_State.thy
@@ -12,6 +12,8 @@ imports
   "AInvs.KernelInit_AI"
 begin
 
+(* FIXME AARCH64 IF: major cleanup *)
+
 section \<open>Example\<close>
 
 (* This example is a classic 'one way information flow'
@@ -27,8 +29,13 @@ consts s0_context :: user_context
 
 (* define the irqs to come regularly every 10 *)
 
+definition timer_irq :: irq where
+  "timer_irq \<equiv> 0"
+
+abbreviation (input) "timer_int \<equiv> 10"
+
 axiomatization where
-  irq_oracle_def: "AARCH64.irq_oracle \<equiv> \<lambda>pos. if pos mod 10 = 0 then 10 else 0"
+  irq_oracle_def: "AARCH64.irq_oracle \<equiv> \<lambda>pos. if pos mod timer_int = 0 then timer_irq else 0"
 
 context begin interpretation Arch . (*FIXME: arch-split*)
 
@@ -202,28 +209,28 @@ subsubsection \<open>Defining the State\<close>
 
 definition "ntfn_ptr \<equiv> pptr_base + 0x20"
 
-definition "Low_tcb_ptr \<equiv> pptr_base + 0x400"
-definition "High_tcb_ptr = pptr_base + 0x800"
-definition "idle_tcb_ptr = pptr_base + 0x1000"
+definition "Low_tcb_ptr \<equiv> pptr_base + 0x800"
+definition "idle_tcb_ptr = pptr_base + 0x1000" (* FIXME IF: change to idle_thread_ptr *)
+definition "High_tcb_ptr = pptr_base + 0x1800"
+
+lemma "arm_global_pt_ptr = pptr_base + 0x2000" using arm_global_pt_ptr_def .
 
 definition "Low_pt_ptr = pptr_base + 0x4000"
 definition "High_pt_ptr = pptr_base + 0x5000"
 
-definition "Low_pd_ptr = pptr_base + 0x7000"
+definition "Low_pd_ptr = pptr_base + 0x6000"
 definition "High_pd_ptr = pptr_base + 0x8000"
 
-definition "Low_pool_ptr = pptr_base + 0x9000"
-definition "High_pool_ptr = pptr_base + 0xA000"
+definition "Low_pool_ptr = pptr_base + 0xA000"
+definition "High_pool_ptr = pptr_base + 0xB000"
 
-definition "Low_cnode_ptr = pptr_base + 0x10000"
-definition "High_cnode_ptr = pptr_base + 0x18000"
-definition "Silc_cnode_ptr = pptr_base + 0x20000"
-definition "irq_cnode_ptr = pptr_base + 0x28000"
+definition "Low_cnode_ptr = pptr_base + 0x18000"
+definition "High_cnode_ptr = pptr_base + 0x20000"
+definition "Silc_cnode_ptr = pptr_base + 0x28000"
+definition "irq_cnode_ptr = pptr_base + 0x30000"
 
-definition "shared_page_ptr_virt = pptr_base + 0x200000"
+definition "shared_page_ptr_virt = pptr_base + 0x40000000"
 definition "shared_page_ptr_phys = addrFromPPtr shared_page_ptr_virt"
-
-definition "timer_irq \<equiv> 10" (* not sure exactly how this fits in *)
 
 definition "Low_mcp \<equiv> 5 :: priority"
 definition "Low_prio \<equiv> 5 :: priority"
@@ -373,6 +380,14 @@ lemma empty_cnode_eq_None[simp]:
   by (clarsimp simp: empty_cnode_def)
 
 
+definition max_page_size where
+  "max_page_size \<equiv> if config_ARM_PA_SIZE_BITS_40 then ARMLargePage else ARMHugePage"
+
+lemma max_page_size_def2:
+  "max_page_size = vmsize_of_level (max_pt_level - 1)"
+  by (auto simp: max_page_size_def max_pt_level_def2 vmsize_of_level_def)
+
+
 text \<open>Low's CSpace\<close>
 
 definition Low_caps :: cnode_contents where
@@ -383,13 +398,13 @@ definition Low_caps :: cnode_contents where
       (the_nat_to_bl_10 2)
         \<mapsto> CNodeCap Low_cnode_ptr 10 (the_nat_to_bl_10 2),
       (the_nat_to_bl_10 3)
-        \<mapsto> ArchObjectCap (PageTableCap Low_pd_ptr (Some (Low_asid,0))),
+        \<mapsto> ArchObjectCap (PageTableCap Low_pd_ptr VSRootPT_T (Some (Low_asid,0))),
       (the_nat_to_bl_10 4)
         \<mapsto> ArchObjectCap (ASIDPoolCap Low_pool_ptr Low_asid),
       (the_nat_to_bl_10 5)
-        \<mapsto> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_write RISCVLargePage False (Some (Low_asid,0))),
+        \<mapsto> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_write max_page_size False (Some (Low_asid,0))),
       (the_nat_to_bl_10 6)
-        \<mapsto> ArchObjectCap (PageTableCap Low_pt_ptr (Some (Low_asid,0))),
+        \<mapsto> ArchObjectCap (PageTableCap Low_pt_ptr NormalPT_T (Some (Low_asid,0))),
       (the_nat_to_bl_10 318)
         \<mapsto> NotificationCap ntfn_ptr 0 {AllowSend})"
 
@@ -413,10 +428,10 @@ lemma Low_caps_ran:
   "ran Low_caps =
      {ThreadCap Low_tcb_ptr,
       CNodeCap Low_cnode_ptr 10 (the_nat_to_bl_10 2),
-      ArchObjectCap (PageTableCap Low_pd_ptr (Some (Low_asid,0))),
-      ArchObjectCap (PageTableCap Low_pt_ptr (Some (Low_asid,0))),
+      ArchObjectCap (PageTableCap Low_pd_ptr VSRootPT_T (Some (Low_asid,0))),
+      ArchObjectCap (PageTableCap Low_pt_ptr NormalPT_T (Some (Low_asid,0))),
       ArchObjectCap (ASIDPoolCap Low_pool_ptr Low_asid),
-      ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_write RISCVLargePage False (Some (Low_asid,0))),
+      ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_write max_page_size False (Some (Low_asid,0))),
       NotificationCap ntfn_ptr 0 {AllowSend},
       NullCap}"
   apply (rule equalityI)
@@ -437,13 +452,13 @@ definition High_caps :: cnode_contents where
         (the_nat_to_bl_10 2)
           \<mapsto> CNodeCap High_cnode_ptr 10 (the_nat_to_bl_10 2),
         (the_nat_to_bl_10 3)
-          \<mapsto> ArchObjectCap (PageTableCap High_pd_ptr (Some (High_asid,0))),
+          \<mapsto> ArchObjectCap (PageTableCap High_pd_ptr VSRootPT_T (Some (High_asid,0))),
         (the_nat_to_bl_10 4)
           \<mapsto> ArchObjectCap (ASIDPoolCap High_pool_ptr High_asid),
         (the_nat_to_bl_10 5)
-          \<mapsto> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (High_asid,0))),
+          \<mapsto> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only max_page_size False (Some (High_asid,0))),
         (the_nat_to_bl_10 6)
-          \<mapsto> ArchObjectCap (PageTableCap High_pt_ptr (Some (High_asid,0))),
+          \<mapsto> ArchObjectCap (PageTableCap High_pt_ptr NormalPT_T (Some (High_asid,0))),
         (the_nat_to_bl_10 318)
           \<mapsto> NotificationCap ntfn_ptr 0 {AllowRecv}) "
 
@@ -454,10 +469,10 @@ lemma High_caps_ran:
   "ran High_caps =
      {ThreadCap High_tcb_ptr,
       CNodeCap High_cnode_ptr 10 (the_nat_to_bl_10 2),
-      ArchObjectCap (PageTableCap High_pd_ptr (Some (High_asid,0))),
-      ArchObjectCap (PageTableCap High_pt_ptr (Some (High_asid,0))),
+      ArchObjectCap (PageTableCap High_pd_ptr VSRootPT_T (Some (High_asid,0))),
+      ArchObjectCap (PageTableCap High_pt_ptr NormalPT_T (Some (High_asid,0))),
       ArchObjectCap (ASIDPoolCap High_pool_ptr High_asid),
-      ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (High_asid,0))),
+      ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only max_page_size False (Some (High_asid,0))),
       NotificationCap ntfn_ptr 0 {AllowRecv},
       NullCap}"
   apply (rule equalityI)
@@ -476,7 +491,7 @@ definition Silc_caps :: cnode_contents where
        ((the_nat_to_bl_10 2)
           \<mapsto> CNodeCap Silc_cnode_ptr 10 (the_nat_to_bl_10 2),
         (the_nat_to_bl_10 5)
-          \<mapsto> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (Silc_asid,0))),
+          \<mapsto> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only max_page_size False (Some (Silc_asid,0))),
         (the_nat_to_bl_10 318)
           \<mapsto> NotificationCap ntfn_ptr 0 {AllowSend} )"
 
@@ -486,7 +501,7 @@ definition Silc_cnode :: kernel_object where
 lemma Silc_caps_ran:
   "ran Silc_caps =
      {CNodeCap Silc_cnode_ptr 10 (the_nat_to_bl_10 2),
-      ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (Silc_asid,0))),
+      ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only max_page_size False (Some (Silc_asid,0))),
       NotificationCap ntfn_ptr 0 {AllowSend},
       NullCap}"
   apply (rule equalityI)
@@ -502,30 +517,20 @@ text \<open>notification between Low and High\<close>
 definition ntfn :: kernel_object where
   "ntfn \<equiv> Notification \<lparr>ntfn_obj = WaitingNtfn [High_tcb_ptr], ntfn_bound_tcb=None\<rparr>"
 
-
-text \<open>global page table is mapped into the top-level page tables of each vspace\<close>
-
-abbreviation init_global_pt' where
-  "init_global_pt' \<equiv> (\<lambda>idx. if idx \<in> kernel_mapping_slots then global_pte idx else InvalidPTE)"
-
-
 text \<open>Low's VSpace (PageDirectory)\<close>
-
-abbreviation ppn_from_addr :: "paddr \<Rightarrow> pte_ppn" where
-  "ppn_from_addr addr \<equiv> ucast (addr >> pt_bits)"
 
 abbreviation Low_pt' :: pt where
   "Low_pt' \<equiv>
-     (\<lambda>_. InvalidPTE)
-       (0 := PagePTE (ppn_from_addr shared_page_ptr_phys) {} vm_read_write)"
+     NormalPT ((\<lambda>_. InvalidPTE)
+       (0 := PagePTE shared_page_ptr_phys False {} vm_read_write))"
 
 definition Low_pt :: kernel_object where
   "Low_pt \<equiv> ArchObj (PageTable Low_pt')"
 
 abbreviation Low_pd' :: pt where
   "Low_pd' \<equiv>
-     init_global_pt'
-       (0 := PageTablePTE (ppn_from_addr (addrFromPPtr Low_pt_ptr)) {})"
+     VSRootPT ((\<lambda>_. InvalidPTE)
+       (0 := PageTablePTE (ppn_from_pptr Low_pt_ptr)))"
 
 definition Low_pd :: kernel_object where
   "Low_pd \<equiv> ArchObj (PageTable Low_pd')"
@@ -535,16 +540,16 @@ text \<open>High's VSpace (PageDirectory)\<close>
 
 abbreviation High_pt' :: pt where
   "High_pt' \<equiv>
-     (\<lambda>_. InvalidPTE)
-       (0 := PagePTE (ppn_from_addr shared_page_ptr_phys) {} vm_read_only)"
+     NormalPT ((\<lambda>_. InvalidPTE)
+       (0 := PagePTE shared_page_ptr_phys False {} vm_read_only))"
 
 definition High_pt :: kernel_object where
   "High_pt \<equiv> ArchObj (PageTable High_pt')"
 
 abbreviation High_pd' :: pt where
   "High_pd' \<equiv>
-     init_global_pt'
-       (0 := PageTablePTE (ppn_from_addr (addrFromPPtr High_pt_ptr)) {})"
+     VSRootPT ((\<lambda>_. InvalidPTE)
+       (0 := PageTablePTE (ppn_from_pptr High_pt_ptr)))"
 
 definition High_pd :: kernel_object where
   "High_pd \<equiv> ArchObj (PageTable High_pd')"
@@ -554,7 +559,7 @@ text \<open>Low's tcb\<close>
 
 definition Low_tcb :: kernel_object where
   "Low_tcb \<equiv> TCB \<lparr>tcb_ctable = CNodeCap Low_cnode_ptr 10 (the_nat_to_bl_10 2),
-                  tcb_vtable = ArchObjectCap (PageTableCap Low_pd_ptr (Some (Low_asid,0))),
+                  tcb_vtable = ArchObjectCap (PageTableCap Low_pd_ptr VSRootPT_T (Some (Low_asid,0))),
                   tcb_reply = ReplyCap Low_tcb_ptr True {AllowGrant, AllowWrite},
                   tcb_caller = NullCap,
                   tcb_ipcframe = NullCap,
@@ -568,14 +573,14 @@ definition Low_tcb :: kernel_object where
                   tcb_time_slice = Low_time_slice,
                   tcb_domain = Low_domain,
                   tcb_flags = {},
-                  tcb_arch = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
+                  tcb_arch = \<lparr>tcb_context = empty_context, tcb_vcpu = None, tcb_cur_fpu = False\<rparr>\<rparr>"
 
 
 text \<open>High's tcb\<close>
 
 definition High_tcb :: kernel_object where
   "High_tcb \<equiv> TCB \<lparr>tcb_ctable = CNodeCap High_cnode_ptr 10 (the_nat_to_bl_10 2) ,
-                   tcb_vtable = ArchObjectCap (PageTableCap High_pd_ptr (Some (High_asid,0))),
+                   tcb_vtable = ArchObjectCap (PageTableCap High_pd_ptr VSRootPT_T (Some (High_asid,0))),
                    tcb_reply = ReplyCap High_tcb_ptr True {AllowGrant, AllowWrite},
                    tcb_caller = NullCap,
                    tcb_ipcframe = NullCap,
@@ -589,7 +594,7 @@ definition High_tcb :: kernel_object where
                    tcb_time_slice = High_time_slice,
                    tcb_domain = High_domain,
                    tcb_flags = {},
-                   tcb_arch = \<lparr>tcb_context = undefined\<rparr>\<rparr>"
+                  tcb_arch = \<lparr>tcb_context = empty_context, tcb_vcpu = None, tcb_cur_fpu = False\<rparr>\<rparr>"
 
 
 text \<open>idle's tcb\<close>
@@ -610,25 +615,25 @@ definition idle_tcb :: kernel_object where
                    tcb_time_slice = timeSlice,
                    tcb_domain = default_domain,
                    tcb_flags = {},
-                   tcb_arch = \<lparr>tcb_context = empty_context\<rparr>\<rparr>"
+                   tcb_arch = \<lparr>tcb_context = empty_context, tcb_vcpu = None, tcb_cur_fpu = False\<rparr>\<rparr>"
 
 definition
   "irq_cnode \<equiv> CNode 0 (Map.empty([] \<mapsto> cap.NullCap))"
 
-abbreviation
-  "Low_pool' \<equiv> \<lambda>idx. if idx = asid_low_bits_of Low_asid then Some Low_pd_ptr else None"
+abbreviation Low_pool' :: asid_pool where
+  "Low_pool' \<equiv> \<lambda>idx. if idx = asid_low_bits_of Low_asid then Some (ASIDPoolVSpace Low_pd_ptr) else None"
 
 definition
   "Low_pool \<equiv> ArchObj (ASIDPool Low_pool')"
 
 abbreviation
-  "High_pool' \<equiv> \<lambda>idx. if idx = asid_low_bits_of High_asid then Some High_pd_ptr else None"
+  "High_pool' \<equiv> \<lambda>idx. if idx = asid_low_bits_of High_asid then Some (ASIDPoolVSpace High_pd_ptr) else None"
 
 definition
   "High_pool \<equiv> ArchObj (ASIDPool High_pool')"
 
 definition
-  "shared_page \<equiv> ArchObj (DataPage False RISCVLargePage)"
+  "shared_page \<equiv> ArchObj (DataPage False max_page_size)"
 
 definition kh0 :: kheap where
   "kh0 \<equiv> (\<lambda>x. if \<exists>irq :: irq. init_irq_node_ptr + (ucast irq << 5) = x
@@ -649,12 +654,12 @@ definition kh0 :: kheap where
           High_tcb_ptr   \<mapsto> High_tcb,
           idle_tcb_ptr   \<mapsto> idle_tcb,
           shared_page_ptr_virt \<mapsto> shared_page,
-          arm_global_pt_ptr \<mapsto> init_global_pt)"
+          arm_global_pt_ptr \<mapsto> ArchObj global_pt_obj)"
 
 lemma irq_node_offs_min:
-  "init_irq_node_ptr \<le> init_irq_node_ptr + (ucast (irq :: irq) << 5)"
+  "init_irq_node_ptr \<le> init_irq_node_ptr + (ucast (irq::irq) << 5)"
   apply (rule_tac sz=59 in machine_word_plus_mono_right_split)
-   apply (simp add: unat_word_ariths mask_def shiftl_t2n s0_ptr_defs)
+   apply (simp add: unat_word_ariths mask_def shiftl_t2n s0_ptr_defs cte_level_bits_def)
    apply (cut_tac x=irq and 'a=64 in ucast_less)
     apply simp
    apply (simp add: word_less_nat_alt)
@@ -662,56 +667,55 @@ lemma irq_node_offs_min:
   done
 
 lemma irq_node_offs_max:
-  "init_irq_node_ptr + (ucast (irq:: irq) << 5) < init_irq_node_ptr + 0x7E1"
-  apply (simp add: s0_ptr_defs shiftl_t2n)
-  apply (cut_tac x=irq and 'a=64 in ucast_less)
+  "init_irq_node_ptr + (ucast (irq::irq) << 5) < init_irq_node_ptr + 0x4000"
+  apply (simp add: s0_ptr_defs cte_level_bits_def shiftl_t2n)
+  apply (cut_tac x=irq and 'a=machine_word_len in ucast_less)
    apply simp
-  apply (simp add: word_less_nat_alt unat_word_ariths)
+  apply (simp add: word_less_nat_alt unat_word_ariths
+                    cte_level_bits_def irq_len_val)
   done
 
+
 definition irq_node_offs_range where
-  "irq_node_offs_range \<equiv> {x. init_irq_node_ptr \<le> x \<and> x < init_irq_node_ptr + 0x7E1}
+  "irq_node_offs_range \<equiv> {x. init_irq_node_ptr \<le> x \<and> x < init_irq_node_ptr + 0x4000}
                        \<inter> {x. is_aligned x 5}"
 
 lemma irq_node_offs_in_range:
-  "init_irq_node_ptr + (ucast (irq:: irq) << 5) \<in> irq_node_offs_range"
+  "init_irq_node_ptr + (ucast (irq::irq) << 5)
+     \<in> irq_node_offs_range"
   apply (clarsimp simp: irq_node_offs_min irq_node_offs_max irq_node_offs_range_def)
   apply (rule is_aligned_add[OF _ is_aligned_shift])
-  apply (simp add: is_aligned_def s0_ptr_defs)
+  apply (simp add: is_aligned_def s0_ptr_defs cte_level_bits_def)
   done
 
 lemma irq_node_offs_range_correct:
   "x \<in> irq_node_offs_range
-   \<Longrightarrow> \<exists>irq. x = init_irq_node_ptr + (ucast (irq:: irq) << 5)"
-  apply (clarsimp simp: irq_node_offs_min irq_node_offs_max irq_node_offs_range_def s0_ptr_defs)
-  apply (rule_tac x="ucast ((x - 0xFFFFFFC000003000) >> 5)" in exI)
-  apply (clarsimp simp: ucast_ucast_mask)
+   \<Longrightarrow> \<exists>irq. x = init_irq_node_ptr + (ucast (irq::irq) << 5)"
+  unfolding irq_node_offs_range_def
+  apply clarsimp
+  apply (rule_tac x="ucast ((x - init_irq_node_ptr) >> 5)" in exI)
+  apply (simp add: ucast_ucast_mask)
   apply (subst aligned_shiftr_mask_shiftl)
    apply (rule aligned_sub_aligned)
      apply assumption
-    apply (simp add: is_aligned_def)
-   apply simp
-  apply simp
-  apply (rule_tac n=11 in mask_eqI)
+    apply (simp add: is_aligned_def s0_ptr_defs cte_level_bits_def)
+   apply (simp add: cte_level_bits_def)
+  apply (rule_tac n="irq_len + 5" in mask_eqI)
    apply (subst mask_add_aligned)
-    apply (simp add: is_aligned_def)
-   apply (simp add: mask_twice)
+    apply (simp add: is_aligned_def s0_ptr_defs cte_level_bits_def irq_len_val)
+   apply (simp add: mask_twice irq_len_val cte_level_bits_def)
    apply (simp add: diff_conv_add_uminus del: add_uminus_conv_diff)
    apply (subst add.commute[symmetric])
    apply (subst mask_add_aligned)
-    apply (simp add: is_aligned_def)
+    apply (simp add: is_aligned_def s0_ptr_defs cte_level_bits_def irq_len_val)
    apply simp
   apply (simp add: diff_conv_add_uminus del: add_uminus_conv_diff)
   apply (subst add_mask_lower_bits)
-    apply (simp add: is_aligned_def)
-   apply clarsimp
-  apply (cut_tac x=x and y="0xFFFFFFC0000037E0" and n=14 in neg_mask_mono_le)
-   apply (force dest: word_less_sub_1)
-  apply (drule_tac n=11 in aligned_le_sharp)
-   apply (simp add: is_aligned_def)
-  apply (simp add: mask_def is_aligned_mask)
-  apply word_bitwise
-  apply fastforce
+    apply (simp add: is_aligned_def s0_ptr_defs cte_level_bits_def irq_len_val)
+   apply (clarsimp simp: cte_level_bits_def irq_len_val)
+  apply (erule (1) aligned_intvl_neg_mask_start)
+   apply (simp add: is_aligned_def s0_ptr_defs cte_level_bits_def irq_len_val)
+  apply (simp add:  cte_level_bits_def irq_len_val)
   done
 
 lemma irq_node_offs_range_distinct[simp]:
@@ -731,7 +735,7 @@ lemma irq_node_offs_range_distinct[simp]:
   "idle_tcb_ptr \<notin> irq_node_offs_range"
   "arm_global_pt_ptr \<notin> irq_node_offs_range"
   "shared_page_ptr_virt \<notin> irq_node_offs_range"
-  by(simp add:irq_node_offs_range_def s0_ptr_defs)+
+  by(simp add: irq_node_offs_range_def  irq_len_val cte_level_bits_def s0_ptr_defs)+
 
 lemma irq_node_offs_distinct[simp]:
   "init_irq_node_ptr + (ucast (irq:: irq) << 5) \<noteq> Low_cnode_ptr"
@@ -755,14 +759,14 @@ lemma irq_node_offs_distinct[simp]:
 lemma kh0_dom:
   "dom kh0 = {shared_page_ptr_virt, arm_global_pt_ptr, idle_tcb_ptr, High_tcb_ptr, Low_tcb_ptr,
               High_pt_ptr, Low_pt_ptr, High_pd_ptr, Low_pd_ptr, irq_cnode_ptr, ntfn_ptr,
-              Silc_cnode_ptr, High_pool_ptr, Low_pool_ptr, High_cnode_ptr, Low_cnode_ptr}
-           \<union> irq_node_offs_range"
+              Silc_cnode_ptr, High_pool_ptr, Low_pool_ptr, High_cnode_ptr, Low_cnode_ptr} \<union>
+             irq_node_offs_range"
   apply (rule equalityI)
    apply (simp add: kh0_def dom_def)
    apply (clarsimp simp: irq_node_offs_in_range)
   apply (clarsimp simp: dom_def)
   apply (rule conjI, clarsimp simp: kh0_def)+
-  apply (force simp: kh0_def dest: irq_node_offs_range_correct)
+  apply (force simp: kh0_def cte_level_bits_def dest: irq_node_offs_range_correct)
   done
 
 lemmas kh0_SomeD' = set_mp[OF equalityD1[OF kh0_dom[simplified dom_def]], OF CollectI, simplified, OF exI]
@@ -770,7 +774,7 @@ lemmas kh0_SomeD' = set_mp[OF equalityD1[OF kh0_dom[simplified dom_def]], OF Col
 lemma kh0_SomeD:
   "kh0 x = Some y \<Longrightarrow>
         x = shared_page_ptr_virt \<and> y = shared_page \<or>
-        x = arm_global_pt_ptr \<and> y = init_global_pt \<or>
+        x = arm_global_pt_ptr \<and> y = ArchObj global_pt_obj \<or>
         x = idle_tcb_ptr \<and> y = idle_tcb \<or>
         x = High_tcb_ptr \<and> y = High_tcb \<or>
         x = Low_tcb_ptr \<and> y = Low_tcb \<or>
@@ -793,7 +797,7 @@ lemma kh0_SomeD:
 lemmas kh0_obj_def =
   Low_cnode_def High_cnode_def Silc_cnode_def Low_pool_def High_pool_def Low_pd_def High_pd_def
   Low_pt_def High_pt_def  Low_tcb_def High_tcb_def idle_tcb_def irq_cnode_def ntfn_def
-  init_global_pt_def global_pte_def vm_kernel_only_def shared_page_def
+  global_pt_obj_def vm_kernel_only_def shared_page_def
 
 
 definition exst0 :: "det_ext" where
@@ -805,14 +809,32 @@ definition machine_state0 :: "machine_state" where
                      irq_state = 0,
                      underlying_memory = const 0,
                      device_state = Map.empty,
+                     vcpu_state = default_vcpu_state,
+                     fpu_state = FPUState (\<lambda>_. 0) 0 0,
+                     fpu_enabled = False,
                      machine_state_rest = undefined\<rparr>"
+
+(* FIXME AARCH64 IF: override in Init_A *)
+definition init_vspace_uses :: "vspace_ref \<Rightarrow> arm_vspace_region_use" where
+  "init_vspace_uses p \<equiv>
+     if p \<in> kernel_window_range then ArmVSpaceKernelWindow
+     else ArmVSpaceInvalidRegion"
+
+definition max_numlistregs :: nat where
+  "max_numlistregs \<equiv> if config_ARM_GIC_V3 then 16 else 64"
 
 definition arch_state0 :: "arch_state" where
   "arch_state0 \<equiv> \<lparr>
      arm_asid_table = [asid_high_bits_of Low_asid \<mapsto> Low_pool_ptr,
-                         asid_high_bits_of High_asid \<mapsto> High_pool_ptr],
-     arm_kernel_vspace = (\<lambda>level. if level = max_pt_level then {arm_global_pt_ptr} else {}),
-     riscv_kernel_vspace = init_vspace_uses
+                       asid_high_bits_of High_asid \<mapsto> High_pool_ptr],
+     arm_kernel_vspace = init_vspace_uses,
+     arm_asid_map = Map.empty,
+     arm_vmid_table = Map.empty,
+     arm_next_vmid = 0,
+     arm_us_global_vspace = arm_global_pt_ptr,
+     arm_current_vcpu = None,
+     arm_gicvcpu_numlistregs = max_numlistregs - 1,
+     arm_current_fpu_owner = None
    \<rparr>"
 
 definition s0_internal :: "det_ext state" where
@@ -824,8 +846,9 @@ definition s0_internal :: "det_ext state" where
      cur_thread = Low_tcb_ptr,
      idle_thread = idle_tcb_ptr,
      scheduler_action = resume_cur_thread,
-     domain_list = [(0, 10), (1, 10)],
+     domain_list = [(0, 10), (1, 10), (0, 0)],
      domain_index = 0,
+     domain_start_index = 0,
      cur_domain = 0,
      domain_time = 5,
      ready_queues = (const (const [])),
@@ -839,7 +862,7 @@ definition s0_internal :: "det_ext state" where
 lemma kh_s0_def:
   "(kheap s0_internal x = Some y) = (
         x = shared_page_ptr_virt \<and> y = shared_page \<or>
-        x = arm_global_pt_ptr \<and> y = init_global_pt \<or>
+        x = arm_global_pt_ptr \<and> y = ArchObj global_pt_obj \<or>
         x = idle_tcb_ptr \<and> y = idle_tcb \<or>
         x = High_tcb_ptr \<and> y = High_tcb \<or>
         x = Low_tcb_ptr \<and> y = Low_tcb \<or>
@@ -865,7 +888,7 @@ subsubsection \<open>Defining the policy graph\<close>
 definition Sys1AgentMap :: "(auth_graph_label subject_label) agent_map" where
   "Sys1AgentMap \<equiv>
    \<comment> \<open>set the range of the shared_page to Low, default everything else to IRQ0\<close>
-   (\<lambda>p. if p \<in> ptr_range shared_page_ptr_virt (pageBitsForSize RISCVLargePage)
+   (\<lambda>p. if p \<in> ptr_range shared_page_ptr_virt (pageBitsForSize max_page_size)
         then partition_label Low
         else partition_label IRQ0)
    (Low_cnode_ptr := partition_label Low,
@@ -898,7 +921,7 @@ lemma Sys1AgentMap_simps:
   "Sys1AgentMap Low_tcb_ptr = partition_label Low"
   "Sys1AgentMap High_tcb_ptr = partition_label High"
   "Sys1AgentMap idle_tcb_ptr = partition_label Low"
-  "\<And>p. p \<in> ptr_range shared_page_ptr_virt (pageBitsForSize RISCVLargePage)
+  "\<And>p. p \<in> ptr_range shared_page_ptr_virt (pageBitsForSize max_page_size)
          \<Longrightarrow> Sys1AgentMap p = partition_label Low"
   unfolding Sys1AgentMap_def
   apply simp_all
@@ -946,28 +969,28 @@ lemma s0_caps_of_state :
      (p,cap) \<in>
        { ((Low_cnode_ptr,(the_nat_to_bl_10 1)), ThreadCap Low_tcb_ptr),
          ((Low_cnode_ptr,(the_nat_to_bl_10 2)), CNodeCap Low_cnode_ptr 10 (the_nat_to_bl_10 2)),
-         ((Low_cnode_ptr,(the_nat_to_bl_10 3)), ArchObjectCap (PageTableCap Low_pd_ptr (Some (Low_asid,0)))),
-         ((Low_cnode_ptr,(the_nat_to_bl_10 6)), ArchObjectCap (PageTableCap Low_pt_ptr (Some (Low_asid,0)))),
+         ((Low_cnode_ptr,(the_nat_to_bl_10 3)), ArchObjectCap (PageTableCap Low_pd_ptr VSRootPT_T (Some (Low_asid,0)))),
+         ((Low_cnode_ptr,(the_nat_to_bl_10 6)), ArchObjectCap (PageTableCap Low_pt_ptr NormalPT_T (Some (Low_asid,0)))),
          ((Low_cnode_ptr,(the_nat_to_bl_10 4)), ArchObjectCap (ASIDPoolCap Low_pool_ptr Low_asid)),
-         ((Low_cnode_ptr,(the_nat_to_bl_10 5)), ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_write RISCVLargePage False (Some (Low_asid, 0)))),
+         ((Low_cnode_ptr,(the_nat_to_bl_10 5)), ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_write max_page_size False (Some (Low_asid, 0)))),
          ((Low_cnode_ptr,(the_nat_to_bl_10 318)), NotificationCap ntfn_ptr 0 {AllowSend}),
          ((High_cnode_ptr,(the_nat_to_bl_10 1)), ThreadCap High_tcb_ptr),
          ((High_cnode_ptr,(the_nat_to_bl_10 2)), CNodeCap High_cnode_ptr 10 (the_nat_to_bl_10 2)),
-         ((High_cnode_ptr,(the_nat_to_bl_10 3)), ArchObjectCap (PageTableCap High_pd_ptr (Some (High_asid,0)))),
-         ((High_cnode_ptr,(the_nat_to_bl_10 6)), ArchObjectCap (PageTableCap High_pt_ptr (Some (High_asid,0)))),
+         ((High_cnode_ptr,(the_nat_to_bl_10 3)), ArchObjectCap (PageTableCap High_pd_ptr VSRootPT_T (Some (High_asid,0)))),
+         ((High_cnode_ptr,(the_nat_to_bl_10 6)), ArchObjectCap (PageTableCap High_pt_ptr NormalPT_T (Some (High_asid,0)))),
          ((High_cnode_ptr,(the_nat_to_bl_10 4)), ArchObjectCap (ASIDPoolCap High_pool_ptr High_asid)),
-         ((High_cnode_ptr,(the_nat_to_bl_10 5)), ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (High_asid, 0)))),
+         ((High_cnode_ptr,(the_nat_to_bl_10 5)), ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only max_page_size False (Some (High_asid, 0)))),
          ((High_cnode_ptr,(the_nat_to_bl_10 318)), NotificationCap  ntfn_ptr 0 {AllowRecv}) ,
          ((Silc_cnode_ptr,(the_nat_to_bl_10 2)), CNodeCap Silc_cnode_ptr 10 (the_nat_to_bl_10 2)),
-         ((Silc_cnode_ptr,(the_nat_to_bl_10 5)), ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (Silc_asid, 0)))),
+         ((Silc_cnode_ptr,(the_nat_to_bl_10 5)), ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only max_page_size False (Some (Silc_asid, 0)))),
          ((Silc_cnode_ptr,(the_nat_to_bl_10 318)), NotificationCap ntfn_ptr 0 {AllowSend}),
          ((Low_tcb_ptr,(tcb_cnode_index 0)), CNodeCap Low_cnode_ptr 10 (the_nat_to_bl_10 2)),
-         ((Low_tcb_ptr,(tcb_cnode_index 1)), ArchObjectCap (PageTableCap Low_pd_ptr (Some (Low_asid,0)))),
+         ((Low_tcb_ptr,(tcb_cnode_index 1)), ArchObjectCap (PageTableCap Low_pd_ptr VSRootPT_T (Some (Low_asid,0)))),
          ((Low_tcb_ptr,(tcb_cnode_index 2)), ReplyCap Low_tcb_ptr True {AllowGrant, AllowWrite}),
          ((Low_tcb_ptr,(tcb_cnode_index 3)), NullCap),
          ((Low_tcb_ptr,(tcb_cnode_index 4)), NullCap),
          ((High_tcb_ptr,(tcb_cnode_index 0)), CNodeCap High_cnode_ptr 10 (the_nat_to_bl_10 2)),
-         ((High_tcb_ptr,(tcb_cnode_index 1)), ArchObjectCap (PageTableCap High_pd_ptr (Some (High_asid,0)))),
+         ((High_tcb_ptr,(tcb_cnode_index 1)), ArchObjectCap (PageTableCap High_pd_ptr VSRootPT_T (Some (High_asid,0)))),
          ((High_tcb_ptr,(tcb_cnode_index 2)), ReplyCap High_tcb_ptr True {AllowGrant, AllowWrite}),
          ((High_tcb_ptr,(tcb_cnode_index 3)), NullCap),
          ((High_tcb_ptr,(tcb_cnode_index 4)), NullCap)} "
@@ -1039,36 +1062,83 @@ lemma pts_of_s0:
                          High_pd_ptr \<mapsto> High_pd',
                          Low_pt_ptr \<mapsto> Low_pt',
                          High_pt_ptr \<mapsto> High_pt',
-                         arm_global_pt_ptr \<mapsto> init_global_pt']"
+                         arm_global_pt_ptr \<mapsto> VSRootPT (\<lambda>_. InvalidPTE)]"
   by (auto simp: opt_map_def s0_internal_def kh0_def kh0_obj_def
           split: option.splits if_splits)+
 
 
 lemma ptes_of_s0_PageTablePTE:
-  "\<lbrakk> ptes_of s0_internal ptr = Some pte; is_PageTablePTE pte \<rbrakk>
-     \<Longrightarrow> table_base ptr = Low_pd_ptr \<and> pte = PageTablePTE (ppn_from_addr (addrFromPPtr Low_pt_ptr)) {}
-       \<or> table_base ptr = High_pd_ptr \<and> pte = PageTablePTE (ppn_from_addr (addrFromPPtr High_pt_ptr)) {}"
+  "\<lbrakk> ptes_of s0_internal VSRootPT_T ptr = Some pte; is_PageTablePTE pte \<rbrakk>
+     \<Longrightarrow> table_base VSRootPT_T ptr = Low_pd_ptr \<and> pte = PageTablePTE (ppn_from_pptr Low_pt_ptr)
+       \<or> table_base VSRootPT_T ptr = High_pd_ptr \<and> pte = PageTablePTE (ppn_from_pptr High_pt_ptr)"
   by (auto simp: ptes_of_def pts_of_s0 obind_def kh0_obj_def split: option.splits if_splits)
 
 lemma Low_pt_is_aligned[simp]:
-  "is_aligned Low_pt_ptr pt_bits"
+  "is_aligned Low_pt_ptr (pt_bits NormalPT_T)"
   by (clarsimp simp: s0_ptr_defs pt_bits_def table_size_def ptTranslationBits_def pte_bits_def word_size_bits_def is_aligned_def)
+
+lemma Low_pt_is_aligned'[simp]:
+  "is_aligned Low_pt_ptr pageBits"
+  by (fold pt_bits_NormalPT_T) simp
+
+lemma is_aligned_pptr_base:
+  "is_aligned pptr_base pptrBaseOffset_alignment"
+  by (simp add: is_aligned_def pptr_base_def pptrBase_def pptrBaseOffset_alignment_def)
+
+lemma pptr_base_leq[simp]:
+  "pptr_base \<le> Low_pt_ptr"
+  "pptr_base \<le> Low_pd_ptr"
+  "pptr_base \<le> High_pt_ptr"
+  "pptr_base \<le> High_pd_ptr"
+  unfolding Low_pt_ptr_def Low_pd_ptr_def High_pt_ptr_def High_pd_ptr_def
+  apply (all \<open>rule is_aligned_no_wrap'[OF is_aligned_pptr_base]\<close>)
+  apply (simp_all add: pptrBaseOffset_alignment_def)
+  done
+
+lemma pptr_base_less[simp]:
+  "Low_pt_ptr < pptrTop"
+  "Low_pd_ptr < pptrTop"
+  "High_pt_ptr < pptrTop"
+  "High_pd_ptr < pptrTop"
+  by (auto simp: Low_pt_ptr_def Low_pd_ptr_def High_pt_ptr_def High_pd_ptr_def pptrTop_def pptr_base_def pptrBase_def)
 
 lemma High_pt_is_aligned[simp]:
-  "is_aligned High_pt_ptr pt_bits"
+  "is_aligned High_pt_ptr (pt_bits NormalPT_T)"
   by (clarsimp simp: s0_ptr_defs pt_bits_def table_size_def ptTranslationBits_def pte_bits_def word_size_bits_def is_aligned_def)
 
+lemma High_pt_is_aligned'[simp]:
+  "is_aligned High_pt_ptr pageBits"
+  by (fold pt_bits_NormalPT_T) simp
+
 lemma Low_pd_is_aligned[simp]:
-  "is_aligned Low_pd_ptr pt_bits"
+  "is_aligned Low_pd_ptr (pt_bits VSRootPT_T)"
   by (clarsimp simp: s0_ptr_defs pt_bits_def table_size_def ptTranslationBits_def pte_bits_def word_size_bits_def is_aligned_def)
 
 lemma High_pd_is_aligned[simp]:
-  "is_aligned High_pd_ptr pt_bits"
+  "is_aligned High_pd_ptr (pt_bits VSRootPT_T)"
   by (clarsimp simp: s0_ptr_defs pt_bits_def table_size_def ptTranslationBits_def pte_bits_def word_size_bits_def is_aligned_def)
 
+
+lemma ptrFromPAddr_simps[simp]:
+  "ptrFromPAddr (paddr_from_ppn (ppn_from_pptr Low_pt_ptr)) = Low_pt_ptr"
+  "ptrFromPAddr (paddr_from_ppn (ppn_from_pptr High_pt_ptr)) = High_pt_ptr"
+  by (auto simp: ptrFromPAddr_addr_from_ppn)
+
+lemma table_base_simps[simp]:
+  "table_base VSRootPT_T (pt_slot_offset max_pt_level Low_pd_ptr vref) = Low_pd_ptr"
+  "table_base VSRootPT_T (pt_slot_offset max_pt_level High_pd_ptr vref) = High_pd_ptr"
+  by (auto intro: table_base_pt_slot_offset[where level=max_pt_level, simplified level_type_max])
+
 lemma shared_page_ptr_is_aligned[simp]:
-  "is_aligned shared_page_ptr_virt pt_bits"
-  by (clarsimp simp: s0_ptr_defs pt_bits_def table_size_def ptTranslationBits_def pte_bits_def word_size_bits_def is_aligned_def)
+  "is_aligned shared_page_ptr_virt (pageBitsForSize max_page_size)"
+  by (clarsimp simp: s0_ptr_defs pt_bits_def table_size_def max_page_size_def ptTranslationBits_def pte_bits_def word_size_bits_def is_aligned_def pageBits_def)
+
+lemma asid_high_low:
+  "\<lbrakk> asid_high_bits_of asid = asid_high_bits_of asid';
+     asid_low_bits_of asid = asid_low_bits_of asid' \<rbrakk> \<Longrightarrow>
+   asid = asid'"
+  unfolding asid_high_bits_of_def asid_low_bits_of_def asid_high_bits_def asid_low_bits_def
+  by word_bitwise simp
 
 lemma vs_lookup_s0_SomeD:
   "vs_lookup_table lvl asid vref s0_internal = Some (lvl', p)
@@ -1081,26 +1151,60 @@ lemma vs_lookup_s0_SomeD:
   apply (clarsimp simp: vs_lookup_table_def obind_def split: option.splits if_splits)
    apply (clarsimp simp: pool_for_asid_s0 split: if_splits)
   apply (case_tac "lvl = max_pt_level")
-   apply (clarsimp simp: asid_pools_of_s0 pool_for_asid_s0 asid_high_low vspace_for_pool_def
+   apply (clarsimp simp: asid_pools_of_s0 pool_for_asid_s0 asid_high_low vspace_for_pool_def entry_for_pool_def
                   split: if_splits)
   apply (case_tac "lvl = max_pt_level - 1")
    apply (clarsimp simp: pt_walk.simps split: if_splits)
     apply (drule (1) ptes_of_s0_PageTablePTE)
-    apply (auto simp: pptr_from_pte_def ptrFromPAddr_addr_from_ppn' ptes_of_def asid_high_low
-                      kh0_obj_def pts_of_s0 pool_for_asid_s0 asid_pools_of_s0 vspace_for_pool_def
+    apply (auto simp: pptr_from_pte_def  ptes_of_def asid_high_low
+                      kh0_obj_def pts_of_s0 pool_for_asid_s0 asid_pools_of_s0 vspace_for_pool_def entry_for_pool_def
                split: if_splits)[2]
   apply (clarsimp simp: pt_walk.simps)
   apply (clarsimp split: if_splits)
    apply (drule (1) ptes_of_s0_PageTablePTE)
    apply (erule disjE; clarsimp)
-  by (clarsimp simp: pptr_from_pte_def ptrFromPAddr_addr_from_ppn' kh0_obj_def
-                     pt_walk.simps ptes_of_def pts_of_s0 asid_high_low
-                     pool_for_asid_s0 asid_pools_of_s0 vspace_for_pool_def
-              split: if_splits)+
+    apply (clarsimp simp: vspace_for_pool_def entry_for_pool_def pptr_from_pte_def asid_pools_of_s0 pool_for_asid_s0
+                   split: if_splits)
+    apply (clarsimp simp: pts_of_s0 asid_high_low)
+    apply (subst (asm) pt_walk.simps)
+    apply (clarsimp split: if_splits)
+    apply (clarsimp simp: level_pte_of_def pt_apply_def split: pt.splits option.splits if_splits simp: obind_def)
+   apply (clarsimp simp: vspace_for_pool_def entry_for_pool_def pptr_from_pte_def asid_pools_of_s0 pool_for_asid_s0
+                  split: if_splits)
+   apply (clarsimp simp: pts_of_s0 asid_high_low)
+   apply (subst (asm) pt_walk.simps)
+   apply (clarsimp split: if_splits)
+   apply (clarsimp simp: level_pte_of_def pt_apply_def split: pt.splits option.splits if_splits simp: obind_def)
+  apply (clarsimp simp: vspace_for_pool_def entry_for_pool_def pptr_from_pte_def asid_pools_of_s0 pool_for_asid_s0
+                 split: if_splits)
+   apply (clarsimp simp: pts_of_s0 asid_high_low)
+  apply (clarsimp simp: pts_of_s0 asid_high_low)
+  done
 
-lemma pt_bits_left_max_minus_1_pageBitsForSize:
-  "pt_bits_left (max_pt_level - 1) = pageBitsForSize RISCVLargePage"
-  apply (clarsimp simp: pt_bits_left_def max_pt_level_def2)
+lemma ptr_range_weaken:
+  "\<lbrakk> (x :: machine_word) \<in> ptr_range ptr sz'; sz' \<le> sz; sz \<le> word_bits; is_aligned ptr sz \<rbrakk> \<Longrightarrow> x \<in> ptr_range ptr sz"
+  apply (clarsimp simp: ptr_range_def)
+  apply (erule order.trans)
+  apply (frule (1) order.trans)
+  apply (subgoal_tac "ptr + mask sz' \<le> ptr + mask sz")
+   apply (clarsimp simp: mask_def p_assoc_help)
+  apply (subgoal_tac "is_aligned ptr sz \<and> is_aligned ptr sz'")
+   apply (rule aligned_mask_step; clarsimp simp: is_aligned_no_overflow_mask)
+  apply (auto elim: is_aligned_weaken)
+  done
+
+lemma max_page_level_def2:
+  "max_page_level = max_pt_level - 1"
+  by (simp add: max_pt_level_def max_page_level_def asid_pool_level_def)
+
+lemma ptr_range_max_pt_level_minus_1:
+  "\<lbrakk> (x :: machine_word) \<in> ptr_range ptr (pt_bits_left (max_pt_level - 1));
+     is_aligned ptr (pageBitsForSize max_page_size)\<rbrakk>
+     \<Longrightarrow> x \<in> ptr_range ptr (pageBitsForSize max_page_size)"
+  apply (erule ptr_range_weaken)
+    apply (clarsimp simp: max_page_size_def2 max_page_level_def2)
+   apply (clarsimp simp: word_bits_def max_page_size_def pageBits_def ptTranslationBits_def split: if_splits)
+  apply assumption
   done
 
 lemma Sys1_pas_refined:
@@ -1109,7 +1213,7 @@ lemma Sys1_pas_refined:
   apply (intro conjI)
        apply (simp add: Sys1_pas_wellformed)
       apply (clarsimp simp: irq_map_wellformed_aux_def s0_internal_def Sys1AgentMap_def Sys1PAS_def)
-      apply (clarsimp simp: s0_ptr_defs ptr_range_def)
+      apply (clarsimp simp: s0_ptr_defs ptr_range_def ptTranslationBits_def pageBits_def cte_level_bits_def)
       apply word_bitwise
      apply (clarsimp simp: tcb_domain_map_wellformed_aux_def minBound_word High_domain_def Low_domain_def
                            Sys1PAS_def Sys1AgentMap_def default_domain_def)
@@ -1132,9 +1236,13 @@ lemma Sys1_pas_refined:
     apply (elim disjE; clarsimp)
          apply ((clarsimp simp: s0_internal_def kh0_obj_def opt_map_def vs_refs_aux_def
                                 vm_read_only_def vspace_cap_rights_to_auth_def pte_ref2_def
-                                Sys1AuthGraph_def Sys1AgentMap_simps graph_of_def ptrFromPAddr_addr_from_ppn'
-                                shared_page_ptr_phys_def pt_bits_left_max_minus_1_pageBitsForSize
-                         dest!: kh0_SomeD split: option.splits if_splits)+)[6]
+                                Sys1AuthGraph_def Sys1AgentMap_simps graph_of_def
+                                shared_page_ptr_phys_def
+                         dest!: kh0_SomeD split: option.splits if_splits | drule ptr_range_max_pt_level_minus_1)+)[6]
+    apply (clarsimp simp: state_hyp_refs_of_def hyp_refs_of_def tcb_vcpu_refs_def
+                          s0_internal_def refs_of_ao_def
+                   split: option.splits kernel_object.splits arch_kernel_obj.splits)
+     apply (auto dest: kh0_SomeD simp: kh0_obj_def)[2]
    apply (rule subsetI, clarsimp)
    apply (erule state_asids_to_policy_aux.cases)
      apply (drule s0_caps_of_state, clarsimp)
@@ -1178,7 +1286,7 @@ lemma Sys1_pas_wellformed_noninterference:
 
 lemma Sys1AgentMap_shared_page_ptr:
   "Sys1AgentMap shared_page_ptr_virt = partition_label Low"
-  by (clarsimp simp: Sys1AgentMap_def s0_ptr_defs ptr_range_def bit_simps)
+  by (clarsimp simp: Sys1AgentMap_def s0_ptr_defs ptr_range_def bit_simps max_page_size_def)
 
 lemma silc_inv_s0:
   "silc_inv Sys1PAS s0_internal s0_internal"
@@ -1224,7 +1332,6 @@ lemma only_timer_irq_s0:
   "only_timer_irq timer_irq s0_internal"
   apply (clarsimp simp: only_timer_irq_def s0_internal_def irq_is_recurring_def is_irq_at_def
                         irq_at_def Let_def irq_oracle_def machine_state0_def timer_irq_def)
-  apply presburger
   done
 
 lemma domain_sep_inv_s0:
@@ -1232,6 +1339,7 @@ lemma domain_sep_inv_s0:
   apply (clarsimp simp: domain_sep_inv_def)
   apply (force dest: cte_wp_at_caps_of_state' s0_caps_of_state
          | rule conjI allI | clarsimp simp: s0_internal_def)+
+  apply (clarsimp simp: timer_irq_def non_kernel_IRQs_def irqVGICMaintenance_def irqVTimerEvent_def)
   done
 
 lemma only_timer_irq_inv_s0:
@@ -1269,13 +1377,13 @@ lemma valid_caps_s0[simp]:
   "s0_internal \<turnstile> CNodeCap Silc_cnode_ptr 10 (the_nat_to_bl_10 2)"
   "s0_internal \<turnstile> ArchObjectCap (ASIDPoolCap Low_pool_ptr Low_asid)"
   "s0_internal \<turnstile> ArchObjectCap (ASIDPoolCap High_pool_ptr High_asid)"
-  "s0_internal \<turnstile> ArchObjectCap (PageTableCap Low_pd_ptr (Some (Low_asid,0)))"
-  "s0_internal \<turnstile> ArchObjectCap (PageTableCap High_pd_ptr (Some (High_asid,0)))"
-  "s0_internal \<turnstile> ArchObjectCap (PageTableCap Low_pt_ptr (Some (Low_asid,0)))"
-  "s0_internal \<turnstile> ArchObjectCap (PageTableCap High_pt_ptr (Some (High_asid,0)))"
-  "s0_internal \<turnstile> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_write RISCVLargePage False (Some (Low_asid,0)))"
-  "s0_internal \<turnstile> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (High_asid,0)))"
-  "s0_internal \<turnstile> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only RISCVLargePage False (Some (Silc_asid,0)))"
+  "s0_internal \<turnstile> ArchObjectCap (PageTableCap Low_pd_ptr VSRootPT_T (Some (Low_asid,0)))"
+  "s0_internal \<turnstile> ArchObjectCap (PageTableCap High_pd_ptr VSRootPT_T (Some (High_asid,0)))"
+  "s0_internal \<turnstile> ArchObjectCap (PageTableCap Low_pt_ptr NormalPT_T (Some (Low_asid,0)))"
+  "s0_internal \<turnstile> ArchObjectCap (PageTableCap High_pt_ptr NormalPT_T (Some (High_asid,0)))"
+  "s0_internal \<turnstile> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_write max_page_size False (Some (Low_asid,0)))"
+  "s0_internal \<turnstile> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only max_page_size False (Some (High_asid,0)))"
+  "s0_internal \<turnstile> ArchObjectCap (FrameCap shared_page_ptr_virt vm_read_only max_page_size False (Some (Silc_asid,0)))"
   "s0_internal \<turnstile> NotificationCap ntfn_ptr 0 {AllowWrite}"
   "s0_internal \<turnstile> NotificationCap ntfn_ptr 0 {AllowRead}"
   "s0_internal \<turnstile> ReplyCap Low_tcb_ptr True {AllowGrant,AllowWrite}"
@@ -1284,7 +1392,8 @@ lemma valid_caps_s0[simp]:
                  valid_cap_def cap_aligned_def is_aligned_def obj_at_def cte_level_bits_def
                  is_ntfn_def is_tcb_def is_cap_table_def a_type_def the_nat_to_bl_def nat_to_bl_def
                  Low_asid_def High_asid_def Silc_asid_def asid_low_bits_def asid_bits_def
-                 wellformed_mapdata_def valid_vm_rights_def vmsz_aligned_def)
+                 wellformed_mapdata_def valid_vm_rights_def vmsz_aligned_def
+                 max_page_size_def pageBits_def ptTranslationBits_def)
 
 lemma valid_obj_s0[simp]:
   "valid_obj Low_cnode_ptr       Low_cnode      s0_internal"
@@ -1301,7 +1410,7 @@ lemma valid_obj_s0[simp]:
   "valid_obj Low_tcb_ptr         Low_tcb        s0_internal"
   "valid_obj High_tcb_ptr        High_tcb       s0_internal"
   "valid_obj idle_tcb_ptr        idle_tcb       s0_internal"
-  "valid_obj arm_global_pt_ptr init_global_pt s0_internal"
+  "valid_obj arm_global_pt_ptr (ArchObj global_pt_obj) s0_internal"
   "valid_obj shared_page_ptr_virt shared_page s0_internal"
                  apply (simp_all add: valid_obj_def kh0_obj_def)
               apply (simp add: valid_cs_def Low_caps_ran High_caps_ran Silc_caps_ran
@@ -1310,6 +1419,7 @@ lemma valid_obj_s0[simp]:
           apply (simp add: valid_cs_def valid_cs_size_def word_bits_def
                            cte_level_bits_def well_formed_cnode_n_def)
          apply (clarsimp simp: valid_tcb_def tcb_cap_cases_def valid_tcb_state_def valid_arch_tcb_def
+                               valid_pt_range_def invalid_mapping_slots_def
                                is_valid_vtable_root_def is_master_reply_cap_def is_ntfn_def obj_at_def
                                wellformed_pte_def valid_vm_rights_def vm_kernel_only_def
                 | fastforce simp: s0_internal_def kh0_def kh0_obj_def)+
@@ -1317,20 +1427,20 @@ lemma valid_obj_s0[simp]:
 
 lemma valid_objs_s0:
   "valid_objs s0_internal"
-  apply (clarsimp simp: valid_objs_def)
-  apply (subst (asm) s0_internal_def, clarsimp)
-  apply (drule kh0_SomeD)
-  apply (elim disjE; clarsimp)
-  apply (fastforce simp: valid_obj_def valid_cs_def valid_cs_size_def
+   apply (clarsimp simp: valid_objs_def)
+   apply (subst (asm) s0_internal_def, clarsimp)
+   apply (drule kh0_SomeD)
+   apply (elim disjE; clarsimp)
+   apply (fastforce simp: valid_obj_def valid_cs_def valid_cs_size_def
                          cte_level_bits_def word_bits_def well_formed_cnode_n_def)
-  done
+   done
 
 lemma pspace_aligned_s0:
   "pspace_aligned s0_internal"
   apply (clarsimp simp: pspace_aligned_def s0_internal_def)
   apply (drule kh0_SomeD)
   apply (auto simp: cte_level_bits_def irq_node_offs_range_def
-                    is_aligned_def s0_ptr_defs kh0_obj_def bit_simps)
+                    is_aligned_def s0_ptr_defs kh0_obj_def bit_simps max_page_size_def)
   done
 
 lemma pspace_distinct_s0:
@@ -1346,12 +1456,13 @@ lemma pspace_distinct_s0:
    apply auto[1]
   apply (elim disjE)
   (* slow *)
-  by (simp | clarsimp simp: kh0_obj_def cte_level_bits_def s0_ptr_defs pte_bits_def bit_simps
-           | fastforce
-           | clarsimp simp: irq_node_offs_range_def s0_ptr_defs,
-             drule_tac x="0x1F" in word_plus_strict_mono_right, simp, simp add: add.commute,
-             drule(1) notE[rotated, OF less_trans, OF _ _ leD, rotated 2]
-           | drule(1) notE[rotated, OF le_less_trans, OF _ _ leD, rotated 2], simp, assumption)+
+  by ((simp | clarsimp simp: kh0_obj_def cte_level_bits_def s0_ptr_defs pte_bits_def bit_simps
+            | fastforce split: if_split_asm
+            | clarsimp simp: irq_node_offs_range_def s0_ptr_defs irq_len_def cte_level_bits_def,
+              drule_tac x="0x1F" in word_plus_strict_mono_right, simp, simp add: add.commute,
+              drule(1) notE[rotated, OF less_trans, OF _ _ leD, rotated 2]
+            | drule(1) notE[rotated, OF le_less_trans, OF _ _ leD, rotated 2], simp, assumption)+)
+
 
 lemma valid_pspace_s0[simp]:
   "valid_pspace s0_internal"
@@ -1360,7 +1471,7 @@ lemma valid_pspace_s0[simp]:
    apply (clarsimp simp: if_live_then_nonz_cap_def)
    apply (subst (asm) s0_internal_def)
    apply (clarsimp simp: ex_nonz_cap_to_def live_def arch_tcb_live_def
-                         hyp_live_def obj_at_def kh0_def kh0_obj_def
+                         hyp_live_def obj_at_def kh0_def kh0_obj_def arch_live_def
                   split: if_splits)
      apply (rule_tac x="High_cnode_ptr" in exI)
      apply (rule_tac x="the_nat_to_bl_10 1" in exI)
@@ -1378,7 +1489,7 @@ lemma valid_pspace_s0[simp]:
     apply (force dest: s0_caps_of_state simp: cte_wp_at_caps_of_state zombies_final_def is_zombie_def)
    apply (clarsimp simp: sym_refs_def state_refs_of_def state_hyp_refs_of_def
                          refs_of_def s0_internal_def kh0_def kh0_obj_def)
-  apply (clarsimp simp: sym_refs_def state_hyp_refs_of_def s0_internal_def kh0_def)
+  apply (clarsimp simp: sym_refs_def state_hyp_refs_of_def s0_internal_def kh0_def kh0_obj_def)
   done
 
 lemma descendants_s0[simp]:
@@ -1477,18 +1588,38 @@ lemma valid_global_refs_s0[simp]:
                      | simp only: s0_ptr_defs, force)+
   done
 
+
+lemma valid_uses_init_A_st[simp]: "valid_uses_2 init_vspace_uses"
+proof -
+  have "\<And>p. p < pptrTop \<Longrightarrow> canonical_address p"
+    by (simp add: canonical_address_range canonical_bit_def mask_def pptrTop_def
+                  word_le_nat_alt word_less_nat_alt)
+  moreover
+  have "pptr_base < pptrTop"
+    by (simp add: pptrTop_def pptr_base_def pptrBase_def)
+  moreover
+  have "pptrTop < kdev_base"
+    by (simp add: kdev_base_def kdevBase_def pptrTop_def)
+  ultimately
+  show ?thesis
+    unfolding valid_uses_2_def init_vspace_uses_def window_defs
+    by (auto simp: kernel_window_range_def)
+qed
+
 lemma valid_arch_state_s0[simp]:
   "valid_arch_state s0_internal"
   apply (clarsimp simp: valid_arch_state_def s0_internal_def arch_state0_def)
   apply (intro conjI)
-    apply (auto simp: valid_asid_table_def kh0_def kh0_obj_def opt_map_def split: option.splits)[1]
-   apply (fastforce simp: valid_global_arch_objs_def obj_at_def kh0_def a_type_def
-                         init_global_pt_def max_pt_level_not_asid_pool_level[symmetric])
-  apply (clarsimp simp: valid_global_tables_def pt_walk.simps obind_def)
-  apply (fastforce dest: pt_walk_max_level
-                   simp: obind_def opt_map_def asid_pool_level_eq geq_max_pt_level pte_of_def kh0_def
-                         kh0_obj_def pte_rights_of_def
-                  split: if_splits)
+        apply (auto simp: valid_asid_table_def kh0_def kh0_obj_def opt_map_def asid_entry_def
+                          asid_high_bits_of_def asid_low_bits_def Low_asid_def High_asid_def
+                   split: option.splits)[1]
+       apply (clarsimp simp: vmid_inv_def is_inv_def)
+      apply (clarsimp simp: valid_vmid_table_def)
+     apply (clarsimp simp: cur_vcpu_def)
+    apply (clarsimp simp: valid_global_arch_objs_def obj_at_def kh0_def a_type_def
+                              max_pt_level_not_asid_pool_level[symmetric] global_pt_obj_def)
+   apply (clarsimp simp: valid_global_tables_def opt_map_def kh0_def global_pt_obj_def empty_pt_def)
+  apply (clarsimp simp: valid_numlistregs_def word_bits_def max_numlistregs_def)
   done
 
 lemma valid_irq_node_s0[simp]:
@@ -1497,15 +1628,15 @@ lemma valid_irq_node_s0[simp]:
   apply (rule conjI)
    apply (simp add: s0_internal_def)
    apply (rule injI)
-   apply simp
+   apply (simp add: cte_level_bits_def)
    apply (rule ccontr)
-   apply (rule_tac bnd="0x40" and 'a=64 in shift_distinct_helper[rotated 3])
+   apply (rule_tac bnd="0x200" and 'a=64 in shift_distinct_helper[rotated 3])
         apply assumption
-       apply simp
+       apply (simp add: cte_level_bits_def)
       apply simp
-     apply (rule ucast_less[where 'b=6, simplified])
+     apply (rule ucast_less[where 'b=9, simplified])
      apply simp
-    apply (rule ucast_less[where 'b=6, simplified])
+    apply (rule ucast_less[where 'b=9, simplified])
     apply simp
    apply (rule notI)
    apply (drule ucast_up_inj)
@@ -1534,10 +1665,11 @@ lemma valid_arch_objs_s0[simp]:
   "valid_vspace_objs s0_internal"
   apply (clarsimp simp: valid_vspace_objs_def obj_at_def)
   apply (drule vs_lookup_s0_SomeD)
-  apply (auto simp: aobjs_of_Some kh_s0_def kh0_obj_def data_at_def obj_at_def
-                    ptrFromPAddr_addr_from_ppn' vmpage_size_of_level_def max_pt_level_def2
-                    shared_page_ptr_phys_def)
-  done
+  apply (elim disjE)
+  by (auto simp: aobjs_of_Some kh_s0_def kh0_obj_def data_at_def obj_at_def
+                 max_pt_level_def2 vmsize_of_level_def max_page_level_def
+                 shared_page_ptr_phys_def max_page_size_def opt_map_def
+          split: option.splits)
 
 lemma valid_vs_lookup_s0_internal:
   "valid_vs_lookup s0_internal"
@@ -1548,7 +1680,7 @@ lemma valid_vs_lookup_s0_internal:
   apply (clarsimp simp: valid_vs_lookup_def vs_lookup_target_def vs_lookup_slot_def split: if_splits)
    \<comment> \<open>asid pool level\<close>
    apply (drule vs_lookup_level)
-   apply (clarsimp simp: pool_for_asid_vs_lookup pool_for_asid_s0 asid_pools_of_s0
+   apply (clarsimp simp: pool_for_asid_vs_lookup pool_for_asid_s0 asid_pools_of_s0 entry_for_pool_def
                          vspace_for_pool_def user_region_def vref_for_level_asid_pool
                   dest!: asid_high_low split: if_splits)
     \<comment> \<open>High asid\<close>
@@ -1573,89 +1705,113 @@ lemma valid_vs_lookup_s0_internal:
    prefer 2
    \<comment> \<open>bot level = max pt level\<close>
 
-   apply (clarsimp simp: pool_for_asid_s0 vspace_for_pool_def asid_pools_of_s0
+   apply (clarsimp simp: pool_for_asid_s0 vspace_for_pool_def asid_pools_of_s0 entry_for_pool_def
                   dest!: asid_high_low split: if_splits)
     \<comment> \<open>High asid\<close>
     apply (rule conjI, clarsimp simp: High_asid_def asid_low_bits_def)
     apply (rule_tac x=High_cnode_ptr in exI)
     apply (rule_tac x="(the_nat_to_bl_10 6)" in exI)
-    apply (rule_tac x="ArchObjectCap (PageTableCap High_pt_ptr (Some (High_asid,0)))" in exI)
+    apply (rule_tac x="ArchObjectCap (PageTableCap High_pt_ptr NormalPT_T (Some (High_asid,0)))" in exI)
     apply (subst (asm) s0_internal_def)
-    apply (clarsimp simp: in_omonad ptes_of_def High_pd_def ptrFromPAddr_addr_from_ppn'
+    apply (clarsimp simp: in_omonad ptes_of_def High_pd_def
                    dest!: kh0_SomeD split: if_splits)
-     apply (intro conjI)
+    apply (intro conjI)
       apply (fastforce simp: High_cnode_def High_caps_def caps_of_state_simps
                              s0_internal_def kh0_def well_formed_cnode_n_def)
-     apply (clarsimp simp: vref_for_level_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
-     apply (word_bitwise, fastforce)
-    apply (clarsimp simp: kh0_obj_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
-    apply (rule FalseE, word_bitwise, fastforce simp: elf_index_value)
+     apply (clarsimp simp: pptr_from_pte_def)
+    apply (clarsimp simp: vref_for_level_def user_region_simps mask_def bit_simps pt_simps asid_pool_level_def s0_ptr_defs split: if_splits)
+     apply (word_bitwise, clarsimp simp: bit_simps)
+    apply (word_bitwise, clarsimp simp: bit_simps)
    \<comment> \<open>Low asid\<close>
    apply (rule conjI, clarsimp simp: Low_asid_def asid_low_bits_def)
    apply (rule_tac x=Low_cnode_ptr in exI)
    apply (rule_tac x="(the_nat_to_bl_10 6)" in exI)
-   apply (rule_tac x="ArchObjectCap (PageTableCap Low_pt_ptr (Some (Low_asid,0)))" in exI)
+   apply (rule_tac x="ArchObjectCap (PageTableCap Low_pt_ptr NormalPT_T (Some (Low_asid,0)))" in exI)
    apply (subst (asm) s0_internal_def)
-   apply (clarsimp simp: in_omonad ptes_of_def Low_pd_def ptrFromPAddr_addr_from_ppn'
+   apply (clarsimp simp: in_omonad ptes_of_def Low_pd_def
                   dest!: kh0_SomeD split: if_splits)
-    apply (intro conjI)
+   apply (intro conjI)
      apply (fastforce simp: Low_cnode_def Low_caps_def caps_of_state_simps
                             s0_internal_def kh0_def well_formed_cnode_n_def)
-    apply (clarsimp simp: vref_for_level_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
-    apply (word_bitwise, fastforce)
-   apply (clarsimp simp: kh0_obj_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
-   apply (rule FalseE, word_bitwise, fastforce simp: elf_index_value)
+    apply (clarsimp simp: pptr_from_pte_def)
+   apply (clarsimp simp: vref_for_level_def user_region_simps mask_def bit_simps pt_simps asid_pool_level_def s0_ptr_defs split: if_splits)
+    apply (word_bitwise, clarsimp simp: bit_simps)
+   apply (word_bitwise, clarsimp simp: bit_simps)
   \<comment> \<open>bot level < max pt level\<close>
-  apply (clarsimp simp: pool_for_asid_s0 vspace_for_pool_def asid_pools_of_s0
+  apply (clarsimp simp: pool_for_asid_s0 vspace_for_pool_def asid_pools_of_s0 entry_for_pool_def
                  dest!: asid_high_low split: if_splits)
      \<comment> \<open>High asid\<close>
      apply (subst (asm) ptes_of_def)
      apply (clarsimp simp: pts_of_s0)
-     apply (clarsimp simp: in_omonad kh0_obj_def pptr_from_pte_def ptrFromPAddr_addr_from_ppn'
+     apply (clarsimp simp: in_omonad kh0_obj_def pptr_from_pte_def
                     split: if_splits)
      apply (rule conjI, clarsimp simp: High_asid_def asid_low_bits_def)
      apply (prop_tac "pt_walk (max_pt_level - 1) bot_level High_pt_ptr vref (ptes_of s0_internal) =
                       Some (max_pt_level - 1, High_pt_ptr)")
       apply (clarsimp simp: pt_walk.simps)
       apply (clarsimp simp: ptes_of_def pts_of_s0 in_omonad split: if_splits)
-     apply (clarsimp simp: ptes_of_def pts_of_s0 shared_page_ptr_phys_def ptrFromPAddr_addr_from_ppn'
-                    split: if_splits)
+     apply (clarsimp simp: ptes_of_def pts_of_s0 shared_page_ptr_phys_def)
      apply (rule_tac x=High_cnode_ptr in exI)
      apply (rule_tac x="the_nat_to_bl_10 5" in exI)
      apply (rule exI, intro conjI)
        apply (fastforce simp: High_cnode_def High_caps_def caps_of_state_simps
                               s0_internal_def kh0_def well_formed_cnode_n_def)
-      apply clarsimp
-     apply (clarsimp simp: vref_for_level_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
-     apply (word_bitwise, fastforce)
-    \<comment> \<open>Low asid\<close>
-    prefer 2
+      apply (clarsimp split: if_splits)
+     apply (clarsimp split: if_splits)
+      apply (clarsimp simp: vref_for_level_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs asid_pool_level_def split: if_splits)
+       apply (word_bitwise, clarsimp simp: bit_simps)
+      apply (word_bitwise, clarsimp simp: bit_simps)
+     apply (clarsimp simp: vref_for_level_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs asid_pool_level_def  split: if_splits)
+      apply word_bitwise
+     apply word_bitwise
     apply (subst (asm) ptes_of_def)
     apply (clarsimp simp: pts_of_s0)
-    apply (clarsimp simp: in_omonad kh0_obj_def pptr_from_pte_def ptrFromPAddr_addr_from_ppn'
+    apply (clarsimp simp: in_omonad kh0_obj_def pptr_from_pte_def
                    split: if_splits)
-    apply (rule conjI, clarsimp simp: Low_asid_def asid_low_bits_def)
-    apply (prop_tac "pt_walk (max_pt_level - 1) bot_level Low_pt_ptr vref (ptes_of s0_internal) =
-                     Some (max_pt_level - 1, Low_pt_ptr)")
+    apply (rule conjI, clarsimp simp: High_asid_def asid_low_bits_def)
+    apply (prop_tac "pt_walk (max_pt_level - 1) bot_level High_pt_ptr vref (ptes_of s0_internal) =
+                     Some (max_pt_level - 1, High_pt_ptr)")
      apply (clarsimp simp: pt_walk.simps)
      apply (clarsimp simp: ptes_of_def pts_of_s0 in_omonad split: if_splits)
-    apply (clarsimp simp: ptes_of_def pts_of_s0 shared_page_ptr_phys_def ptrFromPAddr_addr_from_ppn'
-                   split: if_splits)
-    apply (rule_tac x=Low_cnode_ptr in exI)
-    apply (rule_tac x="the_nat_to_bl_10 5" in exI)
-    apply (rule exI, intro conjI)
-      apply (fastforce simp: Low_cnode_def Low_caps_def caps_of_state_simps
-                             s0_internal_def kh0_def well_formed_cnode_n_def)
-     apply clarsimp
-    apply (clarsimp simp: vref_for_level_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
-    apply (word_bitwise, fastforce)
+     apply (clarsimp simp: ptes_of_def pts_of_s0 shared_page_ptr_phys_def)
+
+    \<comment> \<open>Low asid\<close>
+
+   apply (subst (asm) ptes_of_def)
+   apply (clarsimp simp: pts_of_s0)
+   apply (clarsimp simp: in_omonad kh0_obj_def pptr_from_pte_def
+                  split: if_splits)
+   apply (rule conjI, clarsimp simp: Low_asid_def asid_low_bits_def)
+   apply (prop_tac "pt_walk (max_pt_level - 1) bot_level Low_pt_ptr vref (ptes_of s0_internal) =
+                    Some (max_pt_level - 1, Low_pt_ptr)")
+    apply (clarsimp simp: pt_walk.simps)
+    apply (clarsimp simp: ptes_of_def pts_of_s0 in_omonad split: if_splits)
+   apply (clarsimp simp: ptes_of_def pts_of_s0 shared_page_ptr_phys_def)
+   apply (rule_tac x=Low_cnode_ptr in exI)
+   apply (rule_tac x="the_nat_to_bl_10 5" in exI)
+   apply (rule exI, intro conjI)
+     apply (fastforce simp: Low_cnode_def Low_caps_def caps_of_state_simps
+                            s0_internal_def kh0_def well_formed_cnode_n_def)
+    apply (clarsimp split: if_splits)
+   apply (clarsimp split: if_splits)
+    apply (clarsimp simp: vref_for_level_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs asid_pool_level_def split: if_splits)
+     apply word_bitwise
+    apply word_bitwise
+   apply (clarsimp simp: vref_for_level_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs asid_pool_level_def split: if_splits)
+    apply (word_bitwise, clarsimp simp: bit_simps)
+   apply (word_bitwise, clarsimp simp: bit_simps)
+
    \<comment> \<open>No lookups to other ptes\<close>
-   apply (clarsimp simp: in_omonad ptes_of_def pts_of_s0  split: if_splits)
-   apply (clarsimp simp: kh0_obj_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
-   apply (rule FalseE, word_bitwise, fastforce simp: elf_index_value)
-  apply (clarsimp simp: in_omonad ptes_of_def pts_of_s0  split: if_splits)
-  apply (clarsimp simp: kh0_obj_def mask_def pt_simps user_region_simps bit_simps s0_ptr_defs)
-  apply (rule FalseE, word_bitwise, fastforce simp: elf_index_value)
+  apply (subst (asm) ptes_of_def)
+  apply (clarsimp simp: pts_of_s0)
+  apply (clarsimp simp: in_omonad kh0_obj_def pptr_from_pte_def
+                 split: if_splits)
+  apply (rule conjI, clarsimp simp: Low_asid_def asid_low_bits_def)
+  apply (prop_tac "pt_walk (max_pt_level - 1) bot_level Low_pt_ptr vref (ptes_of s0_internal) =
+                   Some (max_pt_level - 1, Low_pt_ptr)")
+   apply (clarsimp simp: pt_walk.simps)
+   apply (clarsimp simp: ptes_of_def pts_of_s0 in_omonad split: if_splits)
+  apply (clarsimp simp: ptes_of_def pts_of_s0 shared_page_ptr_phys_def)
   done
 
 lemma valid_arch_caps_s0[simp]:
@@ -1715,112 +1871,30 @@ lemma equal_kernel_mappings_s0[simp]:
                 pageBits_def ptTranslationBits_def mask_def max_pt_level_def2
   apply (clarsimp simp: equal_kernel_mappings_def obj_at_def vspace_for_asid_def
                         vspace_for_pool_def pool_for_asid_s0 asid_pools_of_s0)
-   apply (clarsimp simp: obind_def pts_of_s0)
-   apply (clarsimp simp: has_kernel_mappings_def split: if_splits)
-   apply (rule conjI; clarsimp)
-    apply (clarsimp simp: kernel_mapping_slots_def s0_ptr_defs misc)
-   apply (fastforce simp: pts_of_s0 s0_internal_def arch_state0_def
-                          kh0_obj_def opt_map_def riscv_global_pt_def
-                   dest!: kh0_SomeD split: if_splits option.splits)
-  apply (clarsimp simp: pts_of_s0)
-  apply (clarsimp simp: s0_internal_def riscv_global_pt_def arch_state0_def kh0_obj_def
-                        kernel_mapping_slots_def s0_ptr_defs misc elf_index_value)+
   done
 
 lemma valid_asid_map_s0[simp]:
   "valid_asid_map s0_internal"
   by (clarsimp simp: valid_asid_map_def s0_internal_def arch_state0_def)
 
-lemma valid_global_pd_mappings_s0_helper:
-  "\<lbrakk> pptr_base \<le> vref; vref < pptr_base + (1 << kernel_window_bits) \<rbrakk>
-     \<Longrightarrow> \<exists>a b. pt_lookup_target 0 arm_global_pt_ptr vref (ptes_of s0_internal) = Some (a, b) \<and>
-               is_aligned b (pt_bits_left a) \<and>
-               addrFromPPtr b + (vref && mask (pt_bits_left a)) = addrFromPPtr vref"
-  supply misc = vref_for_level_def pt_bits_left_def asid_pool_level_size
-                pageBits_def ptTranslationBits_def mask_def max_pt_level_def2
-  apply (clarsimp simp: pt_lookup_target_def obind_def split: option.splits)
-  apply (prop_tac "pt_lookup_slot_from_level max_pt_level 0 arm_global_pt_ptr vref (ptes_of s0_internal) =
-                   Some (max_pt_level, pt_slot_offset max_pt_level arm_global_pt_ptr vref)")
-   apply (clarsimp simp: pt_lookup_slot_from_level_def pt_walk.simps)
-   apply (fastforce simp: ptes_of_def in_omonad s0_internal_def kh0_def init_global_pt_def
-                          global_pte_def is_aligned_pt_slot_offset_pte)
-  apply (clarsimp simp: pt_lookup_slot_from_level_def pt_walk.simps)
-  apply (rule conjI; clarsimp dest!: pt_walk_max_level simp: max_pt_level_def2 split: if_splits)
-  apply (rule conjI; clarsimp)
-   apply (clarsimp simp: ptes_of_def pts_of_s0 global_pte_def kernel_window_bits_def
-                         table_index_offset_pt_bits_left is_aligned_pt_slot_offset_pte
-                  split: if_splits)
-    apply (clarsimp simp: misc s0_ptr_defs)
-    apply (word_bitwise, fastforce)
-   apply (clarsimp simp: misc s0_ptr_defs kernel_mapping_slots_def)
-   apply (word_bitwise, fastforce)
-  apply (clarsimp simp: ptes_of_def pts_of_s0 is_aligned_pt_slot_offset_pte global_pte_def
-                 split: if_splits)
-   apply (clarsimp simp: addr_from_ppn_def ptrFromPAddr_def addrFromPPtr_def bit_simps
-                         mask_def s0_ptr_defs pt_bits_left_def max_pt_level_def2
-                         pptrBaseOffset_def paddrBase_def is_aligned_def kernel_window_bits_def)
-   apply (word_bitwise, fastforce)
-  apply (clarsimp simp: addr_from_ppn_def ptrFromPAddr_def addrFromPPtr_def bit_simps is_aligned_def
-                        s0_ptr_defs pt_bits_left_def max_pt_level_def2 kernel_mapping_slots_def
-                        mask_def pt_slot_offset_def pt_index_def pptrBaseOffset_def paddrBase_def
-                        toplevel_bits_value elf_index_value kernel_window_bits_def)
-  apply (word_bitwise, fastforce)
-  done
-
-lemma ptes_of_elf_window:
-  "\<lbrakk>kernel_elf_base \<le> vref; vref < kernel_elf_base + 2 ^ pageBits\<rbrakk>
-   \<Longrightarrow> ptes_of s0_internal (pt_slot_offset max_pt_level arm_global_pt_ptr vref)
-       = Some (global_pte elf_index)"
-  unfolding ptes_of_def pts_of_s0
-  apply (clarsimp simp: obind_def elf_window_4k is_aligned_pt_slot_offset_pte)
-  done
-
-lemma valid_global_pd_mappings_s0_helper':
-  "\<lbrakk> kernel_elf_base \<le> vref; vref < kernel_elf_base + (1 << pageBits) \<rbrakk>
-     \<Longrightarrow> \<exists>a b. pt_lookup_target 0 arm_global_pt_ptr vref (ptes_of s0_internal) = Some (a, b) \<and>
-               is_aligned b (pt_bits_left a) \<and>
-               addrFromPPtr b + (vref && mask (pt_bits_left a)) = addrFromKPPtr vref"
-  supply misc = vref_for_level_def pt_bits_left_def asid_pool_level_size
-                pageBits_def ptTranslationBits_def mask_def max_pt_level_def2
-  apply (clarsimp simp: pt_lookup_target_def obind_def split: option.splits)
-  apply (prop_tac "pt_lookup_slot_from_level max_pt_level 0 arm_global_pt_ptr vref (ptes_of s0_internal) =
-                   Some (max_pt_level, pt_slot_offset max_pt_level arm_global_pt_ptr vref)")
-   apply (clarsimp simp: pt_lookup_slot_from_level_def pt_walk.simps)
-   apply (fastforce simp: ptes_of_def in_omonad s0_internal_def kh0_def init_global_pt_def
-                          global_pte_def is_aligned_pt_slot_offset_pte)
-  apply (rule conjI; clarsimp)
-  apply (rule conjI; clarsimp)
-   apply (clarsimp simp: pt_lookup_slot_from_level_def pt_walk.simps)
-  apply (rule conjI; clarsimp)
-   apply (clarsimp simp: ptes_of_elf_window global_pte_def split: if_splits)
-  apply (clarsimp simp: ptes_of_elf_window global_pte_def elf_index_value)
-  apply (clarsimp simp: is_aligned_ptrFromPAddr_kernelELFPAddrBase kernelELFPAddrBase_addrFromKPPtr)
-  done
-
 lemma valid_global_pd_mappings_s0[simp]:
   "valid_global_vspace_mappings s0_internal"
-  unfolding valid_global_vspace_mappings_def Let_def
-  apply (intro conjI)
-    apply (simp add: s0_internal_def arch_state0_def riscv_global_pt_def)
-   apply (fastforce simp: s0_internal_def arch_state0_def in_omonad kernel_window_def
-                          init_vspace_uses_def translate_address_def riscv_global_pt_def
-                   dest!: valid_global_pd_mappings_s0_helper split: if_splits)
-  apply (fastforce simp: translate_address_def in_omonad s0_internal_def arch_state0_def
-                         riscv_global_pt_def kernel_elf_window_def init_vspace_uses_def
-                  dest!: valid_global_pd_mappings_s0_helper' split: if_splits)
-  done
+  unfolding valid_global_vspace_mappings_def by simp
 
 lemma pspace_in_kernel_window_s0[simp]:
   "pspace_in_kernel_window s0_internal"
-  apply (clarsimp simp: pspace_in_kernel_window_def kernel_window_def
+  apply (clarsimp simp: pspace_in_kernel_window_def kernel_window_def kernel_window_range_def
                         init_vspace_uses_def s0_internal_def arch_state0_def)
-  apply (subgoal_tac "x \<in> {pptr_base..<pptr_base + (1 << kernel_window_bits)}"; clarsimp)
   apply (drule kh0_SomeD)
-  by (clarsimp simp: s0_ptr_defs kh0_obj_def cte_level_bits_def table_size pageBits_def
-                     ptTranslationBits_def kernel_window_bits_def
-              dest!: irq_node_offs_range_correct
-      | erule disjE dual_order.strict_trans2[rotated] dual_order.trans
-      | rule conjI | word_bitwise)+
+  apply (auto simp: s0_ptr_defs kh0_obj_def pageBits_def ptTranslationBits_def pptrTop_def table_size_def
+                    pte_bits_def word_size_bits_def cte_level_bits_def max_page_size_def
+             dest!: irq_node_offs_range_correct
+              elim: dual_order.trans dual_order.strict_trans2[rotated])
+   apply word_bitwise
+   apply clarsimp
+  apply word_bitwise
+  apply clarsimp
+  done
 
 lemma cap_refs_in_kernel_window_s0[simp]:
   "cap_refs_in_kernel_window s0_internal"
@@ -1832,12 +1906,11 @@ lemma cap_refs_in_kernel_window_s0[simp]:
   apply (erule swap, clarsimp)
   apply (drule s0_caps_of_state)
   apply (clarsimp simp: kernel_window_def init_vspace_uses_def s0_internal_def arch_state0_def)
-  apply (subgoal_tac "x \<in> {pptr_base..<pptr_base + (1 << kernel_window_bits)}"; clarsimp)
-  by (clarsimp simp: s0_ptr_defs kh0_obj_def table_size pageBits_def ptTranslationBits_def
-                     kernel_window_bits_def
-              dest!: irq_node_offs_range_correct
-      | erule disjE dual_order.strict_trans2[rotated] dual_order.trans
-      | rule conjI | word_bitwise)+
+  apply (auto simp: s0_ptr_defs kh0_obj_def pageBits_def ptTranslationBits_def pptrTop_def table_size_def
+                    pte_bits_def word_size_bits_def cte_level_bits_def kernel_window_range_def
+             dest!: irq_node_offs_range_correct
+              elim: dual_order.trans dual_order.strict_trans2[rotated])
+  done
 
 lemma cur_tcb_s0[simp]:
   "cur_tcb s0_internal"
@@ -1880,9 +1953,13 @@ lemma respects_device_trivial:
   apply (clarsimp simp: s0_internal_def machine_state0_def)
   done
 
+lemma valid_cur_fpu_s0[simp]:
+  "valid_cur_fpu s0_internal"
+  by (auto simp: valid_cur_fpu_def s0_internal_def is_tcb_cur_fpu_def obj_at_def kh0_obj_def arch_state0_def dest!: kh0_SomeD)
+
 lemma einvs_s0:
   "einvs s0_internal"
-  by (simp add: valid_state_def invs_def valid_cur_fpu_def respects_device_trivial)
+  by (simp add: valid_state_def invs_def respects_device_trivial)
 
 
 subsubsection \<open>Haskell state\<close>
@@ -1922,6 +1999,11 @@ lemma Sys1_valid_initial_state_noenabled:
                            domain_sep_inv_s0 Sys1_pas_refined Sys1_guarded_pas_domain
                            idle_equiv_refl)
           apply (clarsimp simp: valid_domain_list_2_def s0_internal_def exst0_def)
+          apply (intro conjI)
+            apply (clarsimp simp: valid_cur_hyp_def valid_cur_vcpu_def pred_tcb_at_def obj_at_def kh0_def
+                                  kh0_obj_def active_cur_vcpu_of_def arch_state0_def)
+           apply (clarsimp simp: cur_hyp_in_cur_domain_def cur_vcpu_in_cur_domain_def cur_vcpu_tcb_def arch_state0_def)
+          apply (clarsimp simp: cur_fpu_in_cur_domain_def arch_state0_def)
          apply (simp add: det_inv_s0)
         apply (simp add: s0_internal_def exst0_def)
        apply (simp add: ct_in_state_def st_tcb_at_tcb_states_of_state_eq

--- a/proof/infoflow/ADT_IF.thy
+++ b/proof/infoflow/ADT_IF.thy
@@ -884,6 +884,84 @@ definition irq_state_next where
 
 
 locale ADT_IF_1 =
+  assumes dmo_getActiveIRQ_wp':
+  "\<lbrace>(\<lambda>s. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
+           (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>))
+    and domain_sep_inv False (st :: det_state) and valid_irq_states\<rbrace>
+   do_machine_op (getActiveIRQ in_kernel)
+   \<lbrace>P\<rbrace>"
+  and dmo_getActiveIRQ_wp:
+  "\<lbrace>\<lambda>s :: det_state. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
+           (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>)\<rbrace>
+   do_machine_op (getActiveIRQ False)
+   \<lbrace>P\<rbrace>"
+   and do_extended_op_valid_irq_states[wp]:
+     "do_extended_op eop \<lbrace>\<lambda>s :: det_state. valid_irq_states s\<rbrace>"
+   and dmo_getActiveIRQ_valid_irq_states[wp]:
+     "do_machine_op (getActiveIRQ in_kernel) \<lbrace>\<lambda>s :: det_state. valid_irq_states s\<rbrace>"
+   and deleted_irq_handler_valid_irq_states[wp]:
+     "deleted_irq_handler irq \<lbrace>\<lambda>s :: det_state. valid_irq_states s\<rbrace>"
+   and arch_finalise_cap_valid_irq_states[wp]:
+     "arch_finalise_cap c x \<lbrace>\<lambda>s :: det_state. valid_irq_states s\<rbrace>"
+   and arch_post_cap_deletion_valid_irq_states[wp]:
+     "arch_post_cap_deletion c \<lbrace>\<lambda>s :: det_state. valid_irq_states s\<rbrace>"
+   and prepare_thread_delete_valid_irq_states[wp]:
+     "prepare_thread_delete ptr \<lbrace>\<lambda>s :: det_state. valid_irq_states s\<rbrace>"
+  and cur_hyp_in_cur_domain_machine_state_update[simp]:
+    "\<And>f. cur_hyp_in_cur_domain (machine_state_update f s) = cur_hyp_in_cur_domain s"
+  and cur_fpu_in_cur_domain_machine_state_update[simp]:
+    "\<And>f. cur_fpu_in_cur_domain (machine_state_update f s) = cur_fpu_in_cur_domain s"
+  and thread_set_no_etcb_change_cur_fpu_in_cur_domain:
+    "(\<And>P tcb. P (tcb_domain (f tcb)) = (P (tcb_domain tcb) :: bool)) \<Longrightarrow> thread_set f t' \<lbrace>cur_fpu_in_cur_domain\<rbrace>"
+  and thread_set_no_etcb_change_cur_hyp_in_cur_domain:
+    "(\<And>P tcb. P (tcb_domain (f tcb)) = (P (tcb_domain tcb) :: bool)) \<Longrightarrow> thread_set f t' \<lbrace>cur_hyp_in_cur_domain\<rbrace>"
+  and thread_set_tcb_context_valid_cur_hyp[wp]:
+    "thread_set (tcb_arch_update (arch_tcb_context_set tc)) tcb \<lbrace>\<lambda>s :: det_state. valid_cur_hyp s\<rbrace>"
+  and maybe_handle_interrupt_cur_hyp_in_cur_domain:
+    "maybe_handle_interrupt in_kernel \<lbrace>cur_hyp_in_cur_domain\<rbrace>"
+  and maybe_handle_interrupt_cur_fpu_in_cur_domain:
+    "maybe_handle_interrupt in_kernel \<lbrace>cur_fpu_in_cur_domain\<rbrace>"
+  and maybe_handle_interrupt_valid_cur_hyp:
+    "\<lbrace>valid_cur_hyp and invs\<rbrace> maybe_handle_interrupt in_kernel \<lbrace>\<lambda>_ s :: det_state. valid_cur_hyp s\<rbrace>"
+  and handle_event_cur_hyp_in_cur_domain[wp]:
+    "\<lbrace>cur_hyp_in_cur_domain and invs and ct_in_cur_domain and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+     handle_event e
+     \<lbrace>\<lambda>_. cur_hyp_in_cur_domain\<rbrace>"
+  and handle_event_cur_fpu_in_cur_domain[wp]:
+    "\<lbrace>cur_fpu_in_cur_domain and einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+     handle_event e
+     \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
+  and handle_event_valid_cur_hyp:
+    "\<lbrace>valid_cur_hyp and einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+     handle_event e
+     \<lbrace>\<lambda>_ s :: det_state. valid_cur_hyp s\<rbrace>"
+  and schedule_cur_hyp_in_cur_domain:
+    "\<lbrace>\<lambda>s. cur_hyp_in_cur_domain s \<and> valid_sched s \<and> valid_objs s \<and> sym_refs (state_hyp_refs_of s)\<rbrace>
+     schedule
+     \<lbrace>\<lambda>_. cur_hyp_in_cur_domain\<rbrace>"
+  and schedule_cur_fpu_in_cur_domain:
+    "\<lbrace>\<lambda>s. cur_fpu_in_cur_domain s \<and> valid_sched s \<and> valid_objs s \<and> sym_refs (state_hyp_refs_of s)\<rbrace>
+     schedule
+     \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
+  and schedule_valid_cur_hyp:
+    "\<lbrace>valid_cur_hyp and valid_idle\<rbrace>
+     schedule
+     \<lbrace>\<lambda>_ s :: det_state. valid_cur_hyp s\<rbrace>"
+  and activate_thread_cur_hyp_in_cur_domain:
+    "activate_thread \<lbrace>cur_hyp_in_cur_domain\<rbrace>"
+  and activate_thread_cur_fpu_in_cur_domain:
+    "activate_thread \<lbrace>cur_fpu_in_cur_domain\<rbrace>"
+  and activate_thread_valid_cur_hyp:
+    "activate_thread \<lbrace>\<lambda>s :: det_state. valid_cur_hyp s\<rbrace>"
+  and do_user_op_if_cur_hyp_in_cur_domain[wp]:
+    "do_user_op_if uop tc \<lbrace>cur_hyp_in_cur_domain\<rbrace>"
+  and do_user_op_if_cur_fpu_in_cur_domain[wp]:
+    "do_user_op_if uop tc \<lbrace>cur_fpu_in_cur_domain\<rbrace>"
+  and do_user_op_if_valid_cur_hyp[wp]:
+    "do_user_op_if uop tc \<lbrace>\<lambda>s :: det_state. valid_cur_hyp s\<rbrace>"
+
+
+locale ADT_IF_2 = ADT_IF_1 +
   fixes initial_aag :: "'a subject_label PAS"
   assumes do_user_op_if_invs[wp]:
     "do_user_op_if uop tc \<lbrace>invs and ct_running :: det_state \<Rightarrow> bool\<rbrace>"
@@ -928,10 +1006,10 @@ locale ADT_IF_1 =
   and init_arch_objects_irq_state_of_state[wp]:
     "\<And>P. init_arch_objects new_type dev ptr num_objects obj_sz refs \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
   and getActiveIRQ_None:
-    "(None, s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) (s :: det_state))
+    "(None, s') \<in> fst (do_machine_op (getActiveIRQ False) (s :: det_state))
      \<Longrightarrow> irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = None"
   and getActiveIRQ_Some:
-    "(Some irq, s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) s)
+    "(Some irq, s') \<in> fst (do_machine_op (getActiveIRQ False) s)
      \<Longrightarrow> irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = Some irq"
   and kernel_entry_if_idle_equiv:
     "\<lbrace>invs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and domain_sep_inv irqs st and idle_equiv st
@@ -963,12 +1041,12 @@ locale ADT_IF_1 =
   and do_user_op_if_irq_measure_if:
     "\<And>P. do_user_op_if uop tc \<lbrace>\<lambda>s :: det_state. P (irq_measure_if s)\<rbrace>"
   and invoke_tcb_irq_state_inv:
-    "\<lbrace>(\<lambda>s. irq_state_inv st s) and domain_sep_inv False (sta :: det_state)
+    "\<lbrace>(\<lambda>s. irq_state_inv st s) and domain_sep_inv False (sta :: det_state) and valid_irq_states
                                and tcb_inv_wf tinv and K (irq_is_recurring irq st)\<rbrace>
      invoke_tcb tinv
      \<lbrace>\<lambda>_ s. irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   and reset_untyped_cap_irq_state_inv:
-    "\<lbrace>irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
+    "\<lbrace>irq_state_inv st and domain_sep_inv False sta and valid_irq_states and K (irq_is_recurring irq st)\<rbrace>
      reset_untyped_cap slot
      \<lbrace>\<lambda>y. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>y. irq_state_next st\<rbrace>"
   and handle_vm_fault_irq_state_of_state[wp]:
@@ -979,12 +1057,8 @@ locale ADT_IF_1 =
     "create_cap type bits untyped dev sl \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
   and arch_invoke_irq_control_irq_state_of_state[wp]:
     "arch_invoke_irq_control ici \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
-  and thread_set_pas_refined:
-    "\<lbrakk> \<And>tcb. \<forall>(getF, v)\<in>ran tcb_cap_cases. getF (f tcb) = getF tcb;
-       \<And>tcb. tcb_state (f tcb) = tcb_state tcb;
-       \<And>tcb. tcb_bound_notification (f tcb) = tcb_bound_notification tcb;
-       \<And>tcb. tcb_domain (f tcb) = tcb_domain tcb \<rbrakk>
-       \<Longrightarrow> thread_set f t \<lbrace>pas_refined aag\<rbrace>"
+  and thread_set_context_pas_refined:
+    "thread_set (tcb_arch_update (arch_tcb_context_set ctxt)) t \<lbrace>pas_refined aag\<rbrace>"
 begin
 
 lemmas do_user_op_if_no_domain_caps[wp] =
@@ -1000,7 +1074,7 @@ lemma kernel_entry_silc_inv[wp]:
   unfolding kernel_entry_if_def
   by (wpsimp simp: ran_tcb_cap_cases arch_tcb_update_aux2
                wp: hoare_weak_lift_imp handle_event_silc_inv thread_set_silc_inv thread_set_invs_trivial
-                   thread_set_not_state_valid_sched thread_set_pas_refined
+                   thread_set_not_state_valid_sched thread_set_context_pas_refined
       | wp (once) hoare_vcg_imp_lift | force)+
 
 lemma kernel_entry_pas_refined[wp]:
@@ -1011,7 +1085,7 @@ lemma kernel_entry_pas_refined[wp]:
    \<lbrace>\<lambda>_. pas_refined aag\<rbrace>"
   unfolding kernel_entry_if_def
   by (wpsimp simp: ran_tcb_cap_cases schact_is_rct_def arch_tcb_update_aux2
-               wp: hoare_vcg_imp_lift' handle_event_pas_refined thread_set_pas_refined
+               wp: hoare_vcg_imp_lift' handle_event_pas_refined thread_set_context_pas_refined
                    guarded_pas_domain_lift thread_set_invs_trivial thread_set_not_state_valid_sched)+
 
 lemma kernel_entry_if_domain_sep_inv:
@@ -1048,6 +1122,52 @@ lemma kernel_entry_if_valid_domain_list[wp]:
   unfolding kernel_entry_if_def
   by (wpsimp wp: thread_set_invs_trivial simp: ran_tcb_cap_cases arch_tcb_update_aux2)
 
+lemma thread_set_tcb_context_ct_in_cur_domain[wp]:
+ "thread_set (\<lambda>tcb. tcb\<lparr>tcb_arch := arch_tcb_context_set tc (tcb_arch tcb)\<rparr>) t
+         \<lbrace>ct_in_cur_domain\<rbrace>"
+  apply (simp add: thread_set_def set_object_def get_object_def)
+  apply wpsimp
+  done
+
+lemma thread_set_ct_active'[wp]:
+  "thread_set
+          (\<lambda>tcb. tcb\<lparr>tcb_arch := arch_tcb_context_set tc (tcb_arch tcb)\<rparr>)
+          t
+         \<lbrace>ct_active\<rbrace>"
+  by (simp add: arch_tcb_update_aux2
+      thread_set_tcb_context_update_ct_active)
+
+lemma kernel_entry_if_cur_fpu_in_cur_domain:
+  "\<lbrace>cur_fpu_in_cur_domain and einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)
+                                     and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+   kernel_entry_if e tc
+   \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
+  apply (simp add: kernel_entry_if_def)
+  apply (wpsimp wp: thread_set_not_state_valid_sched thread_set_no_etcb_change_cur_fpu_in_cur_domain thread_set_invs_trivial ball_tcb_cap_casesI
+                    hoare_vcg_imp_lift')
+  done
+
+lemma kernel_entry_if_cur_hyp_in_cur_domain:
+  "\<lbrace>cur_hyp_in_cur_domain and einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)
+                                     and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+   kernel_entry_if e tc
+   \<lbrace>\<lambda>_. cur_hyp_in_cur_domain\<rbrace>"
+  apply (simp add: kernel_entry_if_def)
+  apply (wpsimp wp: thread_set_no_etcb_change_cur_hyp_in_cur_domain thread_set_invs_trivial ball_tcb_cap_casesI
+                    hoare_vcg_imp_lift')
+  apply (clarsimp simp: valid_sched_def)
+  done
+
+lemma kernel_entry_if_valid_cur_hyp:
+  "\<lbrace>valid_cur_hyp and einvs and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s)
+                                     and (\<lambda>s. scheduler_action s = resume_cur_thread)\<rbrace>
+   kernel_entry_if e tc
+   \<lbrace>\<lambda>_. valid_cur_hyp\<rbrace>"
+  apply (simp add: kernel_entry_if_def arch_tcb_update_aux2)
+  apply (wpsimp wp: handle_event_valid_cur_hyp thread_set_invs_trivial ball_tcb_cap_casesI
+                    hoare_vcg_imp_lift' thread_set_not_state_valid_sched)
+  done
+
 crunch schedule_if
   for pas_refined[wp]: "pas_refined aag"
 
@@ -1082,7 +1202,12 @@ lemma handle_preemption_if_invs:
   by (wpsimp wp: handle_spurious_irq_invs)
 
 
-context ADT_IF_1 begin
+context ADT_IF_2 begin
+
+crunch handle_preemption_if
+  for cur_hyp_in_cur_domain: cur_hyp_in_cur_domain
+  and cur_fpu_in_cur_domain: cur_fpu_in_cur_domain
+  and valid_cur_hyp: "\<lambda>s :: det_state. valid_cur_hyp s"
 
 lemma handle_kernel_interrupt_domain_sep_inv:
   "\<lbrace>domain_sep_inv irqs st and K (irq \<notin> non_kernel_IRQs)\<rbrace>
@@ -1134,9 +1259,11 @@ end
 
 
 lemma handle_preemption_if_silc_inv[wp]:
-  "handle_preemption_if tc \<lbrace>silc_inv aag st\<rbrace>"
+  "\<lbrace>silc_inv aag st and domain_sep_inv False st\<rbrace>
+   handle_preemption_if tc
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding handle_preemption_if_def maybe_handle_interrupt_def
-  by (wpsimp wp: handle_interrupt_silc_inv do_machine_op_silc_inv)
+  by (wpsimp wp: handle_interrupt_silc_inv' do_machine_op_silc_inv hoare_drop_imps)
 
 crunch handle_preemption_if
   for cur_domain[wp]: "\<lambda>s::det_state. P (cur_domain s)"
@@ -1239,7 +1366,7 @@ lemma set_thread_state_scheduler_action:
   done
 
 
-context ADT_IF_1 begin
+context ADT_IF_2 begin
 
 lemma schedule_guarded_pas_domain:
   "\<lbrace>guarded_pas_domain aag and einvs and pas_refined aag\<rbrace>
@@ -1303,10 +1430,11 @@ crunch schedule_if
   and valid_list[wp]: valid_list
 
 lemma schedule_if_irq_masks:
-  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and valid_irq_states\<rbrace>
    schedule_if tc
    \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
-  by (simp add: schedule_if_def | wp)+
+  unfolding schedule_if_def
+  by (wpsimp wp: schedule_irq_masks[where st=st])
 
 
 definition kernel_schedule_if ::
@@ -1393,15 +1521,15 @@ definition ADT_A_if ::
                                       kernel_handle_preemption_if kernel_schedule_if kernel_exit_A_if
                \<inter> {(s,s'). step_restrict s'})\<rparr>"
 
+
+context ADT_IF_2 begin
+
 lemma check_active_irq_if_wp:
-  "\<lbrace>\<lambda>s. P ((irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s))),tc)
+  "\<lbrace>\<lambda>s :: det_state. P ((irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s))),tc)
           (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>)\<rbrace>
    check_active_irq_if tc
    \<lbrace>P\<rbrace>"
   by (wpsimp wp: dmo_getActiveIRQ_wp simp: check_active_irq_if_def)
-
-
-context ADT_IF_1 begin
 
 lemma handle_preemption_if_only_timer_irq_inv[wp]:
   "handle_preemption_if tc \<lbrace>only_timer_irq_inv irq st\<rbrace>"
@@ -1412,9 +1540,12 @@ end
 
 
 lemma schedule_if_only_timer_irq_inv[wp]:
-  "schedule_if tc \<lbrace>only_timer_irq_inv irq st\<rbrace>"
-  by (wp only_timer_irq_inv_pres schedule_if_irq_masks | blast)+
-
+  "\<lbrace>only_timer_irq_inv irq st and domain_sep_inv False st and valid_irq_states\<rbrace>
+   schedule_if tc
+   \<lbrace>\<lambda>_. only_timer_irq_inv irq st\<rbrace>"
+  by (wpsimp wp: only_timer_irq_inv_pres[where P="domain_sep_inv False st and valid_irq_states"]
+                 schedule_if_irq_masks
+      | simp)+
 
 subsection \<open>Big step IF automaton\<close>
 
@@ -1538,7 +1669,8 @@ locale valid_initial_state_noenabled = invariant_over_ADT_if + (* FIXME: arch-sp
                                pas_refined (current_aag s) s \<and>
                                guarded_pas_domain (current_aag s) s \<and>
                                idle_equiv s0_internal s \<and>
-                               valid_domain_list s \<and> valid_vspace_objs_if s"
+                               valid_domain_list s \<and> valid_vspace_objs_if s \<and> valid_cur_hyp s \<and>
+                               cur_hyp_in_cur_domain s \<and> cur_fpu_in_cur_domain s"
   assumes Invs_s0_internal: "Invs s0_internal"
   assumes det_inv_s0: "det_inv KernelExit (cur_context s0_internal) s0_internal"
   assumes scheduler_action_s0_internal: "scheduler_action s0_internal = resume_cur_thread"
@@ -1667,7 +1799,7 @@ lemma kernel_entry_if_noIRQ_domain_time_sep_inv:
    \<lbrace>\<lambda>_ s. P (domain_time s)\<rbrace>"
   by (wpsimp wp: kernel_entry_if_noIRQ_domain_time_inv simp: no_domain_caps_strg)
 
-context ADT_IF_1 begin
+context ADT_IF_2 begin
 
 lemma kernel_entry_if_domain_time_sched_action:
   "\<lbrace>\<lambda>s. domain_time s > 0\<rbrace>
@@ -2021,8 +2153,13 @@ lemma handle_preemption_if_valid_sched[wp]:
 
 
 locale ADT_valid_initial_state =
-  ADT_IF_1 initial_aag + valid_initial_state _ _ _ initial_aag for initial_aag
+  ADT_IF_2 initial_aag + valid_initial_state _ _ _ initial_aag for initial_aag
 begin
+
+crunch schedule_if
+  for cur_hyp_in_cur_domain[wp]: "cur_hyp_in_cur_domain"
+  and cur_fpu_in_cur_domain[wp]: "cur_fpu_in_cur_domain"
+  and valid_cur_hyp[wp]: "\<lambda>s :: det_state. valid_cur_hyp s"
 
 lemma invs_if_Step_ADT_A_if:
   notes active_from_running[simp]
@@ -2045,6 +2182,9 @@ lemma invs_if_Step_ADT_A_if:
                        kernel_entry_if_idle_equiv
                        kernel_entry_if_domain_time_sched_action
                        kernel_entry_if_noIRQ_domain_time_sep_inv
+                       kernel_entry_if_cur_hyp_in_cur_domain
+                       kernel_entry_if_cur_fpu_in_cur_domain
+                       kernel_entry_if_valid_cur_hyp
                        hoare_false_imp ct_idle_lift
                     | clarsimp intro!: guarded_pas_is_subject_current_aag[rule_format]
                     | intro conjI)+
@@ -2075,6 +2215,9 @@ lemma invs_if_Step_ADT_A_if:
                       kernel_entry_if_domain_sep_inv kernel_entry_if_guarded_pas_domain
                       kernel_entry_if_domain_time_sched_action
                       kernel_entry_if_noIRQ_domain_time_sep_inv
+                      kernel_entry_if_cur_hyp_in_cur_domain
+                      kernel_entry_if_cur_fpu_in_cur_domain
+                      kernel_entry_if_valid_cur_hyp
                       ct_idle_lift
                    | clarsimp intro: guarded_pas_is_subject_current_aag)+
           apply (rule conjI, fastforce intro!: active_from_running)
@@ -2096,12 +2239,16 @@ lemma invs_if_Step_ADT_A_if:
                  rule hoare_drop_imps)
           apply (wp handle_preemption_if_invs handle_preemption_if_domain_sep_inv
                     handle_preemption_if_domain_time_sched_action
-                    handle_preemption_if_det_inv ct_idle_lift)
-         apply fastforce
+                    handle_preemption_if_det_inv ct_idle_lift
+                    handle_preemption_if_cur_hyp_in_cur_domain
+                    handle_preemption_if_cur_fpu_in_cur_domain
+                    handle_preemption_if_valid_cur_hyp)
+         apply clarsimp
         apply (simp add: kernel_schedule_if_def | elim exE conjE)+
         apply (erule use_valid)
          apply ((wp schedule_if_ct_running_or_ct_idle schedule_if_domain_time_nonzero'
                     schedule_if_domain_time_nonzero schedule_if_det_inv hoare_false_imp
+                    schedule_if_cur_hyp_in_cur_domain schedule_if_cur_fpu_in_cur_domain schedule_if_valid_cur_hyp
                  | fastforce simp: invs_valid_idle)+)[2]
        apply (simp add: kernel_exit_A_if_def | elim exE conjE)+
        apply (frule state_unchanged[OF kernel_exit_if_inv])
@@ -2121,7 +2268,7 @@ lemma invs_if_Step_ADT_A_if:
       apply simp
       apply (erule use_valid, erule use_valid[OF _ check_active_irq_if_wp])
        apply (rule_tac Q'="\<lambda>a. (invs and ct_running) and
-                              (\<lambda>b. valid_vspace_objs_if b \<and> valid_list b \<and> valid_sched b \<and>
+                              (\<lambda>b. valid_vspace_objs_if b \<and> valid_list b \<and> valid_sched b \<and> valid_cur_hyp b \<and>
                                    only_timer_irq_inv timer_irq s0_internal b \<and>
                                    silc_inv initial_aag s0_internal b \<and>
                                    pas_refined initial_aag b \<and>
@@ -2129,7 +2276,8 @@ lemma invs_if_Step_ADT_A_if:
                                    idle_equiv s0_internal b \<and>
                                    domain_sep_inv False s0_internal b \<and>
                                    valid_domain_list b \<and> 0 < domain_time b \<and>
-                                   scheduler_action b = resume_cur_thread)" in hoare_strengthen_post)
+                                   scheduler_action b = resume_cur_thread \<and>
+                                   cur_hyp_in_cur_domain b \<and> cur_fpu_in_cur_domain b)" in hoare_strengthen_post)
         apply ((wp do_user_op_if_invs ct_idle_lift | simp add: ct_active_not_idle' | clarsimp)+)[2]
       apply (erule use_valid[OF _ check_active_irq_if_wp])
       apply (simp add: ct_in_state_def)
@@ -2143,7 +2291,7 @@ lemma invs_if_Step_ADT_A_if:
      apply simp
      apply (erule use_valid, erule use_valid[OF _ check_active_irq_if_wp])
       apply (rule_tac Q'="\<lambda>a. (invs and ct_running) and
-                             (\<lambda>b. valid_vspace_objs_if b \<and> valid_list b \<and> valid_sched b \<and>
+                             (\<lambda>b. valid_vspace_objs_if b \<and> valid_list b \<and> valid_sched b \<and> valid_cur_hyp b \<and>
                                   only_timer_irq_inv timer_irq s0_internal b \<and>
                                   silc_inv initial_aag s0_internal b \<and>
                                   pas_refined initial_aag b \<and>
@@ -2151,7 +2299,8 @@ lemma invs_if_Step_ADT_A_if:
                                   idle_equiv s0_internal b \<and>
                                   domain_sep_inv False s0_internal b \<and>
                                   valid_domain_list b \<and> 0 < domain_time b \<and>
-                                  scheduler_action b = resume_cur_thread)" in hoare_strengthen_post)
+                                  scheduler_action b = resume_cur_thread \<and>
+                                  cur_hyp_in_cur_domain b \<and> cur_fpu_in_cur_domain b)" in hoare_strengthen_post)
        apply ((wp do_user_op_if_invs | simp | clarsimp simp: ct_active_not_idle')+)[2]
      apply (erule use_valid[OF _ check_active_irq_if_wp])
      apply (simp add: ct_in_state_def)
@@ -2464,23 +2613,6 @@ lemma OR_choiceE_wp:
   apply (fastforce split: prod.splits)
   done
 
-lemma preemption_point_irq_state_inv'[wp]:
-  "\<lbrace>irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
-   preemption_point
-   \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
-  apply (simp add: preemption_point_def)
-  apply (wpsimp wp: OR_choiceE_wp[where P'="irq_state_inv st and K(irq_is_recurring irq st)"
-                                    and P''="irq_state_inv st and K(irq_is_recurring irq st)"]
-              simp: reset_work_units_def)+
-     apply simp
-     apply (wpsimp wp: OR_choiceE_wp dmo_getActiveIRQ_wp simp: reset_work_units_def)+
-     apply (clarsimp simp: irq_state_inv_def)
-     apply (simp add: next_irq_state_Suc[OF _ recurring_next_irq_state_dom])
-     apply (clarsimp simp: irq_state_next_def)
-     apply (simp add: next_irq_state_Suc'[OF _ recurring_next_irq_state_dom])
-    apply (wp | simp add: update_work_units_def irq_state_inv_def | fastforce)+
-  done
-
 lemma validE_validE_E':
   "\<lbrace>P\<rbrace> f \<lbrace>Q\<rbrace>, \<lbrace>E\<rbrace> \<Longrightarrow> \<lbrace>P\<rbrace> f -, \<lbrace>E\<rbrace>"
   apply (rule validE_validE_E)
@@ -2488,9 +2620,6 @@ lemma validE_validE_E':
     apply assumption
    apply simp+
   done
-
-lemmas preemption_point_irq_state_inv[wp] = validE_validE_R'[OF preemption_point_irq_state_inv']
-lemmas preemption_point_irq_state_next[wp] = validE_validE_E'[OF preemption_point_irq_state_inv']
 
 lemma hoare_add_postE:
   "\<lbrakk> \<lbrace>S\<rbrace> f \<lbrace>\<lambda>_. S'\<rbrace>; \<lbrace>P\<rbrace> f \<lbrace>\<lambda>r s. S' s \<longrightarrow> Q r s\<rbrace>, \<lbrace>\<lambda>r s. S' s \<longrightarrow> E r s\<rbrace> \<rbrakk>
@@ -2504,14 +2633,47 @@ lemma hoare_add_postE:
     apply (assumption, simp, fastforce split: sum.splits)
   done
 
+
+context ADT_IF_1 begin
+
+lemma preemption_point_valid_irq_states[wp]:
+  "preemption_point \<lbrace>\<lambda>s :: det_state. valid_irq_states s\<rbrace>"
+  unfolding preemption_point_def
+  by (wp OR_choiceE_wp[where P'=valid_irq_states and P''=valid_irq_states] hoare_drop_imps
+      | wpc | simp)+
+
+crunch cap_delete
+  for valid_irq_states[wp]: "\<lambda>s :: det_state. valid_irq_states s"
+  (wp: crunch_wps mapM_x_wp hoare_drop_imps simp: crunch_simps)
+
+lemma preemption_point_irq_state_inv'[wp]:
+  "\<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state) and valid_irq_states and K (irq_is_recurring irq st)\<rbrace>
+   preemption_point
+   \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+  (is "validE ?P _ _ _")
+  apply (simp add: preemption_point_def)
+  apply (wpsimp wp: OR_choiceE_wp[where P'="?P" and P''="?P"]
+              simp: reset_work_units_def)+
+      apply simp
+     apply (wpsimp wp: OR_choiceE_wp dmo_getActiveIRQ_wp'[where st=sta] simp: reset_work_units_def)+
+     apply (clarsimp simp: irq_state_inv_def)
+     apply (simp add: next_irq_state_Suc[OF _ recurring_next_irq_state_dom])
+     apply (clarsimp simp: irq_state_next_def)
+     apply (simp add: next_irq_state_Suc'[OF _ recurring_next_irq_state_dom])
+    apply (wp | simp add: update_work_units_def irq_state_inv_def | fastforce)+
+  done
+
+lemmas preemption_point_irq_state_inv[wp] = validE_validE_R'[OF preemption_point_irq_state_inv']
+lemmas preemption_point_irq_state_next[wp] = validE_validE_E'[OF preemption_point_irq_state_inv']
+
 lemma rec_del_irq_state_inv':
   notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del] rec_del.simps[simp del]
   shows
-    "s \<turnstile> \<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
+    "s \<turnstile> \<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state) and valid_irq_states and K (irq_is_recurring irq st)\<rbrace>
          rec_del call
          \<lbrace>\<lambda>a s. (case call of FinaliseSlotCall x y \<Rightarrow> y \<or> fst a \<longrightarrow> snd a = NullCap
                             | _ \<Rightarrow> True) \<and>
-                domain_sep_inv False sta s \<and> irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
+                domain_sep_inv False sta s \<and> valid_irq_states s \<and> irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
 proof (induct s arbitrary: rule: rec_del.induct, simp_all only: rec_del_fails hoare_fail_any)
   case (1 slot exposed s) show ?case
     apply (simp add: split_def rec_del.simps)
@@ -2536,12 +2698,13 @@ next
                  (wp preemption_point_irq_state_inv[where irq=irq] | simp)+)[1]
          apply (rule spec_strengthen_postE)
           apply (rule "2.hyps"[simplified], fastforce+)
-           apply (wp  finalise_cap_domain_sep_inv_cap get_cap_wp
+           apply (wp finalise_cap_domain_sep_inv_cap get_cap_wp
                      finalise_cap_returns_NullCap[where irqs=False, simplified]
                      drop_spec_validE[OF liftE_wp] set_cap_domain_sep_inv
                   | simp add: without_preemption_def split del: if_split
                   | wp (once) hoare_drop_imps
-                  | wp irq_state_inv_triv)+
+                  | wp irq_state_inv_triv
+                  | fastforce)+
     apply (blast dest: cte_wp_at_domain_sep_inv_cap)
     done
 next
@@ -2564,7 +2727,7 @@ next
 qed
 
 lemma rec_del_irq_state_inv:
-  "\<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
+  "\<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state) and valid_irq_states and K (irq_is_recurring irq st)\<rbrace>
    rec_del call
    \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   apply (rule hoare_strengthen_postE)
@@ -2574,7 +2737,7 @@ lemma rec_del_irq_state_inv:
   done
 
 lemma cap_delete_irq_state_inv':
-  "\<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
+  "\<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state) and valid_irq_states and K (irq_is_recurring irq st)\<rbrace>
    cap_delete slot
    \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   by (wpsimp wp: rec_del_irq_state_inv simp: cap_delete_def) auto
@@ -2585,7 +2748,7 @@ lemmas cap_delete_irq_state_next[wp] = validE_validE_E'[OF cap_delete_irq_state_
 lemma cap_revoke_irq_state_inv'':
   notes drop_spec_valid[wp_split del] drop_spec_validE[wp_split del]
   shows
-    "s \<turnstile> \<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
+    "s \<turnstile> \<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state) and valid_irq_states and K (irq_is_recurring irq st)\<rbrace>
          cap_revoke slot
          \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
 proof(induct rule: cap_revoke.induct[where ?a1.0=s])
@@ -2612,13 +2775,13 @@ lemmas cap_revoke_irq_state_inv[wp] = validE_validE_R'[OF cap_revoke_irq_state_i
 lemmas cap_revoke_irq_state_next[wp] = validE_validE_E'[OF cap_revoke_irq_state_inv']
 
 lemma finalise_slot_irq_state_inv:
-  "\<lbrace>irq_state_inv st and domain_sep_inv False sta and K (irq_is_recurring irq st)\<rbrace>
+  "\<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state) and valid_irq_states and K (irq_is_recurring irq st)\<rbrace>
    finalise_slot p e
    \<lbrace>\<lambda>_ s. irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   by (wpsimp wp: rec_del_irq_state_inv[folded validE_R_def] simp: finalise_slot_def) blast
 
 lemma invoke_cnode_irq_state_inv:
-  "\<lbrace>irq_state_inv st and domain_sep_inv False sta
+  "\<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state) and valid_irq_states
                      and valid_cnode_inv cnode_invocation and K (irq_is_recurring irq st)\<rbrace>
    invoke_cnode cnode_invocation
    \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
@@ -2633,6 +2796,9 @@ lemma invoke_cnode_irq_state_inv:
                  | wp (once) hoare_drop_imps)+)[7]
   apply fastforce
   done
+
+end
+
 
 lemma checked_insert_irq_state_of_state[wp]:
   "check_cap_at a b (check_cap_at c d (cap_insert e f g)) \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
@@ -2683,7 +2849,7 @@ lemma irq_state_inv_trivE':
   done
 
 
-context ADT_IF_1 begin
+context ADT_IF_2 begin
 
 crunch invoke_irq_control
   for irq_state_of_state[wp]: "\<lambda>s. P (irq_state_of_state s)"
@@ -2693,17 +2859,18 @@ lemma invoke_irq_control_noErr[wp]:
   by (cases a; wpsimp simp: arch_invoke_irq_control_noErr)
 
 lemma invoke_untyped_irq_state_inv:
-  "\<lbrace>irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
+  "\<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state)
+                     and valid_irq_states and K (irq_is_recurring irq st)\<rbrace>
    invoke_untyped ui
    \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
   apply (cases ui, simp add: invoke_untyped_def mapM_x_def[symmetric])
   apply (rule hoare_pre)
    apply (wp mapM_x_wp' whenE_wp reset_untyped_cap_irq_state_inv[where irq=irq]
-         | rule irq_state_inv_triv | simp)+
+         | rule irq_state_inv_triv | fastforce)+
   done
 
 lemma perform_invocation_irq_state_inv:
-   "\<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state)
+   "\<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state) and valid_irq_states
                       and valid_invocation op and K (irq_is_recurring irq st)
                       and (\<lambda>s. \<forall>i. op = InvokeIRQHandler i \<longrightarrow>
                                    (\<exists>p. cte_wp_at ((=) (IRQHandlerCap (irq_of_handler_inv i))) p s))\<rbrace>
@@ -2713,14 +2880,16 @@ lemma perform_invocation_irq_state_inv:
          (solves \<open>(wp invoke_untyped_irq_state_inv[where irq=irq] irq_state_inv_triv
                       invoke_tcb_irq_state_inv invoke_cnode_irq_state_inv[simplified validE_R_def]
                    | clarsimp | simp add: invoke_domain_def)+\<close>)?)
+    apply wp
+     apply (wpsimp wp: irq_state_inv_triv' invoke_irq_control_irq_masks)
+     apply assumption
+    apply auto[1]
    apply wp
-    apply (wpsimp wp: irq_state_inv_triv' invoke_irq_control_irq_masks)
+    apply (wp irq_state_inv_triv' invoke_irq_handler_irq_masks | clarsimp)+
     apply assumption
    apply auto[1]
-  apply wp
-   apply (wp irq_state_inv_triv' invoke_irq_handler_irq_masks | clarsimp)+
-   apply assumption
-  apply auto[1]
+  apply (wp irq_state_inv_triv' arch_perform_invocation_irq_masks)
+  apply fastforce
   done
 
 lemma hoare_drop_impE:
@@ -2769,12 +2938,16 @@ lemma handle_event_irq_state_inv:
 end
 
 
+lemma schedule_if_irq_state_of_state[wp]:
+  "schedule_if tc \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  by (wpsimp simp: schedule_if_def activate_thread_def wp: hoare_drop_imps)
+
 lemma schedule_if_irq_state_inv:
-  "schedule_if tc \<lbrace>irq_state_inv st\<rbrace>"
-  by (wp irq_state_inv_triv
-      | simp add: schedule_if_def activate_thread_def
-      | wpc
-      | wp (once) hoare_drop_imps)+
+  "\<lbrace>irq_state_inv st and domain_sep_inv False st and valid_irq_states\<rbrace>
+   schedule_if tc
+   \<lbrace>\<lambda>_. irq_state_inv st\<rbrace>"
+  unfolding irq_state_inv_def
+  by (wpsimp wp: schedule_if_irq_masks[where st=st] | wps)+
 
 lemma irq_measure_if_inv:
   assumes irq_state:
@@ -2823,7 +2996,7 @@ abbreviation next_irq_state_of_state where
   "next_irq_state_of_state s \<equiv> next_irq_state (Suc (irq_state_of_state s)) (irq_masks_of_state s)"
 
 
-context ADT_IF_1 begin
+context ADT_IF_2 begin
 
 lemma kernel_entry_if_next_irq_state_of_state:
   "\<lbrakk> event \<noteq> Interrupt; invs i_s; domain_sep_inv False (st :: det_state) i_s;
@@ -2888,18 +3061,20 @@ end
 
 
 lemma schedule_if_irq_measure_if:
-  "(r, b) \<in> fst (schedule_if uc i_s) \<Longrightarrow> irq_measure_if b \<le> irq_measure_if i_s"
+  "\<lbrakk> (r, b) \<in> fst (schedule_if uc i_s); domain_sep_inv False st i_s; valid_irq_states i_s \<rbrakk>
+     \<Longrightarrow> irq_measure_if b \<le> irq_measure_if i_s"
   apply (fold irq_measure_if_inv_def)
   apply (erule use_valid[OF _ irq_measure_if_inv'] | wp schedule_if_irq_state_inv | simp)+
-  apply (simp add: irq_measure_if_inv_def)
+  apply (simp add: irq_measure_if_inv_def domain_sep_inv_refl)
   done
 
 lemma schedule_if_next_irq_state_of_state:
-  "(r, b) \<in> fst (schedule_if uc i_s) \<Longrightarrow> next_irq_state_of_state b = next_irq_state_of_state i_s"
+  "\<lbrakk> (r, b) \<in> fst (schedule_if uc i_s); domain_sep_inv False st i_s; valid_irq_states i_s \<rbrakk>
+     \<Longrightarrow> next_irq_state_of_state b = next_irq_state_of_state i_s"
   apply (erule use_valid)
    apply (rule_tac Q'="\<lambda>_. irq_state_inv i_s" in hoare_strengthen_post)
     apply (wp schedule_if_irq_state_inv)
-   apply (auto simp: irq_state_inv_def)
+   apply (auto simp: irq_state_inv_def domain_sep_inv_refl)
   done
 
 lemma next_irq_state_of_state_triv:
@@ -3033,11 +3208,11 @@ lemma ADT_A_if_Step_measure_if':
                apply (clarsimp split: if_splits)
               apply (rule Suc_le_lessD)
               apply (simp add: kernel_schedule_if_def)
-              apply (blast intro: schedule_if_irq_measure_if)
+              apply (blast intro: schedule_if_irq_measure_if invs_valid_irq_states)
              apply (simp add: kernel_schedule_if_def)
-             apply (blast intro: schedule_if_next_irq_state_of_state)
+             apply (blast intro: schedule_if_next_irq_state_of_state invs_valid_irq_states)
             apply (simp add: kernel_schedule_if_def)
-            apply (blast intro: schedule_if_next_irq_state_of_state)
+            apply (blast intro: schedule_if_next_irq_state_of_state invs_valid_irq_states)
            apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
           apply (clarsimp simp: kernel_exit_A_if_def)
           apply ((erule use_valid, wp | simp)+)[1]
@@ -3127,7 +3302,7 @@ lemma ADT_A_if_Step_measure_if'':
            apply (clarsimp split: if_splits)
           apply (rule Suc_le_lessD)
           apply (simp add: kernel_schedule_if_def)
-          apply (blast intro: schedule_if_irq_measure_if)
+          apply (blast intro: schedule_if_irq_measure_if invs_valid_irq_states)
          apply (clarsimp simp: kernel_exit_A_if_def split: if_splits)
         apply (clarsimp simp: kernel_exit_A_if_def)
         apply ((erule use_valid, wp | simp)+)[1]
@@ -3172,7 +3347,7 @@ lemma ADT_A_if_Step_irq_masks:
     apply (erule use_valid[OF _ handle_preemption_if_irq_masks])
     apply fastforce
    apply (erule use_valid[OF _ schedule_if_irq_masks])
-   apply fastforce
+   apply (blast intro: invs_valid_irq_states)
   apply (erule use_valid[OF _ kernel_exit_irq_masks])
   apply simp
   done

--- a/proof/infoflow/ARM/ArchADT_IF.thy
+++ b/proof/infoflow/ARM/ArchADT_IF.thy
@@ -15,9 +15,70 @@ theory ArchADT_IF
 imports ADT_IF
 begin
 
-context Arch begin global_naming ARM
+context Arch begin arch_global_naming
 
 named_theorems ADT_IF_assms
+
+lemma dmo_getActiveIRQ_wp'[ADT_IF_assms]:
+  "\<lbrace>(\<lambda>s. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
+           (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>))
+    and domain_sep_inv False st and valid_irq_states\<rbrace>
+   do_machine_op (getActiveIRQ in_kernel)
+   \<lbrace>P\<rbrace>"
+  apply (simp add: do_machine_op_def getActiveIRQ_def non_kernel_IRQs_def)
+  apply (wp modify_wp | wpc)+
+  apply clarsimp
+  apply (erule use_valid)
+   apply (wp modify_wp)
+  apply (auto simp: Let_def non_kernel_IRQs_def irq_at_def split: if_splits)
+  done
+
+lemma dmo_getActiveIRQ_wp[ADT_IF_assms]:
+  "\<lbrace>(\<lambda>s. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
+           (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>))\<rbrace>
+   do_machine_op (getActiveIRQ False)
+   \<lbrace>P\<rbrace>"
+  apply (simp add: do_machine_op_def getActiveIRQ_def non_kernel_IRQs_def)
+  apply (wp modify_wp | wpc)+
+  apply clarsimp
+  apply (erule use_valid)
+   apply (wp modify_wp)
+  apply (auto simp: Let_def non_kernel_IRQs_def irq_at_def split: if_splits)
+  done
+
+lemma deleted_irq_handler_valid_irq_states[wp]:
+  "deleted_irq_handler irq \<lbrace>valid_irq_states\<rbrace>"
+  unfolding deleted_irq_handler_def set_irq_state_def valid_irq_states_def valid_irq_masks_def maskInterrupt_def
+  by (wpsimp wp: dmo_wp)
+
+lemma dmo_valid_irq_states[wp]:
+  "(\<And>P. f \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace>) \<Longrightarrow> do_machine_op f \<lbrace>valid_irq_states\<rbrace>"
+  unfolding valid_irq_states_def do_machine_op_def
+  by (wpsimp, erule use_valid; assumption)
+
+lemma dmo_getActiveIRQ_valid_irq_states[wp]:
+  "do_machine_op (getActiveIRQ in_kernel) \<lbrace>valid_irq_states\<rbrace>"
+  unfolding getActiveIRQ_def by wpsimp
+
+lemmas [wp] = invalidateLocalTLB_ASID_irq_masks cleanCaches_PoU_irq_masks setHardwareASID_irq_masks
+set_current_pd_irq_masks
+
+crunch prepare_thread_delete, arch_finalise_cap, arch_post_cap_deletion
+  for valid_irq_states[wp]: "\<lambda>s :: det_state. valid_irq_states s"
+  (wp: crunch_wps mapM_x_wp hoare_drop_imps  simp: crunch_simps)
+
+end
+
+
+global_interpretation ADT_IF_1?: ADT_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (unfold valid_cur_hyp_def cur_hyp_in_cur_domain_def)?; (fact ADT_IF_assms | wpsimp)?)
+qed
+
+
+context Arch begin arch_global_naming
 
 lemma dmo_getExMonitor_wp[wp]:
   "\<lbrace>\<lambda>s. P (exclusive_state (machine_state s)) s\<rbrace>
@@ -151,14 +212,14 @@ crunch init_arch_objects
   (wp: crunch_wps dmo_wp ignore: do_machine_op)
 
 lemma getActiveIRQ_None[ADT_IF_assms]:
-  "(None,s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) s)  \<Longrightarrow>
+  "(None,s') \<in> fst (do_machine_op (getActiveIRQ False) s)  \<Longrightarrow>
    irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = None"
   apply (erule use_valid)
    apply (wp dmo_getActiveIRQ_wp)
   by simp
 
 lemma getActiveIRQ_Some[ADT_IF_assms]:
-  "(Some i, s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) s)
+  "(Some i, s') \<in> fst (do_machine_op (getActiveIRQ False) s)
    \<Longrightarrow> irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = Some i"
   apply (erule use_valid)
    apply (wp dmo_getActiveIRQ_wp)
@@ -299,11 +360,18 @@ lemma do_user_op_if_irq_measure_if[ADT_IF_assms]:
          | wps |wp dmo_wp | wpc)+
   done
 
-crunch set_flags
+crunch set_flags, arch_post_set_flags
   for irq_states_of_state[wp]: "\<lambda>s. P (irq_state_of_state s)"
 
+lemma checked_cap_insert_valid_irq_states[wp]:
+  "check_cap_at a b (check_cap_at c d (cap_insert a b e)) \<lbrace>valid_irq_states\<rbrace>"
+  by (wpsimp simp: check_cap_at_def)+
+
+crunch set_mcpriority
+  for valid_irq_states[wp]: valid_irq_states
+
 lemma invoke_tcb_irq_state_inv[ADT_IF_assms]:
-  "\<lbrace>(\<lambda>s. irq_state_inv st s) and domain_sep_inv False sta
+  "\<lbrace>(\<lambda>s. irq_state_inv st s) and domain_sep_inv False (sta :: det_state) and valid_irq_states
                              and tcb_inv_wf tinv and K (irq_is_recurring irq st)\<rbrace>
    invoke_tcb tinv
    \<lbrace>\<lambda>_ s. irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
@@ -314,10 +382,10 @@ lemma invoke_tcb_irq_state_inv[ADT_IF_assms]:
                | clarsimp
                | wp (once) irq_state_inv_triv)+)[3]
     defer
-    apply ((wp irq_state_inv_triv | simp)+)[2]
-  (* just ThreadControl left *)
-  apply (simp add: split_def cong: option.case_cong)
-  by (wp hoare_vcg_all_liftE_R hoare_vcg_all_lift hoare_vcg_const_imp_liftE_R
+      apply ((wp irq_state_inv_triv | simp)+)[2]
+    apply (simp add: split_def cong: option.case_cong)
+ by (clarsimp split del: if_split cong: conj_cong
+     | wp hoare_vcg_all_liftE_R hoare_vcg_all_lift hoare_vcg_const_imp_liftE_R
          checked_cap_insert_domain_sep_inv cap_delete_deletes
          cap_delete_irq_state_inv[where st=st and sta=sta and irq=irq]
          cap_delete_irq_state_next[where st=st and sta=sta and irq=irq]
@@ -329,19 +397,33 @@ lemma invoke_tcb_irq_state_inv[ADT_IF_assms]:
       | wp (once) irq_state_inv_triv hoare_drop_imps
       | clarsimp split: option.splits | intro impI conjI allI)+
 
+crunch freeMemory
+  for irq_masks[wp]: "\<lambda>s. P (irq_masks s)"
+  (wp: mapM_x_wp)
+
+lemma valid_irq_states_kheap_update[simp]:
+  "valid_irq_states (kheap_update f s) = valid_irq_states s"
+  by (simp add: valid_irq_states_def)
+
+crunch delete_objects
+  for valid_irq_states[wp]: valid_irq_states
+  (wp: dmo_machine_state_lift simp: crunch_simps detype_def)
+
 lemma reset_untyped_cap_irq_state_inv[ADT_IF_assms]:
-  "\<lbrace>irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
+  "\<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state) and valid_irq_states and K (irq_is_recurring irq st)\<rbrace>
    reset_untyped_cap slot
    \<lbrace>\<lambda>y. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>y. irq_state_next st\<rbrace>"
   apply (cases "irq_is_recurring irq st", simp_all)
   apply (simp add: reset_untyped_cap_def)
   apply (rule hoare_pre)
-   apply (wp no_irq_clearMemory mapME_x_wp' hoare_vcg_const_imp_lift
-             get_cap_wp preemption_point_irq_state_inv'[where irq=irq]
-          | rule irq_state_inv_triv
-          | simp add: unless_def
-          | wp (once) dmo_wp)+
-  done
+  by (wp no_irq_clearMemory hoare_vcg_const_imp_lift set_cap_domain_sep_inv
+         hoare_post_addE[where Q'="domain_sep_inv False sta and valid_irq_states", OF mapME_x_wp']
+         get_cap_wp preemption_point_irq_state_inv'[where irq=irq]
+      | rule hoare_vcg_conj_lift
+      | rule irq_state_inv_triv
+      | simp add: unless_def
+      | wp (once) dmo_wp
+      | fastforce)+
 
 crunch
   handle_vm_fault, handle_hypervisor_fault
@@ -375,10 +457,31 @@ lemma thread_set_pas_refined[ADT_IF_assms]:
       | wps thread_set_caps_of_state_trivial[OF cps]
             thread_set_thread_st_auth_trivT[OF st]
             thread_set_thread_bound_ntfns_trivT[OF ntfn])+
+
+lemma thread_set_context_state_hyp_refs_of:
+  "thread_set (tcb_arch_update (arch_tcb_context_set ctxt)) t \<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>"
+  by (wpsimp simp: thread_set_def wp: set_object_wp )
+
+lemma thread_set_context_pas_refined[ADT_IF_assms]:
+  "thread_set (tcb_arch_update (arch_tcb_context_set ctxt)) t \<lbrace>pas_refined aag\<rbrace>"
+  unfolding pas_refined_def state_objs_to_policy_def
+  apply (rule hoare_weaken_pre)
+   apply (wpsimp wp: tcb_domain_map_wellformed_lift_strong thread_set_edomains)
+   apply (wps thread_set_state_vrefs thread_set_context_state_hyp_refs_of)
+   apply (rule hoare_lift_Pf2[where f="caps_of_state"])
+    apply (rule hoare_lift_Pf2[where f="thread_st_auth"])
+     apply (rule hoare_lift_Pf2[where f="thread_bound_ntfns"])
+      apply wp
+     apply (wpsimp wp: thread_set_thread_bound_ntfns_trivT )
+    apply (wpsimp wp: thread_set_thread_st_auth_trivT)
+   apply (wpsimp wp: thread_set_caps_of_state_trivial simp: ran_tcb_cap_cases)
+  apply simp
+  done
+
 end
 
 
-global_interpretation ADT_IF_1?: ADT_IF_1
+global_interpretation ADT_IF_2?: ADT_IF_2
 proof goal_cases
   interpret Arch .
   case 1 show ?case
@@ -387,7 +490,7 @@ qed
 
 sublocale valid_initial_state \<subseteq> valid_initial_state?: ADT_valid_initial_state ..
 
-hide_fact ADT_IF_1.do_user_op_silc_inv
+hide_fact ADT_IF_2.do_user_op_silc_inv
 requalify_facts ARM.do_user_op_silc_inv
 declare do_user_op_silc_inv[wp]
 

--- a/proof/infoflow/ARM/ArchArch_IF.thy
+++ b/proof/infoflow/ARM/ArchArch_IF.thy
@@ -110,11 +110,10 @@ lemma store_word_offs_reads_respects[Arch_IF_assms]:
   apply (simp add: storeWord_def)
   apply (simp add: do_machine_op_bind)
   apply wp
-     apply (rule use_spec_ev)
-     apply (rule do_machine_op_spec_reads_respects)
+     apply (rule do_machine_op_reads_respects)
       apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def in_monad)
       apply (fastforce intro: equiv_forI elim: equiv_forE)
-     apply (rule use_spec_ev do_machine_op_spec_reads_respects assert_ev2
+     apply (rule do_machine_op_reads_respects assert_ev2
             | simp add: spec_equiv_valid_def | wp modify_wp)+
   done
 
@@ -141,16 +140,6 @@ lemma set_thread_state_globals_equiv[Arch_IF_assms]:
     apply (clarsimp simp: valid_arch_state_def obj_at_def tcb_at_def2 get_tcb_def is_tcb_def
                     dest: get_tcb_SomeD
                    split: option.splits kernel_object.splits)+
-  done
-
-lemma set_cap_globals_equiv''[Arch_IF_assms]:
-  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
-   set_cap cap p
-   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_cap_def
-  apply (simp only: split_def)
-  apply (wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
-  apply (fastforce simp: valid_arch_state_def obj_at_def is_tcb_def)+
   done
 
 lemma as_user_globals_equiv[Arch_IF_assms]:
@@ -185,7 +174,7 @@ global_interpretation Arch_IF_1?: Arch_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Arch_IF_assms)?)
+    by (unfold_locales; (fact Arch_IF_assms | solves simp)?)
 qed
 
 
@@ -773,11 +762,11 @@ lemma perform_page_invocation_reads_respects:
       apply (simp add: mapM_discarded swp_def)
       apply (wp dmo_mol_reads_respects dmo_cacheRangeOp_reads_respects  mapM_x_ev''
                 store_pte_reads_respects set_cap_reads_respects mapM_ev'' store_pde_reads_respects
-                unmap_page_reads_respects set_vm_root_reads_respects dmo_mol_2_reads_respects
+                unmap_page_reads_respects set_vm_root_reads_respects
                 set_vm_root_for_flush_reads_respects get_cap_rev  do_flush_reads_respects
                 invalidate_tlb_by_asid_reads_respects get_master_pte_reads_respects
                 get_master_pde_reads_respects set_mrs_reads_respects set_message_info_reads_respects
-             | simp add: cleanByVA_PoU_def pte_check_if_mapped_def pde_check_if_mapped_def
+             | simp add: cleanByVA_PoU_def pte_check_if_mapped_def pde_check_if_mapped_def dmo_distr
              | wpc | wp (once) hoare_drop_imps[where Q'="\<lambda>r s. r"])+
   apply (clarsimp simp: authorised_page_inv_def valid_page_inv_def)
   apply (auto simp: cte_wp_at_caps_of_state valid_slots_def cap_auth_conferred_def
@@ -1312,7 +1301,7 @@ lemma perform_page_table_invocation_globals_equiv:
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding perform_page_table_invocation_def cleanCacheRange_PoU_def
   apply (rule hoare_weaken_pre)
-   apply (wp store_pde_globals_equiv set_cap_globals_equiv'' dmo_cacheRangeOp_lift
+   apply (wp store_pde_globals_equiv set_cap_globals_equiv dmo_cacheRangeOp_lift
              mapM_x_swp_store_pte_globals_equiv unmap_page_table_globals_equiv
           | wpc | simp add: cleanByVA_PoU_def)+
   apply (fastforce simp: authorised_for_globals_page_table_inv_def
@@ -1491,7 +1480,7 @@ lemma perform_page_invocation_globals_equiv:
   apply (rule hoare_weaken_pre)
   apply (wp mapM_swp_store_pte_globals_equiv hoare_vcg_all_lift dmo_cacheRangeOp_lift
             mapM_swp_store_pde_globals_equiv mapM_x_swp_store_pte_globals_equiv
-            mapM_x_swp_store_pde_globals_equiv set_cap_globals_equiv''
+            mapM_x_swp_store_pde_globals_equiv set_cap_globals_equiv
             unmap_page_globals_equiv store_pte_globals_equiv store_pde_globals_equiv hoare_weak_lift_imp
             do_flush_globals_equiv set_mrs_globals_equiv set_message_info_globals_equiv
          | wpc | simp add: do_machine_op_bind cleanByVA_PoU_def)+
@@ -1519,7 +1508,7 @@ lemma perform_asid_control_invocation_globals_equiv:
   apply (rule hoare_pre)
    apply wpc
    apply (rename_tac word1 cslot_ptr1 cslot_ptr2 word2)
-   apply (wp modify_wp cap_insert_globals_equiv''
+   apply (wp modify_wp cap_insert_globals_equiv
              retype_region_ASIDPoolObj_globals_equiv[simplified]
              retype_region_invs_extras(5)[where sz=pageBits]
              retype_region_invs_extras(6)[where sz=pageBits]
@@ -1595,7 +1584,7 @@ lemma perform_asid_pool_invocation_globals_equiv:
   "\<lbrace>globals_equiv s and valid_arch_state\<rbrace> perform_asid_pool_invocation api \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding perform_asid_pool_invocation_def
   apply (rule hoare_weaken_pre)
-   apply (wp modify_wp set_asid_pool_globals_equiv set_cap_globals_equiv''
+   apply (wp modify_wp set_asid_pool_globals_equiv set_cap_globals_equiv
         get_cap_wp | wpc | simp)+
   done
 
@@ -1726,22 +1715,19 @@ lemma mapM_x_swp_store_pte_reads_respects':
                   (mapM_x (swp store_pte InvalidPTE) [word , word + 4 .e. word + 2 ^ pt_bits - 1])"
   apply (rule gen_asm_ev)
   apply (wp mapM_x_ev)
-   apply simp
-   apply (rule equiv_valid_guard_imp)
-    apply (wp store_pte_reads_respects)
-   apply simp
-   apply (elim conjE)
-   apply (subgoal_tac "is_aligned word pt_bits")
-    apply (frule (1) word_aligned_pt_slots)
     apply simp
-   apply (frule cte_wp_valid_cap)
-    apply (rule invs_valid_objs)
+    apply (rule equiv_valid_guard_imp)
+     apply (wp store_pte_reads_respects)
+    apply clarsimp
+    apply (subgoal_tac "is_aligned word pt_bits")
+     apply (frule (1) word_aligned_pt_slots)
+     apply simp
     apply simp
-   apply (simp add: valid_cap_def cap_aligned_def pt_bits_def pageBits_def)
-  apply simp
-  apply wp
-  apply simp
-  apply (fastforce simp: is_cap_simps dest!: cte_wp_at_pt_exists_cap[OF invs_valid_objs])
+   apply wpsimp+
+  apply (frule cte_wp_valid_cap)
+   apply (rule invs_valid_objs)
+   apply simp
+  apply (simp add: valid_cap_def cap_aligned_def pt_bits_def pageBits_def)
   done
 
 lemma word_shiftr_20_le_1_shift_pageBits:
@@ -1778,18 +1764,19 @@ lemma mapM_x_swp_store_pde_reads_respects':
                                                                     and K (is_subject aag w))
      (mapM_x (swp store_pde InvalidPDE)
              (map ((\<lambda>x. x + w) \<circ> swp (<<) 2) [0 .e. (kernel_base >> 20) - 1]))"
+  apply (rule gen_asm_ev)
   apply (wp mapM_x_ev)
-   apply simp
-   apply (rule equiv_valid_guard_imp)
-    apply (wp store_pde_reads_respects)
+    apply simp
+    apply (rule equiv_valid_guard_imp)
+     apply (wp store_pde_reads_respects)
+    apply clarsimp
+    apply (subgoal_tac "is_aligned w pd_bits")
+     apply (clarsimp simp add: pd_bits_store_pde_helper)
+     apply simp
+   apply wpsimp+
+  apply (frule cte_wp_valid_cap)
    apply clarsimp
-   apply (subgoal_tac "is_aligned w pd_bits")
-    apply (simp add: pd_bits_store_pde_helper)
-   apply (frule (1) cte_wp_valid_cap)
-   apply (simp add: valid_cap_def cap_aligned_def pd_bits_def pageBits_def)
-  apply simp
-  apply wp
-  apply (clarsimp simp: wellformed_pde_def)+
+  apply (simp add: valid_cap_def cap_aligned_def pd_bits_def pageBits_def)
   done
 
 lemma mapM_x_swp_store_pte_pas_refined_simple:

--- a/proof/infoflow/ARM/ArchCNode_IF.thy
+++ b/proof/infoflow/ARM/ArchCNode_IF.thy
@@ -34,24 +34,14 @@ lemma set_object_globals_equiv'':
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   by (wpsimp wp: set_object_globals_equiv)
 
-lemma set_cap_globals_equiv':
-  "\<lbrace>globals_equiv s and (\<lambda> s. fst p \<noteq> arm_global_pd (arch_state s))\<rbrace>
-   set_cap cap p
-   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_cap_def
-  apply (simp only: split_def)
-  apply (wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
-  apply (fastforce simp: obj_at_def is_tcb_def)
-  done
-
 lemma set_cap_globals_equiv[CNode_IF_assms]:
-  "\<lbrace>globals_equiv s and valid_global_objs and valid_arch_state\<rbrace>
+  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
    set_cap cap p
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding set_cap_def
   apply (simp only: split_def)
   apply (wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
-  apply (fastforce simp: valid_global_objs_def valid_vso_at_def obj_at_def is_tcb_def)
+  apply (fastforce simp: valid_arch_state_def obj_at_def is_tcb_def)+
   done
 
 (* moved from ADT_IF *)
@@ -128,14 +118,22 @@ lemma dmo_getActiveIRQ_reads_respects[CNode_IF_assms]:
   notes gets_ev[wp del]
   shows "reads_respects aag l (invs and only_timer_irq_inv irq st)
                        (do_machine_op (getActiveIRQ in_kernel))"
-  apply (rule use_spec_ev)
-  apply (rule do_machine_op_spec_reads_respects')
+  apply (rule do_machine_op_reads_respects')
    apply (simp add: getActiveIRQ_def)
    apply (wp irq_state_increment_reads_respects_memory irq_state_increment_reads_respects_device
              gets_ev[where f="irq_oracle \<circ> irq_state"] equiv_valid_inv_conj_lift
              gets_irq_masks_equiv_valid modify_wp
           | simp add: no_irq_def)+
   apply (rule only_timer_irq_inv_determines_irq_masks, blast+)
+  done
+
+lemma dmo_getActiveIRQ_globals_equiv[CNode_IF_assms]:
+  "do_machine_op (getActiveIRQ in_kernel) \<lbrace>globals_equiv st\<rbrace>"
+  unfolding globals_equiv_def arch_globals_equiv_def idle_equiv_def
+  apply (rule hoare_weaken_pre)
+   apply wps
+   apply wpsimp
+  apply clarsimp
   done
 
 end

--- a/proof/infoflow/ARM/ArchFinalCaps.thy
+++ b/proof/infoflow/ARM/ArchFinalCaps.thy
@@ -346,6 +346,10 @@ lemma invoke_tcb_silc_inv[FinalCaps_assms]:
       | intro impI
       | rule conjI)+
 
+lemma handle_reserved_irq_non_kernel_IRQs[FinalCaps_assms]:
+  "\<lbrace>P and K (irq \<notin> non_kernel_IRQs)\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_. P\<rbrace>"
+  unfolding handle_reserved_irq_def by wpsimp
+
 end
 
 
@@ -354,6 +358,14 @@ proof goal_cases
   interpret Arch .
   case 1 show ?case
     by (unfold_locales; (fact FinalCaps_assms)?)
+qed
+
+
+global_interpretation FinalCaps_3?: FinalCaps_3
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact FinalCaps_assms | wpsimp)?)
 qed
 
 end

--- a/proof/infoflow/ARM/ArchFinalise_IF.thy
+++ b/proof/infoflow/ARM/ArchFinalise_IF.thy
@@ -19,8 +19,7 @@ crunch arch_post_cap_deletion
 lemma dmo_maskInterrupt_reads_respects[Finalise_IF_assms]:
   "reads_respects aag l \<top> (do_machine_op (maskInterrupt m irq))"
   unfolding maskInterrupt_def
-  apply (rule use_spec_ev)
-  apply (rule do_machine_op_spec_reads_respects)
+  apply (rule do_machine_op_reads_respects)
    apply (simp add: equiv_valid_def2)
    apply (rule modify_ev2)
    apply (fastforce simp: equiv_for_def)
@@ -165,21 +164,15 @@ lemma set_notification_equiv_but_for_labels[Finalise_IF_assms]:
   done
 
 lemma thread_set_reads_respects[Finalise_IF_assms]:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "reads_respects aag l \<top> (thread_set x y)"
-  unfolding thread_set_def fun_app_def
-  apply (case_tac "aag_can_read aag y \<or> aag_can_affect aag l y")
-   apply (wp set_object_reads_respects)
-   apply (clarsimp, rule reads_affects_equiv_get_tcb_eq, simp+)[1]
-  apply (simp add: equiv_valid_def2)
-  apply (rule equiv_valid_rv_guard_imp)
-   apply (rule_tac L="{pasObjectAbs aag y}" and L'="{pasObjectAbs aag y}"
-                in ev2_invisible[OF domains_distinct])
-       apply (assumption | simp add: labels_are_invisible_def)+
-     apply (rule modifies_at_mostI[where P="\<top>"]
-            | wp set_object_equiv_but_for_labels
-            | simp
-            | (clarify, drule get_tcb_not_asid_pool_at))+
+  "reads_respects aag l \<top> (thread_set f thread)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule_tac ptr=thread in reads_respects_unit_cases)
+  unfolding thread_set_def
+     apply (wpsimp wp: set_object_reads_respects)
+    apply (wpsimp wp: set_object_equiv_but_for_labels)
+    apply (clarsimp simp: get_tcb_def obj_at_def)
+   apply wpsimp+
+  apply (auto intro: reads_affects_equiv_get_tcb_eq)
   done
 
 lemma aag_cap_auth_ASIDPoolCap:
@@ -381,7 +374,7 @@ global_interpretation Finalise_IF_1?: Finalise_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Finalise_IF_assms)?)
+    by (unfold_locales; (fact Finalise_IF_assms | wpsimp wp: Finalise_IF_assms)?)
 qed
 
 end

--- a/proof/infoflow/ARM/ArchIRQMasks_IF.thy
+++ b/proof/infoflow/ARM/ArchIRQMasks_IF.thy
@@ -163,6 +163,9 @@ lemma invoke_tcb_irq_masks[IRQMasks_IF_assms]:
 crunch arch_prepare_set_domain
   for inv[IRQMasks_IF_assms,wp]: P
 
+crunch arch_prepare_next_domain
+  for valid_irq_states[wp]: valid_irq_states
+
 end
 
 
@@ -170,7 +173,7 @@ global_interpretation IRQMasks_IF_2?: IRQMasks_IF_2
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact IRQMasks_IF_assms)?)
+    by (unfold_locales; (fact IRQMasks_IF_assms | wpsimp)?)
 qed
 
 

--- a/proof/infoflow/ARM/ArchInfoFlow.thy
+++ b/proof/infoflow/ARM/ArchInfoFlow.thy
@@ -10,6 +10,8 @@ imports
   "Lib.EquivValid"
 begin
 
+consts equiv_for :: "('a \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> 'a \<Rightarrow> 'c) \<Rightarrow> 'b \<Rightarrow> 'b \<Rightarrow> bool"
+
 context Arch begin global_naming ARM
 
 section \<open>Arch-specific equivalence properties\<close>
@@ -65,6 +67,12 @@ definition arch_globals_equiv :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kh
      (ct \<noteq> it \<longrightarrow> exclusive_state ms = exclusive_state ms')"
 
 declare arch_globals_equiv_def[simp]
+
+definition equiv_hyp :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "equiv_hyp P s s' \<equiv> True"
+
+definition equiv_fpu :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "equiv_fpu P s s' \<equiv> True"
 
 end
 

--- a/proof/infoflow/ARM/ArchInfoFlow_IF.thy
+++ b/proof/infoflow/ARM/ArchInfoFlow_IF.thy
@@ -82,6 +82,70 @@ lemma equiv_asids_guard_imp[InfoFlow_IF_assms]:
   "\<lbrakk> equiv_asids R s s'; \<And>x. Q x \<Longrightarrow> R x \<rbrakk> \<Longrightarrow> equiv_asids Q s s'"
   by (auto simp: equiv_asids_def)
 
+
+definition identical_hyp_state_updates :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> machine_state \<Rightarrow> machine_state \<Rightarrow> bool" where
+  "identical_hyp_state_updates _ _ _ _ _ \<equiv> True"
+
+definition identical_fpu_state_updates :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> machine_state \<Rightarrow> machine_state \<Rightarrow> bool" where
+  "identical_fpu_state_updates _ _ _ _ _ \<equiv> True"
+
+definition no_hyp :: "'m machine_monad \<Rightarrow> bool" where
+  "no_hyp f \<equiv> True"
+
+definition no_fpu :: "'m machine_monad \<Rightarrow> bool" where
+  "no_fpu f \<equiv> True"
+
+lemma equiv_hyp_dummy[intro!,simp]:
+  "equiv_hyp P s s'"
+  by (simp add: equiv_hyp_def)
+
+lemma equiv_fpu_dummy[intro!,simp]:
+  "equiv_fpu P s s'"
+  by (simp add: equiv_fpu_def)
+
+lemma identical_hyp_states_updates_dummy[intro!,simp]:
+  "identical_hyp_state_updates P s s' ms ms'"
+  by (simp add: identical_hyp_state_updates_def)
+
+lemma identical_fpu_states_updates_dummy[intro!,simp]:
+  "identical_fpu_state_updates P s s' ms ms'"
+  by (simp add: identical_fpu_state_updates_def)
+
+lemma no_hyp_dummy[intro!,simp]:
+  "no_hyp f"
+  by (simp add: no_hyp_def)
+
+lemma no_fpu_dummy[intro!,simp]:
+  "no_fpu f"
+  by (simp add: no_fpu_def)
+
+lemmas equiv_arch_dummy =
+  equiv_hyp_dummy
+  equiv_fpu_dummy
+  identical_hyp_states_updates_dummy
+  identical_fpu_states_updates_dummy
+  no_hyp_dummy
+  no_fpu_dummy
+
+end
+
+arch_requalify_consts
+  identical_hyp_state_updates
+  identical_fpu_state_updates
+  no_hyp
+  no_fpu
+
+
+global_interpretation InfoFlow_IF_1?: InfoFlow_IF_1 identical_hyp_state_updates identical_fpu_state_updates
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact InfoFlow_IF_assms | solves \<open>rule equiv_arch_dummy\<close>)?)
+qed
+
+
+context Arch begin arch_global_naming
+
 lemma dmo_loadWord_rev[InfoFlow_IF_assms]:
   "reads_equiv_valid_inv A aag (K (for_each_byte_of_word (aag_can_read aag) p))
                                (do_machine_op (loadWord p))"
@@ -107,14 +171,45 @@ lemma dmo_loadWord_rev[InfoFlow_IF_assms]:
       apply (wp wp_post_taut loadWord_inv | simp)+
   done
 
+lemma do_machine_op_reads_respects'[InfoFlow_IF_assms]:
+  assumes equiv_dmo:
+   "equiv_valid_inv (equiv_machine_state (aag_can_read aag) and equiv_irq_state)
+                    (equiv_machine_state (aag_can_affect aag l)) Q f"
+  assumes guard:
+    "\<And>s. P s \<Longrightarrow> Q (machine_state s)"
+  and no_hyp: "no_hyp f"
+  and no_fpu: "no_fpu f"
+  shows
+  "reads_respects aag l P (do_machine_op f)"
+  apply (rule use_spec_ev)
+  unfolding do_machine_op_def spec_equiv_valid_def
+  apply (rule equiv_valid_2_guard_imp)
+   apply (rule_tac  R'="\<lambda> rv rv'. equiv_machine_state (aag_can_read aag or aag_can_affect aag l) rv rv' \<and> equiv_irq_state rv rv'" and Q="\<lambda> r s. st = s \<and> Q r" and Q'="\<lambda> r s. Q r" and P="(=) st" and P'="\<top>" in equiv_valid_2_bind)
+       apply (rule gen_asm_ev2_l[simplified K_def pred_conj_def])
+       apply (rule gen_asm_ev2_r')
+       apply (rule_tac R'="\<lambda> (r, ms') (r', ms'').  r = r' \<and> equiv_machine_state (aag_can_read aag)  ms' ms'' \<and> equiv_machine_state (aag_can_affect aag l) ms' ms'' \<and> equiv_irq_state ms' ms''" and Q="\<lambda> r s. st = s" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
+            apply (clarsimp simp: modify_def get_def put_def bind_def return_def equiv_valid_2_def)
+            apply (fastforce intro: reads_equiv_machine_state_update affects_equiv_machine_state_update)
+            apply (insert equiv_dmo)[1]
+           apply (clarsimp simp: select_f_def equiv_valid_2_def equiv_valid_def2 equiv_for_or simp: split_def split: prod.splits simp: equiv_for_def)[1]
+           apply (drule_tac x=rv in spec, drule_tac x=rv' in spec)
+           apply (fastforce)
+          apply (rule select_f_inv)
+         apply (rule wp_post_taut)
+        apply simp+
+      apply (clarsimp simp: equiv_valid_2_def in_monad)
+      apply (fastforce elim: reads_equivE affects_equivE equiv_forE intro: equiv_forI)
+     apply (wp | simp add: guard)+
+  done
+
 end
 
 
-global_interpretation InfoFlow_IF_1?: InfoFlow_IF_1
+global_interpretation InfoFlow_IF_1?: InfoFlow_IF_2 identical_hyp_state_updates identical_fpu_state_updates no_hyp no_fpu
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact InfoFlow_IF_assms)?)
+    by (unfold_locales; (fact InfoFlow_IF_assms | solves \<open>rule equiv_arch_dummy\<close>)?)
 qed
 
 end

--- a/proof/infoflow/ARM/ArchInterrupt_IF.thy
+++ b/proof/infoflow/ARM/ArchInterrupt_IF.thy
@@ -40,12 +40,12 @@ lemma arch_invoke_irq_control_reads_respects[Interrupt_IF_assms]:
   done
 
 lemma arch_invoke_irq_control_globals_equiv[Interrupt_IF_assms]:
-  "\<lbrace>globals_equiv st and valid_arch_state and valid_global_objs\<rbrace>
+  "\<lbrace>globals_equiv st and valid_arch_state\<rbrace>
    arch_invoke_irq_control ai
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (induct ai;
          wpsimp wp: set_irq_state_globals_equiv set_irq_state_valid_global_objs
-                    cap_insert_globals_equiv'' dmo_mol_globals_equiv
+                    cap_insert_globals_equiv dmo_mol_globals_equiv
                simp: setIRQTrigger_def)
   done
 

--- a/proof/infoflow/ARM/ArchIpc_IF.thy
+++ b/proof/infoflow/ARM/ArchIpc_IF.thy
@@ -54,6 +54,7 @@ lemma storeWord_equiv_but_for_labels[Ipc_IF_assms]:
      apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_states])
     apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_irq_node])
    apply (fastforce simp: equiv_asids_def equiv_asid_def elim: states_equiv_forE)
+  apply auto[2]
   apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=ready_queues])
   done
 
@@ -203,9 +204,7 @@ lemma dmo_loadWord_reads_respects[Ipc_IF_assms]:
   "reads_respects aag l (K (for_each_byte_of_word (\<lambda> x. aag_can_read_or_affect aag l x) p))
                   (do_machine_op (loadWord p))"
   apply (rule gen_asm_ev)
-  apply (rule use_spec_ev)
-  apply (rule spec_equiv_valid_hoist_guard)
-  apply (rule do_machine_op_spec_reads_respects)
+  apply (rule do_machine_op_reads_respects)
    apply (simp add: loadWord_def equiv_valid_def2 spec_equiv_valid_def)
    apply (rule_tac R'="\<lambda>rv rv'. for_each_byte_of_word (\<lambda>y. rv y = rv' y) p"
                and Q="\<top>\<top>" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
@@ -288,7 +287,7 @@ global_interpretation Ipc_IF_1?: Ipc_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Ipc_IF_assms)?)
+    by (unfold_locales; (fact Ipc_IF_assms | wpsimp wp: Ipc_IF_assms)?)
 qed
 
 
@@ -442,7 +441,7 @@ lemma set_mrs_reads_respects'[Ipc_IF_assms]:
   apply (simp add: equiv_valid_def2)
   apply (rule equiv_valid_rv_guard_imp)
    apply (case_tac buf)
-    apply (rule_tac Q="\<top>" and P="\<top>" and L="{pasObjectAbs aag thread}" in ev_invisible[OF domains_distinct])
+    apply (rule_tac Q="\<top>" and P="\<top>" and L="{pasObjectAbs aag thread}" in revrv_invisible[OF domains_distinct])
       apply (clarsimp simp: labels_are_invisible_def)
      apply (rule modifies_at_mostI)
      apply (simp add: set_mrs_def)
@@ -452,7 +451,7 @@ lemma set_mrs_reads_respects'[Ipc_IF_assms]:
    apply (rename_tac buf')
    apply (rule_tac Q="\<top>" and L="{pasObjectAbs aag thread} \<union> (pasObjectAbs aag)
                                  ` (ptr_range buf' msg_align_bits)"
-                in ev_invisible[OF domains_distinct])
+                in revrv_invisible[OF domains_distinct])
      apply (auto simp: labels_are_invisible_def ipc_buffer_has_auth_def
                  dest: reads_read_page_read_thread simp: aag_can_affect_label_def)[1]
     apply (rule modifies_at_mostI)

--- a/proof/infoflow/ARM/ArchNoninterference.thy
+++ b/proof/infoflow/ARM/ArchNoninterference.thy
@@ -257,6 +257,7 @@ lemma dmo_storeWord_reads_respects_g[Noninterference_assms, wp]:
                            equiv_for_def equiv_asids_def equiv_asid_def silc_dom_equiv_def)
    apply (rule affects_equiv_machine_state_update, assumption)
    apply (fastforce simp: equiv_for_def affects_equiv_def states_equiv_for_def)
+  apply auto[2]
   apply (simp add: equiv_valid_def2 equiv_valid_2_def)
   done
 
@@ -275,6 +276,7 @@ lemma dmo_clearExMonitor_reads_respects_g':
   apply (simp add: reads_equiv_g_def reads_equiv_def2 affects_equiv_def2 globals_equiv_def
                    idle_equiv_def states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def)
   apply metis
+  apply simp
   done
 
 lemma arch_switch_to_thread_reads_respects_g'[Noninterference_assms]:
@@ -423,6 +425,56 @@ lemma arch_tcb_get_registers_equality[Noninterference_assms]:
    \<Longrightarrow> tcb_arch tcb = tcb_arch tcb'"
   by (auto simp: arch_tcb_get_registers_def intro: arch_tcb.equality user_context.expand)
 
+lemma getActiveIRQ_ev2[Noninterference_assms]:
+  "equiv_valid_2 (scheduler_equiv aag)
+                 (scheduler_affects_equiv aag l) (scheduler_affects_equiv aag l)
+                 (\<lambda>irq irq'. irq = irq' \<or> irq = None \<and> irq' \<in> Some ` non_kernel_IRQs)
+                 (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+                 (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+   (do_machine_op (getActiveIRQ True)) (do_machine_op (getActiveIRQ False))"
+  apply (simp add: getActiveIRQ_no_non_kernel_IRQs)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (erule use_valid, rule dmo_getActiveIRQ_wp)+
+  apply clarsimp
+  apply (clarsimp simp: scheduler_equiv_def irq_at_def Let_def)
+   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
+                         silc_dom_equiv_def equiv_for_def)
+  apply (clarsimp simp: scheduler_affects_equiv_def)
+  apply (intro conjI impI)
+    apply (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def)
+   apply (clarsimp simp: scheduler_globals_frame_equiv_def)
+  apply (clarsimp simp: arch_scheduler_affects_equiv_def)
+  done
+
+lemma arch_prepare_next_domain_reads_respects_g[Noninterference_assms]:
+  "reads_respects_g aag l invs arch_prepare_next_domain"
+  unfolding arch_prepare_next_domain_def by wpsimp
+
+lemma partitionIntegrity_subjectAffects_tcb_fpu[Noninterference_assms]:
+  assumes par_inte: "partitionIntegrity aag s s'"
+  and "kheap s x = Some (TCB tcb)"
+      "kheap s' x = Some (TCB tcb')"
+      "tcb' = tcb\<lparr>tcb_arch := new_arch\<rparr>"
+      "arch_tcb_get_registers new_arch = arch_tcb_get_registers (tcb_arch tcb)"
+      "tcb_hyp_refs new_arch = tcb_hyp_refs (tcb_arch tcb)"
+      "kheap s x \<noteq> kheap s' x"
+      "silc_inv aag st s"
+      "pas_wellformed_noninterference aag"
+      "pas_refined aag s" "pas_refined aag s'"
+      "pas_cur_domain aag s" "pas_cur_domain aag s'"
+      "cur_fpu_in_cur_domain s" "cur_fpu_in_cur_domain s'"
+      "invs s" "invs s'"
+  notes inte_obj = par_inte[THEN partitionIntegrity_integrity, THEN integrity_subjects_obj,
+                            THEN spec[where x=x], simplified integrity_obj_def, simplified]
+  shows "subject_can_affect_label_directly aag (pasObjectAbs aag x)"
+  apply (insert assms(2,3,4,5,7))
+  apply (clarsimp simp: arch_tcb_get_registers_def)
+  apply (subgoal_tac "new_arch = tcb_arch tcb")
+   apply clarsimp
+  apply (rule arch_tcb.equality; clarsimp?)
+  apply (rule user_context.expand; clarsimp)
+  done
+
 end
 
 context begin interpretation Arch .
@@ -437,7 +489,7 @@ global_interpretation Noninterference_1?: Noninterference_1 _ arch_globals_equiv
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Noninterference_assms | solves \<open>rule integrity_arch_triv\<close>)?)
+    by (unfold_locales; (fact Noninterference_assms | solves \<open>wpsimp wp: Noninterference_assms\<close> | solves \<open>rule integrity_arch_triv\<close>)?)
 qed
 
 sublocale valid_initial_state \<subseteq> valid_initial_state?:

--- a/proof/infoflow/ARM/ArchRetype_IF.thy
+++ b/proof/infoflow/ARM/ArchRetype_IF.thy
@@ -82,11 +82,6 @@ lemma dmo_cacheRangeOp_reads_respects:
   apply (rule hoare_TrueI)
   done
 
-lemma dmo_cleanCacheRange_PoU_reads_respects:
-  "reads_respects aag l \<top> (do_machine_op (cleanCacheRange_PoU vsrat vend pstart))"
-  unfolding cleanCacheRange_PoU_def
-  by (wp dmo_cacheRangeOp_reads_respects dmo_mol_reads_respects | simp add: cleanByVA_PoU_def)+
-
 lemma set_pd_globals_equiv:
   "\<lbrace>globals_equiv st and (\<lambda>s. a \<noteq> arm_global_pd (arch_state s))\<rbrace> set_pd a b \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding set_pd_def
@@ -181,7 +176,8 @@ lemma copy_global_mappings_reads_respects_g:
                             pspace_aligned s \<and> valid_arch_state s" in hoare_weaken_pre)
       apply (rule gets_sp)
      apply (assumption)
-    apply (wp mapM_x_ev store_pde_reads_respects_g get_pde_revg)
+    apply (rule mapM_x_ev)
+     apply (wp mapM_x_ev store_pde_reads_respects_g get_pde_revg)
      apply (drule subsetD[OF copy_global_mappings_index_subset])
      apply (clarsimp simp: pd_shifting' invs_aligned_pdD)
     apply (wp get_pde_inv store_pde_aligned store_pde_valid_arch | simp | fastforce)+
@@ -220,32 +216,11 @@ lemma dmo_cleanCacheRange_PoU_globals_equiv:
   unfolding cleanCacheRange_PoU_def
   by (wp dmo_mol_globals_equiv dmo_cacheRangeOp_lift | simp add: cleanByVA_PoU_def)+
 
-lemma dmo_cleanCacheRange_PoU_reads_respects_g:
-  "reads_respects_g aag l \<top> (do_machine_op (cleanCacheRange_PoU x y z))"
-  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply (rule dmo_cleanCacheRange_PoU_reads_respects)
-   apply (rule doesnt_touch_globalsI[where P="\<top>", simplified, OF dmo_cleanCacheRange_PoU_globals_equiv])
-  by simp
-
 lemma dmo_cleanCacheRange_RAM_globals_equiv:
   "do_machine_op (cleanCacheRange_RAM x y z) \<lbrace>globals_equiv s\<rbrace>"
   unfolding cleanCacheRange_RAM_def
   by (wpsimp wp: dmo_mol_globals_equiv dmo_cacheRangeOp_lift
              simp: dmo_bind_valid dsb_def cleanCacheRange_PoC_def cleanByVA_def cleanL2Range_def)
-
-lemma dmo_cleanCacheRange_RAM_reads_respects:
-  "reads_respects aag l \<top> (do_machine_op (cleanCacheRange_RAM vsrat vend pstart))"
-  unfolding cleanCacheRange_RAM_def
-  by (wp dmo_cacheRangeOp_reads_respects dmo_mol_reads_respects empty_fail_cleanByVA empty_fail_cacheRangeOp
-      | simp add: cleanL2Range_def dsb_def cleanCacheRange_PoC_def cleanByVA_def
-      | subst do_machine_op_bind)+
-
-lemma dmo_cleanCacheRange_RAM_reads_respects_g:
-  "reads_respects_g aag l \<top> (do_machine_op (cleanCacheRange_RAM x y z))"
-  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
-    apply (rule dmo_cleanCacheRange_RAM_reads_respects)
-   apply (rule doesnt_touch_globalsI[where P="\<top>", simplified, OF dmo_cleanCacheRange_RAM_globals_equiv])
-  by simp
 
 lemma mol_globals_equiv:
   "machine_op_lift mop \<lbrace>\<lambda>ms. globals_equiv st (s\<lparr>machine_state := ms\<rparr>)\<rbrace>"
@@ -281,26 +256,6 @@ lemma dmo_freeMemory_globals_equiv[Retype_IF_assms]:
   apply (erule use_valid)
    apply (wp mapM_x_wp' storeWord_globals_equiv mol_globals_equiv)
   apply (simp_all)
-  done
-
-lemma init_arch_objects_reads_respects_g:
-  "reads_respects_g aag l ((\<lambda>s. arm_global_pd (arch_state s) \<notin> set refs \<and>
-                                pspace_aligned s \<and> valid_arch_state s) and
-                           K (\<forall>x\<in>set refs. is_subject aag x) and
-                           K (\<forall>x\<in>set refs. new_type = ArchObject PageDirectoryObj
-                                           \<longrightarrow> is_aligned x pd_bits) and
-                           K ((0::obj_ref) < of_nat num_objects))
-                    (init_arch_objects new_type dev ptr num_objects obj_sz refs)"
-  apply (unfold init_arch_objects_def fun_app_def)
-  apply (rule gen_asm_ev)+
-  apply (rule equiv_valid_guard_imp)
-   apply (wp dmo_cleanCacheRange_RAM_reads_respects_g
-             dmo_cleanCacheRange_PoU_reads_respects_g
-             mapM_x_ev'' when_ev
-             equiv_valid_guard_imp[OF copy_global_mappings_reads_respects_g]
-             copy_global_mappings_valid_arch_state copy_global_mappings_pspace_aligned
-             hoare_vcg_ball_lift | wpc | simp)+
-  apply clarsimp
   done
 
 lemma copy_global_mappings_globals_equiv:
@@ -428,7 +383,7 @@ global_interpretation Retype_IF_1?: Retype_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Retype_IF_assms)?)
+    by (unfold_locales; (fact Retype_IF_assms | solves wpsimp)?)
 qed
 
 
@@ -499,7 +454,6 @@ lemma reset_untyped_cap_reads_respects_g:
         apply (clarsimp simp: valid_cap_simps cap_aligned_def field_simps
                               free_index_of_def invs_valid_global_objs)
        apply (simp add: aligned_add_aligned is_aligned_shiftl)
-       apply (clarsimp simp: Kernel_Config.resetChunkBits_def)
        apply (rule hoare_pre)
         apply (wp preemption_point_inv' set_untyped_cap_invs_simple set_cap_cte_wp_at
                   set_cap_no_overlap only_timer_irq_inv_pres[where Q=\<top>, OF _ set_cap_domain_sep_inv]
@@ -547,6 +501,52 @@ lemma retype_region_ret_pd_aligned:
     apply (rule retype_region_aligned_for_init)
    apply simp
   apply (clarsimp simp: obj_bits_api_def default_arch_object_def pd_bits_def pageBits_def)
+  done
+
+lemma dmo_cleanCacheRange_PoU_reads_respects:
+  "reads_respects aag l \<top> (do_machine_op (cleanCacheRange_PoU vsrat vend pstart))"
+  unfolding cleanCacheRange_PoU_def
+  by (wp dmo_cacheRangeOp_reads_respects dmo_mol_reads_respects | simp add: cleanByVA_PoU_def)+
+
+lemma dmo_cleanCacheRange_PoU_reads_respects_g:
+  "reads_respects_g aag l \<top> (do_machine_op (cleanCacheRange_PoU x y z))"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule dmo_cleanCacheRange_PoU_reads_respects)
+   apply (rule doesnt_touch_globalsI[where P="\<top>", simplified, OF dmo_cleanCacheRange_PoU_globals_equiv])
+  by simp
+
+lemma dmo_cleanCacheRange_RAM_reads_respects:
+  "reads_respects aag l \<top> (do_machine_op (cleanCacheRange_RAM vsrat vend pstart))"
+  unfolding cleanCacheRange_RAM_def
+  by (wp dmo_cacheRangeOp_reads_respects dmo_mol_reads_respects empty_fail_cleanByVA empty_fail_cacheRangeOp
+      | simp add: cleanL2Range_def dsb_def cleanCacheRange_PoC_def cleanByVA_def
+      | subst do_machine_op_bind)+
+
+lemma dmo_cleanCacheRange_RAM_reads_respects_g:
+  "reads_respects_g aag l \<top> (do_machine_op (cleanCacheRange_RAM x y z))"
+  apply (rule equiv_valid_guard_imp[OF reads_respects_g])
+    apply (rule dmo_cleanCacheRange_RAM_reads_respects)
+   apply (rule doesnt_touch_globalsI[where P="\<top>", simplified, OF dmo_cleanCacheRange_RAM_globals_equiv])
+  by simp
+
+lemma init_arch_objects_reads_respects_g:
+  "reads_respects_g aag l ((\<lambda>s. arm_global_pd (arch_state s) \<notin> set refs \<and>
+                                pspace_aligned s \<and> valid_arch_state s) and
+                           K (\<forall>x\<in>set refs. is_subject aag x) and
+                           K (\<forall>x\<in>set refs. new_type = ArchObject PageDirectoryObj
+                                           \<longrightarrow> is_aligned x pd_bits) and
+                           K ((0::obj_ref) < of_nat num_objects))
+                    (init_arch_objects new_type dev ptr num_objects obj_sz refs)"
+  apply (unfold init_arch_objects_def fun_app_def)
+  apply (rule gen_asm_ev)+
+  apply (rule equiv_valid_guard_imp)
+   apply (wp dmo_cleanCacheRange_RAM_reads_respects_g
+             dmo_cleanCacheRange_PoU_reads_respects_g
+             mapM_x_ev'' when_ev
+             equiv_valid_guard_imp[OF copy_global_mappings_reads_respects_g]
+             copy_global_mappings_valid_arch_state copy_global_mappings_pspace_aligned
+             hoare_vcg_ball_lift | wpc | simp)+
+  apply clarsimp
   done
 
 lemma invoke_untyped_reads_respects_g_wcap[Retype_IF_assms]:
@@ -691,7 +691,6 @@ lemma reset_untyped_cap_globals_equiv:
     apply (clarsimp simp: is_cap_simps ptr_range_def[symmetric]
                           cap_aligned_def bits_of_def
                           free_index_of_def)
-    apply (clarsimp simp: Kernel_Config.resetChunkBits_def)
     apply (strengthen invs_valid_global_objs invs_arch_state)
     apply (wp delete_objects_invs_ex hoare_vcg_const_imp_lift get_cap_wp)+
   apply (clarsimp simp: cte_wp_at_caps_of_state descendants_range_def2 is_cap_simps bits_of_def

--- a/proof/infoflow/ARM/ArchScheduler_IF.thy
+++ b/proof/infoflow/ARM/ArchScheduler_IF.thy
@@ -148,7 +148,7 @@ global_interpretation Scheduler_IF_1?:
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Scheduler_IF_assms)?)
+    by (unfold_locales; (fact Scheduler_IF_assms | wpsimp)?)
 qed
 
 
@@ -234,7 +234,7 @@ lemma ev_asahi_to_asahi_ex_dmo_clearExMonitor:
   apply (rule conjI)
    apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
                          silc_dom_equiv_def equiv_for_def)
-  apply (clarsimp simp: midstrength_scheduler_affects_equiv_def asahi_scheduler_affects_equiv_def
+  apply (auto simp: midstrength_scheduler_affects_equiv_def asahi_scheduler_affects_equiv_def
                         asahi_ex_scheduler_affects_equiv_def states_equiv_for_def equiv_for_def
                         arch_scheduler_affects_equiv_def equiv_asids_def equiv_asid_def
                         scheduler_globals_frame_equiv_def
@@ -255,8 +255,8 @@ lemma store_cur_thread_fragment_midstrength_reads_respects:
   apply simp
   done
 
-lemma arch_switch_to_thread_globals_equiv_scheduler':
-  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
+lemma set_vm_root_globals_equiv_scheduler:
+  "\<lbrace>valid_arch_state and globals_equiv_scheduler sta\<rbrace>
    set_vm_root t
    \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
   by (rule globals_equiv_scheduler_inv', wpsimp)
@@ -270,7 +270,7 @@ lemma reads_respects_scheduler_clearExMonitor[wp]:
   apply (rule conjI)
    apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
                          silc_dom_equiv_def equiv_for_def)
-  apply (clarsimp simp: scheduler_affects_equiv_def arch_scheduler_affects_equiv_def
+  apply (auto simp: scheduler_affects_equiv_def arch_scheduler_affects_equiv_def
                         states_equiv_for_def equiv_for_def equiv_asids_def equiv_asid_def
                         scheduler_globals_frame_equiv_def
               simp del: split_paired_All)
@@ -318,11 +318,11 @@ lemma arch_switch_to_thread_midstrength_reads_respects_scheduler[Scheduler_IF_as
   done
 
 lemma arch_switch_to_idle_thread_globals_equiv_scheduler[Scheduler_IF_assms, wp]:
-  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
+  "\<lbrace>valid_arch_state and globals_equiv_scheduler sta\<rbrace>
    arch_switch_to_idle_thread
    \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
   unfolding arch_switch_to_idle_thread_def storeWord_def
-  by (wp dmo_wp modify_wp thread_get_wp' arch_switch_to_thread_globals_equiv_scheduler')
+  by (wp dmo_wp modify_wp thread_get_wp' set_vm_root_globals_equiv_scheduler)
 
 lemma arch_switch_to_idle_thread_unobservable[Scheduler_IF_assms]:
   "\<lbrace>(\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l = {}) and
@@ -369,6 +369,19 @@ lemma next_domain_midstrength_equiv_scheduler[Scheduler_IF_assms]:
                         globals_equiv_scheduler_def silc_dom_equiv_def domain_fields_equiv_def
                         weak_scheduler_affects_equiv_def midstrength_scheduler_affects_equiv_def
                         states_equiv_for_def idle_equiv_def)
+  done
+
+lemma arch_switch_to_idle_thread_midstrength_reads_respects[Scheduler_IF_assms]:
+  "equiv_valid_inv (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+                   (valid_arch_state and valid_silc_label aag) arch_switch_to_idle_thread"
+  apply (rule equiv_valid_inv_unobservable)
+   apply (rule hoare_pre)
+           apply (rule scheduler_equiv_lift')
+            apply (wpsimp wp: silc_dom_lift)+
+      apply assumption
+ apply (wp midstrength_scheduler_affects_equiv_unobservable
+                | simp | wps)+
+    apply (auto simp: scheduler_equiv_sym midstrength_scheduler_affects_equiv_sym)
   done
 
 lemma resetTimer_exclusive_state[wp]:
@@ -438,6 +451,32 @@ lemma thread_set_scheduler_affects_equiv[Scheduler_IF_assms, wp]:
             apply simp+
   done
 
+lemma thread_set_reads_respects_scheduler[Scheduler_IF_assms]:
+  "reads_respects_scheduler aag l (valid_arch_state and K (valid_tcb_context_update f))
+                                  (thread_set f t)"
+  apply (rule gen_asm_ev)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  unfolding thread_set_def gets_the_def gets_def get_def return_def assert_opt_def fail_def set_object_def get_object_def assert_def put_def
+  apply (clarsimp simp: bind_def split: option.splits if_splits)
+  apply (clarsimp simp: get_tcb_ko_at obj_at_def)
+  unfolding valid_tcb_context_update_def
+  apply (rename_tac s' tcb tcb')
+  apply (erule_tac x=tcb in allE)
+  apply (erule_tac x=tcb' in allE)
+  apply (rule conjI)
+   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def)
+   apply (intro conjI)
+     apply (clarsimp simp: arch_globals_equiv_scheduler_def)
+    apply (clarsimp simp: idle_equiv_def tcb_at_def get_tcb_def arch_tcb_context_get_def)
+   apply (clarsimp simp: silc_dom_equiv_def equiv_for_def)
+  apply (clarsimp simp: scheduler_affects_equiv_def)
+  apply (intro conjI)
+  apply (clarsimp simp: states_equiv_for_def equiv_for_def)
+  apply (intro conjI; clarsimp?)
+    apply (clarsimp simp: equiv_asids_def equiv_asid_def obj_at_def)
+  apply (clarsimp simp: scheduler_globals_frame_equiv_def arch_scheduler_affects_equiv_def)
+  done
+
 lemma set_object_reads_respects_scheduler[Scheduler_IF_assms, wp]:
   "reads_respects_scheduler aag l \<top> (set_object ptr obj)"
   unfolding equiv_valid_def2 equiv_valid_2_def
@@ -456,15 +495,50 @@ lemma arch_prepare_next_domain_ev[Scheduler_IF_assms]:
   "equiv_valid_inv I A (\<lambda>_. True) arch_prepare_next_domain"
   unfolding arch_prepare_next_domain_def by wp
 
+lemma arch_switch_to_thread_silc_dom_equiv[wp]:
+  "arch_switch_to_thread t \<lbrace>silc_dom_equiv aag (st :: det_state)\<rbrace>"
+  by (wpsimp wp: silc_dom_lift)
+
+lemma arch_switch_to_idle_thread_silc_dom_equiv[wp]:
+  "arch_switch_to_idle_thread \<lbrace>silc_dom_equiv aag (st :: det_state)\<rbrace>"
+  by (wpsimp wp: silc_dom_lift)
+
+
+definition cur_hyp_in_cur_domain :: "det_state \<Rightarrow> bool" where
+  "cur_hyp_in_cur_domain s \<equiv> True"
+
+definition cur_fpu_in_cur_domain :: "det_state \<Rightarrow> bool" where
+  "cur_fpu_in_cur_domain s \<equiv> True"
+
+lemma cur_hyp_in_cur_domain_dummy[intro!,simp]:
+  "cur_hyp_in_cur_domain s"
+  by (simp add: cur_hyp_in_cur_domain_def)
+
+lemma cur_fpu_in_cur_domain_dummy[intro!,simp]:
+  "cur_fpu_in_cur_domain s"
+  by (simp add: cur_fpu_in_cur_domain_def)
+
+lemma cur_hyp_in_cur_domain_wp[wp]:
+  "\<lbrace>\<top>\<rbrace> f \<lbrace>\<lambda>_. cur_hyp_in_cur_domain\<rbrace>"
+  unfolding cur_hyp_in_cur_domain_def by wp
+
+lemma cur_fpu_in_cur_domain_wp[wp]:
+  "\<lbrace>\<top>\<rbrace> f \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
+  unfolding cur_fpu_in_cur_domain_def by wp
+
 end
+
+arch_requalify_consts
+  cur_hyp_in_cur_domain
+  cur_fpu_in_cur_domain
 
 
 global_interpretation Scheduler_IF_2?:
-  Scheduler_IF_2 arch_globals_equiv_scheduler arch_scheduler_affects_equiv
+  Scheduler_IF_2 arch_globals_equiv_scheduler arch_scheduler_affects_equiv _ cur_hyp_in_cur_domain cur_fpu_in_cur_domain
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Scheduler_IF_assms)?)
+    by (unfold_locales; (fact Scheduler_IF_assms |solves \<open>wpsimp wp: Scheduler_IF_assms simp: pas_wellformed_noninterference_domains_distinct\<close>)?)
 qed
 
 

--- a/proof/infoflow/ARM/ArchSyscall_IF.thy
+++ b/proof/infoflow/ARM/ArchSyscall_IF.thy
@@ -189,7 +189,7 @@ global_interpretation Syscall_IF_1?: Syscall_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Syscall_IF_assms)?)
+    by (unfold_locales; (fact Syscall_IF_assms | wpsimp wp: Syscall_IF_assms)?)
 qed
 
 end

--- a/proof/infoflow/ARM/ArchTcb_IF.thy
+++ b/proof/infoflow/ARM/ArchTcb_IF.thy
@@ -76,7 +76,7 @@ global_interpretation Tcb_IF_1?: Tcb_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Tcb_IF_assms)?)
+    by (unfold_locales; (fact Tcb_IF_assms | wpsimp wp: Tcb_IF_assms)?)
 qed
 
 
@@ -255,7 +255,7 @@ global_interpretation Tcb_IF_2?: Tcb_IF_2
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Tcb_IF_assms)?)
+    by (unfold_locales; (fact Tcb_IF_assms | wpsimp wp: Tcb_IF_assms)?)
 qed
 
 end

--- a/proof/infoflow/ARM/ArchUserOp_IF.thy
+++ b/proof/infoflow/ARM/ArchUserOp_IF.thy
@@ -124,7 +124,7 @@ global_interpretation UserOp_IF_1?: UserOp_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact UserOp_IF_assms)?)
+    by (unfold_locales; (fact UserOp_IF_assms | wpsimp)?)
 qed
 
 
@@ -919,6 +919,8 @@ lemma dmo_getExMonitor_reads_respects_g:
   "reads_respects_g aag l (\<lambda>s. cur_thread s \<noteq> idle_thread s) (do_machine_op getExMonitor)"
   apply (simp add: getExMonitor_def)
   apply (wp dmo_ev gets_ev'')
+  prefer 2
+   apply assumption
   apply (clarsimp simp: reads_equiv_g_def globals_equiv_def)
   done
 

--- a/proof/infoflow/ARM/Example_Valid_State.thy
+++ b/proof/infoflow/ARM/Example_Valid_State.thy
@@ -1167,7 +1167,7 @@ lemma domain_sep_inv_s0:
   "domain_sep_inv False s0_internal s0_internal"
   apply (clarsimp simp: domain_sep_inv_def)
   apply (force dest: cte_wp_at_caps_of_state' s0_caps_of_state
-        | rule conjI allI | clarsimp simp: s0_internal_def)+
+        | rule conjI allI | clarsimp simp: s0_internal_def non_kernel_IRQs_def)+
   done
 
 lemma only_timer_irq_inv_s0:
@@ -1833,7 +1833,7 @@ lemma Sys1_valid_initial_state_noenabled:
           apply (simp add: only_timer_irq_inv_s0 silc_inv_s0 Sys1_pas_cur_domain
                            domain_sep_inv_s0 Sys1_pas_refined Sys1_guarded_pas_domain
                            idle_equiv_refl)
-          apply (clarsimp simp: obj_valid_pdpt_kh0 valid_domain_list_2_def s0_internal_def exst0_def)
+          apply (clarsimp simp: obj_valid_pdpt_kh0 valid_domain_list_2_def s0_internal_def exst0_def valid_cur_hyp_def)
          apply (simp add: det_inv_s0)
         apply (simp add: s0_internal_def exst0_def)
        apply (simp add: ct_in_state_def st_tcb_at_tcb_states_of_state_eq

--- a/proof/infoflow/Arch_IF.thy
+++ b/proof/infoflow/Arch_IF.thy
@@ -19,7 +19,6 @@ lemmas [wp] = do_ipc_transfer_valid_arch_no_caps
 abbreviation irq_state_of_state :: "det_state \<Rightarrow> nat" where
   "irq_state_of_state s \<equiv> irq_state (machine_state s)"
 
-
 crunch cap_insert, cap_swap_for_delete
   for irq_state_of_state[wp]: "\<lambda>s. P (irq_state_of_state s)"
   (wp: crunch_wps)
@@ -148,18 +147,12 @@ lemma throw_on_false_reads_respects:
    \<Longrightarrow> reads_respects aag l P (throw_on_false ex f)"
   unfolding throw_on_false_def fun_app_def unlessE_def by wpsimp
 
-lemma dmo_mol_2_reads_respects:
-  "reads_respects aag l \<top> (do_machine_op (machine_op_lift mop >>= (\<lambda> y. machine_op_lift mop')))"
-  apply (rule use_spec_ev)
-  apply (rule do_machine_op_spec_reads_respects)
-  by (wpsimp wp: machine_op_lift_ev)+
-
 lemma tl_subseteq:
   "set (tl xs) \<subseteq> set xs"
   by (induct xs, auto)
 
 
-abbreviation(input) aag_can_read_label where
+abbreviation (input) aag_can_read_label where
   "aag_can_read_label aag l \<equiv> l \<in> subjectReads (pasPolicy aag) (pasSubject aag)"
 
 definition labels_are_invisible where
@@ -167,38 +160,60 @@ definition labels_are_invisible where
      (\<forall>d \<in> L. \<not> aag_can_read_label aag d) \<and>
      (aag_can_affect_label aag l \<longrightarrow> (\<forall>d \<in> L. d \<notin> subjectReads (pasPolicy aag) l))"
 
-
-lemma equiv_but_for_reads_equiv:
-  "\<lbrakk> pas_domains_distinct aag; labels_are_invisible aag l L; equiv_but_for_labels aag L s s' \<rbrakk>
+lemma equiv_but_for_reads_equiv':
+  "\<lbrakk> pas_domains_distinct aag \<or> equiv_for (aag_can_read_domain aag) ready_queues s s';
+     labels_are_invisible aag l L; equiv_but_for_labels aag L s s' \<rbrakk>
      \<Longrightarrow> reads_equiv aag s s'"
   apply (simp add: reads_equiv_def2)
   apply (rule conjI)
    apply (clarsimp simp: labels_are_invisible_def equiv_but_for_labels_def)
    apply (rule states_equiv_forI)
-            apply (fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+
-       apply (auto intro!: equiv_forI elim!: states_equiv_forE elim!: equiv_forD simp: o_def)[1]
-      apply (fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+
-    apply (fastforce simp: equiv_asids_def elim: states_equiv_forE elim: equiv_forD)
+             apply (fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+
+         apply (auto intro!: equiv_forI elim!: states_equiv_forE elim!: equiv_forD simp: o_def)[1]
+        apply (fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+
+      apply (fastforce simp: equiv_asids_def elim: states_equiv_forE elim: equiv_forD)
+     apply (fastforce elim!: states_equiv_forE equiv_hyp_guard_imp)
+    apply (fastforce elim!: states_equiv_forE equiv_fpu_guard_imp)
    apply (clarsimp simp: equiv_for_def states_equiv_for_def disjoint_iff_not_equal)
    apply (metis pas_domains_distinct_inj)
   apply (fastforce simp: equiv_but_for_labels_def)
   done
 
-lemma equiv_but_for_affects_equiv:
-  "\<lbrakk> pas_domains_distinct aag; labels_are_invisible aag l L; equiv_but_for_labels aag L s s' \<rbrakk>
+lemma equiv_but_for_affects_equiv':
+  "\<lbrakk> pas_domains_distinct aag \<or> equiv_for (aag_can_affect_domain aag l) ready_queues s s';
+     labels_are_invisible aag l L; equiv_but_for_labels aag L s s' \<rbrakk>
      \<Longrightarrow> affects_equiv aag l s s'"
   apply (subst affects_equiv_def2)
   apply (clarsimp simp: labels_are_invisible_def equiv_but_for_labels_def aag_can_affect_label_def)
   apply (rule states_equiv_forI)
-           apply (fastforce intro!: equiv_forI elim!: states_equiv_forE equiv_forD)+
-   apply (fastforce simp: equiv_asids_def elim!: states_equiv_forE elim!: equiv_forD)
+            apply (fastforce intro!: equiv_forI elim!: states_equiv_forE equiv_forD)+
+     apply (fastforce simp: equiv_asids_def elim!: states_equiv_forE elim!: equiv_forD)
+    apply (fastforce elim!: states_equiv_forE equiv_hyp_guard_imp)
+   apply (fastforce elim!: states_equiv_forE equiv_fpu_guard_imp)
   apply (clarsimp simp: equiv_for_def states_equiv_for_def disjoint_iff_not_equal)
   apply (metis pas_domains_distinct_inj)
   done
 
+lemmas equiv_but_for_reads_equiv = equiv_but_for_reads_equiv'[OF disjI1]
+   and equiv_but_for_affects_equiv = equiv_but_for_affects_equiv'[OF disjI1]
+
+lemma equiv_for_lift:
+  assumes "\<And>P. m \<lbrace>\<lambda>s. P (f s)\<rbrace>"
+  shows "m \<lbrace>\<lambda>s. equiv_for P f st s\<rbrace>"
+    and "m \<lbrace>\<lambda>s. equiv_for P f s st\<rbrace>"
+  using assms
+  by (fastforce simp: equiv_for_def valid_def)+
+
+lemma equiv_for_lift2:
+  assumes "\<And>P. m \<lbrace>\<lambda>s. P (f (g s))\<rbrace>"
+  shows "m \<lbrace>\<lambda>s. equiv_for P f st (g s)\<rbrace>"
+  using assms
+  by (fastforce simp: equiv_for_def valid_def)
+
 (* consider rewriting the return-value assumption using equiv_valid_rv_inv *)
-lemma ev2_invisible:
-  assumes domains_distinct: "pas_domains_distinct aag"
+lemma ev2_invisible':
+  assumes "pas_domains_distinct aag \<or> (\<forall>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace>) \<and>
+                                      (\<forall>P. g \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace>)"
   shows
   "\<lbrakk> labels_are_invisible aag l L; labels_are_invisible aag l L';
      modifies_at_most aag L Q f; modifies_at_most aag L' Q' g;
@@ -210,39 +225,62 @@ lemma ev2_invisible:
    apply blast
   apply (drule_tac s=s in modifies_at_mostD, assumption+)
   apply (drule_tac s=t in modifies_at_mostD, assumption+)
-  apply (frule (1) equiv_but_for_reads_equiv[OF domains_distinct])
-  apply (frule_tac s=t in equiv_but_for_reads_equiv[OF domains_distinct], assumption)
-  apply (drule (1) equiv_but_for_affects_equiv[OF domains_distinct])
-  apply (drule_tac s=t in equiv_but_for_affects_equiv[OF domains_distinct], assumption)
-  apply (blast intro: reads_equiv_trans reads_equiv_sym affects_equiv_trans affects_equiv_sym)
+  apply (insert assms)
+  apply (frule equiv_but_for_reads_equiv'[rotated 2])
+    apply (erule disjE; clarsimp intro!: disjCI2)
+    apply (erule use_valid, wpsimp wp: equiv_for_lift, rule equiv_for_refl)
+   apply assumption
+  apply (drule equiv_but_for_affects_equiv'[rotated 2])
+    apply (erule disjE; clarsimp intro!: disjCI2)
+    apply (erule use_valid, wpsimp wp: equiv_for_lift, rule equiv_for_refl)
+   apply assumption
+  apply (frule equiv_but_for_reads_equiv'[rotated 2])
+    apply (erule disjE; clarsimp intro!: disjCI2)
+    apply (rule equiv_for_sym, erule use_valid, wpsimp wp: equiv_for_lift, rule equiv_for_refl)
+   apply assumption
+  apply (drule equiv_but_for_affects_equiv'[rotated 2])
+    apply (erule disjE; clarsimp intro!: disjCI2)
+    apply (erule use_valid, wpsimp wp: equiv_for_lift, rule equiv_for_refl)
+   apply assumption
+  apply (meson reads_equiv_sym reads_equiv_trans affects_equiv_sym affects_equiv_trans)
   done
 
-lemma ev_invisible:
+lemmas ev2_invisible = ev2_invisible'[OF disjI1]
+
+lemma revrv_invisible:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows
     "\<lbrakk> labels_are_invisible aag l L; modifies_at_most aag L Q f;
        \<forall>s t. P s \<and> P t \<longrightarrow> (\<forall>(rva, s') \<in> fst (f s). \<forall>(rvb, t') \<in> fst(f t). W rva rvb) \<rbrakk>
-       \<Longrightarrow> equiv_valid_2 (reads_equiv aag) (affects_equiv aag l) (affects_equiv aag l)
-                         W (P and Q) (P and Q) f f"
+       \<Longrightarrow> reads_equiv_valid_rv_inv (affects_equiv aag l) aag W (P and Q) f"
   by (rule ev2_invisible[OF domains_distinct]; simp)
 
-lemma modify_det:
-  "det (modify f)"
-  by (clarsimp simp: det_def modify_def get_def put_def bind_def)
+lemma reads_respects_unit_invisible:
+  "\<lbrakk> labels_are_invisible aag l L; modifies_at_most aag L P f; \<And>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+       \<Longrightarrow> reads_respects aag l P (f :: (det_state,unit) nondet_monad)"
+  apply (rule equiv_valid_guard_imp)
+   apply (simp add: equiv_valid_def2)
+   apply (rule ev2_invisible')
+  by simp+
+
+lemma reads_respects_unit_cases':
+  "\<lbrakk> reads_respects aag l (P and K (aag_can_read_or_affect aag l ptr)) f;
+     modifies_at_most aag {pasObjectAbs aag ptr} (Q and K (\<not> aag_can_read_or_affect aag l ptr)) f;
+     \<And>P. f \<lbrace>\<lambda>s. P (ready_queues s)\<rbrace> \<rbrakk>
+     \<Longrightarrow> reads_respects aag l (if aag_can_read_or_affect aag l ptr then P else Q) (f :: (det_state,unit) nondet_monad)"
+  apply (case_tac "aag_can_read_or_affect aag l ptr")
+   apply clarsimp
+  apply (rule_tac L="{pasObjectAbs aag ptr}" in reads_respects_unit_invisible)
+    apply (clarsimp simp: labels_are_invisible_def)
+   apply (clarsimp simp: modifies_at_most_def)
+  apply simp
+  done
+
+lemmas reads_respects_unit_cases = reads_respects_unit_cases'[OF _ modifies_at_mostI]
 
 lemma dummy_kheap_update:
   "st = st\<lparr>kheap := kheap st\<rparr>"
   by simp
-
-lemma reads_affects_equiv_kheap_eq:
-  "\<lbrakk> reads_equiv aag s s'; affects_equiv aag l s s'; aag_can_affect aag l x \<or> aag_can_read aag x \<rbrakk>
-     \<Longrightarrow> kheap s x = kheap s' x"
-  by (fastforce elim: affects_equivE reads_equivE equiv_forE)
-
-lemma reads_affects_equiv_get_tcb_eq:
-  "\<lbrakk> aag_can_read aag t \<or> aag_can_affect aag l t; reads_equiv aag s s'; affects_equiv aag l s s' \<rbrakk>
-     \<Longrightarrow> get_tcb t s = get_tcb t s'"
-  by (fastforce simp: get_tcb_def reads_affects_equiv_kheap_eq)
 
 lemma equiv_valid_get_assert:
   "equiv_valid_inv I A P f
@@ -409,10 +447,6 @@ locale Arch_IF_1 =
     "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
      set_endpoint ptr ep
      \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  and set_cap_globals_equiv'':
-    "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
-     set_cap cap p
-     \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   and set_thread_state_globals_equiv:
     "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
      set_thread_state ref ts
@@ -426,6 +460,10 @@ locale Arch_IF_1 =
     "arch_prepare_set_domain t new_dom \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
   and arch_prepare_next_domain_irq_state_of_state[wp]:
     "arch_prepare_next_domain  \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
+  and equiv_hyp_machine_state_rest_update[simp]:
+    "\<And>P. equiv_hyp P st (s\<lparr>machine_state := ms\<lparr>machine_state_rest := rest\<rparr>\<rparr>) = equiv_hyp P st (s\<lparr>machine_state := ms\<rparr>)"
+  and equiv_fpu_machine_state_rest_update[simp]:
+    "\<And>P. equiv_fpu P st (s\<lparr>machine_state := ms\<lparr>machine_state_rest := rest\<rparr>\<rparr>) = equiv_fpu P st (s\<lparr>machine_state := ms\<rparr>)"
 begin
 
 crunch empty_slot
@@ -465,7 +503,7 @@ lemma mol_states_equiv_for:
   apply (simp add: machine_rest_lift_def split_def)
   apply (wp modify_wp)
   apply (clarsimp simp: states_equiv_for_def equiv_asids_def)
-  apply (fastforce elim!: equiv_forE intro!: equiv_forI)
+  apply (auto elim!: equiv_forE intro!: equiv_forI)
   done
 
 lemma do_machine_op_mol_states_equiv_for:
@@ -487,18 +525,10 @@ lemma set_message_info_reads_respects:
 lemma set_mrs_reads_respects:
   "reads_respects aag l (K (aag_can_read aag t \<or> aag_can_affect aag l t)) (set_mrs t buf msgs)"
   apply (simp add: set_mrs_def cong: option.case_cong_weak)
-  apply (wp mapM_x_ev' store_word_offs_reads_respects set_object_reads_respects
+ apply (wp mapM_x_ev' store_word_offs_reads_respects set_object_reads_respects
          | wpc | simp add: split_def split del: if_split add: zipWithM_x_mapM_x)+
   apply (auto intro: reads_affects_equiv_get_tcb_eq)
   done
-
-lemma cap_insert_globals_equiv'':
-  "\<lbrace>globals_equiv s and valid_global_objs and valid_arch_state\<rbrace>
-   cap_insert new_cap src_slot dest_slot
-   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding cap_insert_def
-  by (wpsimp wp: set_original_globals_equiv update_cdt_globals_equiv
-                 set_cap_globals_equiv'' dxo_wp_weak hoare_drop_imps)
 
 lemma set_message_info_globals_equiv:
   "\<lbrace>globals_equiv s and valid_arch_state and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>

--- a/proof/infoflow/CNode_IF.thy
+++ b/proof/infoflow/CNode_IF.thy
@@ -46,7 +46,7 @@ lemma get_object_rev:
 lemma get_cap_rev:
   "reads_equiv_valid_inv A aag (K (aag_can_read aag (fst slot))) (get_cap slot)"
   unfolding get_cap_def
-  by (wp get_object_rev | wpc | simp add: split_def)+
+  by (wpsimp wp: get_object_rev)
 
 declare if_weak_cong[cong]
 
@@ -321,14 +321,9 @@ locale CNode_IF_1 =
   fixes state_ext_t :: "'s :: state_ext itself"
   and irq_at :: "nat \<Rightarrow> (irq \<Rightarrow> bool) \<Rightarrow> irq option"
   assumes set_cap_globals_equiv:
-    "\<lbrace>globals_equiv s and valid_global_objs and valid_arch_state\<rbrace>
+    "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
      set_cap cap p
      \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  and dmo_getActiveIRQ_wp:
-    "\<lbrace>\<lambda>s. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
-            (s\<lparr>machine_state := machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>\<rparr>)\<rbrace>
-     do_machine_op (getActiveIRQ in_kernel)
-     \<lbrace>\<lambda>rv s :: 's state. P rv s\<rbrace>"
   and arch_globals_equiv_irq_state_update[simp]:
     "arch_globals_equiv ct it kh kh' as as' ms (irq_state_update f ms') =
      arch_globals_equiv ct it kh kh' as as' ms ms'"
@@ -340,7 +335,7 @@ crunch set_untyped_cap_as_full
   for globals_equiv[wp]: "globals_equiv st"
 
 lemma cap_insert_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_global_objs and valid_arch_state\<rbrace>
+  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
    cap_insert new_cap src_slot dest_slot
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding cap_insert_def fun_app_def
@@ -348,14 +343,14 @@ lemma cap_insert_globals_equiv:
                  set_cap_globals_equiv hoare_drop_imps dxo_wp_weak)
 
 lemma cap_move_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_global_objs and valid_arch_state\<rbrace>
+  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
    cap_move new_cap src_slot dest_slot
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding cap_move_def fun_app_def
   by (wpsimp wp: set_original_globals_equiv set_cdt_globals_equiv set_cap_globals_equiv dxo_wp_weak)
 
 lemma cap_swap_globals_equiv:
-  "\<lbrace>globals_equiv s and valid_global_objs and valid_arch_state\<rbrace>
+  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
    cap_swap cap1 slot1 cap2 slot2
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding cap_swap_def
@@ -476,12 +471,6 @@ lemma only_timer_irq_inv_determines_irq_masks:
   apply (case_tac "interrupt_states s x")
     apply (fastforce simp: invs_def valid_state_def valid_irq_states_def valid_irq_masks_def)
    apply fastforce+
-  done
-
-lemma dmo_getActiveIRQ_globals_equiv:
-  "\<lbrace>globals_equiv st\<rbrace> do_machine_op (getActiveIRQ in_kernel) \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (wp dmo_getActiveIRQ_wp)
-  apply (auto simp: globals_equiv_def idle_equiv_def)
   done
 
 crunch reset_work_units, work_units_limit_reached, update_work_units
@@ -660,9 +649,11 @@ locale CNode_IF_3 = CNode_IF_2 +
   fixes aag :: "'a subject_label PAS"
   assumes dmo_getActiveIRQ_reads_respects:
     "reads_respects aag l (invs and only_timer_irq_inv irq st) (do_machine_op (getActiveIRQ in_kernel))"
+  and dmo_getActiveIRQ_globals_equiv:
+    "do_machine_op (getActiveIRQ in_kernel) \<lbrace>globals_equiv st\<rbrace>"
 begin
 
-lemma dmo_getActiveIRQ_reads_respects_g :
+lemma dmo_getActiveIRQ_reads_respects_g:
   "reads_respects_g aag l (invs and only_timer_irq_inv irq st) (do_machine_op (getActiveIRQ in_kernel))"
   apply (rule equiv_valid_guard_imp[OF reads_respects_g])
     apply (rule dmo_getActiveIRQ_reads_respects)
@@ -735,18 +726,6 @@ lemma reads_respects_f_g:
    apply (assumption)
   apply (fastforce intro: globals_equivI)
   done
-
-lemma reads_equiv_valid_rv_inv_f:
-  assumes a: "reads_equiv_valid_rv_inv A aag R P f"
-  assumes b: "\<And>P. \<lbrace>P\<rbrace> f \<lbrace>\<lambda>_. P\<rbrace>"
-  shows "equiv_valid_rv_inv (reads_equiv_f aag) A R P f"
-  apply (clarsimp simp: equiv_valid_2_def reads_equiv_f_def)
-  apply (insert a, clarsimp simp: equiv_valid_2_def)
-  apply (drule_tac x=s in spec, drule_tac x=t in spec, clarsimp)
-  apply (drule (1) bspec, clarsimp)
-  apply (drule (1) bspec, clarsimp)
-  apply (drule state_unchanged[OF b])+
-  by simp
 
 lemma set_cap_silc_inv':
   "\<lbrace>silc_inv aag st and (\<lambda>s. \<not> cap_points_to_label aag cap (pasObjectAbs aag (fst slot))

--- a/proof/infoflow/Decode_IF.thy
+++ b/proof/infoflow/Decode_IF.thy
@@ -347,7 +347,7 @@ begin
 
 lemma decode_invocation_reads_respects_f:
   "reads_respects_f aag l
-     (silc_inv aag st and pas_refined aag and valid_cap cap and invs and ct_active
+     (silc_inv aag st and pas_refined aag and invs and ct_active
                       and domain_sep_inv irqs st'
                       and cte_wp_at ((=) cap) slot and ex_cte_cap_to slot
                       and (\<lambda>s. \<forall>r\<in>zobj_refs cap. ex_nonz_cap_to r s)

--- a/proof/infoflow/FinalCaps.thy
+++ b/proof/infoflow/FinalCaps.thy
@@ -335,16 +335,12 @@ locale FinalCaps_1 =
     "arch_finalise_cap c x \<lbrace>silc_inv aag st\<rbrace>"
   and prepare_thread_delete_silc_inv[wp]:
     "prepare_thread_delete p \<lbrace>silc_inv aag st\<rbrace>"
-  and handle_reserved_irq_silc_inv[wp]:
-    "handle_reserved_irq irq \<lbrace>silc_inv aag st\<rbrace>"
-  and arch_mask_irq_signal_silc_inv[wp]:
-    "arch_mask_irq_signal irq \<lbrace>silc_inv aag st\<rbrace>"
   and handle_vm_fault_silc_inv[wp]:
     "handle_vm_fault t vmft \<lbrace>silc_inv aag st\<rbrace>"
+  and arch_mask_irq_signal_silc_inv[wp]:
+    "arch_mask_irq_signal irq \<lbrace>silc_inv aag st\<rbrace>"
   and handle_vm_fault_cur_thread[wp]:
     "\<And>P. handle_vm_fault t vmft \<lbrace>\<lambda>s :: det_state. P (cur_thread s)\<rbrace>"
-  and handle_hypervisor_fault_silc_inv[wp]:
-    "handle_hypervisor_fault t hvft \<lbrace>silc_inv aag st\<rbrace>"
   and arch_activate_idle_threadt_silc_inv[wp]:
     "arch_activate_idle_thread t \<lbrace>silc_inv aag st\<rbrace>"
   and arch_switch_to_idle_thread_silc_inv[wp]:
@@ -2714,15 +2710,15 @@ end
 
 
 lemma thread_set_tcb_ipc_buffer_update_silc_inv[wp]:
-  "\<lbrace>silc_inv aag st\<rbrace>
-   thread_set (tcb_ipc_buffer_update blah) t
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  "thread_set (tcb_ipc_buffer_update f) t \<lbrace>silc_inv aag st\<rbrace>"
   by (rule thread_set_silc_inv; simp add: tcb_cap_cases_def)
 
 lemma thread_set_tcb_fault_handler_update_silc_inv[wp]:
-  "\<lbrace>silc_inv aag st\<rbrace>
-   thread_set (tcb_fault_handler_update blah) t
-   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  "thread_set (tcb_fault_handler_update f) t \<lbrace>silc_inv aag st\<rbrace>"
+  by (rule thread_set_silc_inv; simp add: tcb_cap_cases_def)
+
+lemma thread_set_tcb_arch_update_silc_inv[wp]:
+  "thread_set (tcb_arch_update f) t \<lbrace>silc_inv aag st\<rbrace>"
   by (rule thread_set_silc_inv; simp add: tcb_cap_cases_def)
 
 lemma thread_set_tcb_fault_handler_update_invs:
@@ -2885,9 +2881,61 @@ crunch timer_tick, handle_yield
   for silc_inv[wp]: "silc_inv aag st"
   (simp: tcb_cap_cases_def)
 
+end
+
+
+locale FinalCaps_3 = FinalCaps_2 +
+  assumes handle_reserved_irq_silc_inv[wp]:
+    "\<lbrace>silc_inv aag st and invs and pas_refined aag and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))\<rbrace>
+     handle_reserved_irq irq
+     \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  and handle_hypervisor_fault_silc_inv[wp]:
+    "\<lbrace>silc_inv aag st and invs and pas_refined aag and is_subject aag o cur_thread and K (is_subject aag t)\<rbrace>
+     handle_hypervisor_fault t hvft
+     \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  and handle_reserved_irq_in_kernel_inv:
+    "\<lbrace>P and K (irq \<notin> non_kernel_IRQs)\<rbrace>
+     handle_reserved_irq irq
+     \<lbrace>\<lambda>_. P :: det_state \<Rightarrow> bool\<rbrace>"
+begin
+
 lemma handle_interrupt_silc_inv:
-  "handle_interrupt irq \<lbrace>silc_inv aag st\<rbrace>"
+  "\<lbrace>silc_inv aag st and invs and pas_refined aag and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))\<rbrace>
+   handle_interrupt irq
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding handle_interrupt_def by (wpsimp wp: hoare_drop_imps)
+
+lemma irq_inactive_or_timer:
+  "\<lbrace>domain_sep_inv False st and Q IRQTimer and Q IRQInactive\<rbrace>
+   get_irq_state irq
+   \<lbrace>Q\<rbrace>"
+  apply (simp add:get_irq_state_def)
+  apply wp
+  apply (clarsimp simp add: domain_sep_inv_def)
+  apply (drule_tac x=irq in spec)
+  apply (drule_tac x=a in spec) (*makes yellow variables*)
+  apply (drule_tac x=b in spec)
+  apply (drule_tac x=aa in spec, drule_tac x=ba in spec)
+  apply clarsimp
+  apply (case_tac "interrupt_states st irq")
+     apply clarsimp+
+  done
+
+lemma handle_interrupt_silc_inv':
+  "\<lbrace>silc_inv aag st and domain_sep_inv False st\<rbrace>
+   handle_interrupt irq
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding handle_interrupt_def
+  apply (wpsimp wp: irq_inactive_or_timer)
+  apply fastforce
+  done
+
+lemma handle_interrupt_in_kernel_silc_inv:
+  "\<lbrace>silc_inv aag st and K (irq \<notin> non_kernel_IRQs)\<rbrace>
+   handle_interrupt irq
+   \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
+  unfolding handle_interrupt_def get_irq_state_def
+  by (wpsimp wp: handle_reserved_irq_in_kernel_inv)
 
 lemma handle_event_silc_inv:
   "\<lbrace>silc_inv aag st and einvs and simple_sched_action and pas_refined aag
@@ -2896,7 +2944,7 @@ lemma handle_event_silc_inv:
                     and (\<lambda>s. ct_active s \<longrightarrow> is_subject aag (cur_thread s))\<rbrace>
    handle_event ev
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
-  apply (case_tac ev; simp_all add: maybe_handle_interrupt_def)
+   apply (case_tac ev; simp_all add: maybe_handle_interrupt_def)
   by (wpsimp wp: handle_send_silc_inv[where st'=st']
                  handle_call_silc_inv[where st'=st']
                  handle_recv_silc_inv
@@ -2904,7 +2952,8 @@ lemma handle_event_silc_inv:
                  handle_interrupt_silc_inv
                  handle_vm_fault_silc_inv
                  handle_hypervisor_fault_silc_inv
-           simp: invs_valid_objs invs_mdb invs_sym_refs)+
+           simp: invs_valid_objs invs_mdb invs_sym_refs
+         | wp (once) hoare_drop_imps)+
 
 crunch activate_thread
   for silc_inv[wp]: "silc_inv aag st"
@@ -2915,6 +2964,7 @@ crunch schedule
    ignore: set_scheduler_action
      simp: crunch_simps)
 
+(* FIXME IF: delete if unused *)
 lemma call_kernel_silc_inv:
   "\<lbrace>silc_inv aag st and einvs and simple_sched_action and pas_refined aag
                     and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)
@@ -2922,7 +2972,13 @@ lemma call_kernel_silc_inv:
    call_kernel ev
    \<lbrace>\<lambda>_. silc_inv aag st\<rbrace>"
   unfolding call_kernel_def maybe_handle_interrupt_def
-  by (wpsimp wp: handle_interrupt_silc_inv handle_event_silc_inv[where st'=st'])
+  apply (wpsimp wp: handle_interrupt_in_kernel_silc_inv handle_event_silc_inv[where st'=st'])
+  apply (rule_tac Q'="\<lambda>rv s.  rv \<notin> Some ` non_kernel_IRQs \<and> silc_inv aag st s" in hoare_strengthen_post[rotated])
+   apply clarsimp
+  apply (wpsimp wp: getActiveIRQ_neq_non_kernel)
+  apply (wpsimp wp: handle_event_silc_inv[where st'=st'])
+  apply clarsimp
+  done
 
 end
 

--- a/proof/infoflow/Finalise_IF.thy
+++ b/proof/infoflow/Finalise_IF.thy
@@ -30,7 +30,7 @@ locale Finalise_IF_1 =
   and set_bound_notification_none_reads_respects:
     "pas_domains_distinct aag \<Longrightarrow> reads_respects aag l \<top> (set_bound_notification ref None)"
   and thread_set_reads_respects:
-    "pas_domains_distinct aag \<Longrightarrow> reads_respects aag l \<top> (thread_set x y)"
+    "reads_respects aag l \<top> (thread_set f thread)"
   and set_tcb_queue_reads_respects[wp]:
     "reads_respects aag l \<top> (set_tcb_queue d prio queue)"
   and set_notification_equiv_but_for_labels:
@@ -38,9 +38,13 @@ locale Finalise_IF_1 =
      set_notification ntfnptr ntfn
      \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
   and prepare_thread_delete_reads_respects_f:
-    "reads_respects_f aag l \<top> (prepare_thread_delete t)"
+    "pas_domains_distinct aag
+     \<Longrightarrow> reads_respects_f aag l (silc_inv aag st and pas_refined aag and valid_arch_state
+                                                 and valid_cur_fpu and K (is_subject aag thread))
+                                (prepare_thread_delete thread)"
   and arch_finalise_cap_reads_respects:
-    "reads_respects aag l (pas_refined aag and invs and cte_wp_at ((=) (ArchObjectCap cap)) slot
+    "pas_domains_distinct aag
+     \<Longrightarrow> reads_respects aag l (pas_refined aag and invs and cte_wp_at ((=) (ArchObjectCap cap)) slot
                                            and K (pas_cap_cur_auth aag (ArchObjectCap cap)))
                           (arch_finalise_cap cap is_final)"
   and arch_finalise_cap_makes_halted:
@@ -65,7 +69,7 @@ locale Finalise_IF_1 =
      arch_finalise_cap acap ex
      \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   and prepare_thread_delete_globals_equiv[wp]:
-    "prepare_thread_delete t \<lbrace>globals_equiv st\<rbrace>"
+    "\<lbrace>globals_equiv s and invs\<rbrace> prepare_thread_delete t \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
 begin
 
 lemma set_irq_state_reads_respects:
@@ -528,6 +532,13 @@ crunch set_simple_ko
   for sched_act[wp]: "\<lambda>s. P (scheduler_action s)"
   (wp: crunch_wps)
 
+lemma thread_get_reads_respects:
+  "reads_respects aag l (K (aag_can_read aag thread \<or> aag_can_affect aag l thread))
+                        (thread_get f thread)"
+  unfolding thread_get_def fun_app_def
+  apply (wp gets_the_ev)
+  apply (auto intro: reads_affects_equiv_get_tcb_eq)
+  done
 
 
 context Finalise_IF_1 begin
@@ -545,18 +556,17 @@ lemma tcb_sched_action_reads_respects:
   apply (simp add: tcb_sched_action_def get_tcb_queue_def)
   apply (subst gets_apply)
   apply (case_tac "aag_can_read aag t \<or> aag_can_affect aag l t")
-   apply (simp add: thread_get_def)
    apply wp
-         apply (rule_tac Q="\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (tcb_domain rv)"
+         apply (rule_tac Q="\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag rv"
                       in equiv_valid_guard_imp)
-          apply (wp gets_apply_ev')
+          apply (wp gets_apply_ev)
           apply (fastforce simp: reads_equiv_def affects_equiv_def equiv_for_def states_equiv_for_def)
-         apply (wp | simp)+
+         apply (wp thread_get_reads_respects | simp)+
    apply (intro conjI impI allI
           | fastforce simp: get_tcb_def elim: reads_equivE affects_equivE equiv_forE)+
    apply (clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def split: option.splits)
-   apply (erule_tac x="(t, tcb_domain y)" in ballE, force)
-   apply (force intro: domtcbs simp: get_tcb_Some etcbs_of'_def)
+   apply (erule_tac x="(t, tcb_domain tcb)" in ballE, force)
+   apply (force intro: domtcbs simp: obj_at_def get_tcb_Some etcbs_of'_def)
   apply (simp add: equiv_valid_def2 thread_get_def)
   apply (rule equiv_valid_rv_bind)
     apply (wpsimp wp: equiv_valid_rv_trivial')
@@ -693,14 +703,6 @@ lemma get_bound_notification_reads_respects':
   apply clarify
   apply (rule requiv_get_tcb_eq)
    apply simp+
-  done
-
-lemma thread_get_reads_respects:
-  "reads_respects aag l (K (aag_can_read aag thread \<or> aag_can_affect aag l thread))
-                  (thread_get f thread)"
-  unfolding thread_get_def fun_app_def
-  apply (wp gets_the_ev)
-  apply (auto intro: reads_affects_equiv_get_tcb_eq)
   done
 
 lemma get_bound_notification_reads_respects:
@@ -956,7 +958,7 @@ lemma cancel_signal_owned_reads_respects:
 
 lemma as_user_get_register_reads_respects:
   "reads_respects aag l (K (is_subject aag thread)) (as_user thread (getRegister reg))"
-  by (fastforce simp: equiv_valid_guard_imp[OF as_user_reads_respects] det_getRegister)
+  by (wpsimp wp: as_user_reads_respects simp: det_getRegister)
 
 lemma update_restart_pc_reads_respects[wp]:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
@@ -1040,6 +1042,14 @@ lemma deleting_irq_handler_reads_respects:
   by (wp cap_delete_one_reads_respects_f reads_respects_f[OF get_irq_slot_reads_respects]
       | simp | blast)+
 
+crunch unbind_notification, set_original, fast_finalise
+  for valid_arch_state[wp]: "valid_arch_state"
+  (wp: dxo_wp_weak mapM_x_wp)
+
+crunch suspend
+  for valid_arch_state[wp]: "\<lambda>s :: det_state. valid_arch_state s"
+  (wp: mapM_x_wp_inv crunch_wps simp: crunch_simps tcb_cap_cases_def)
+
 lemma finalise_cap_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows
@@ -1056,7 +1066,7 @@ lemma finalise_cap_reads_respects:
                         suspend_reads_respects_f[where st=st] deleting_irq_handler_reads_respects
                         unbind_notification_is_subj_reads_respects
                         unbind_maybe_notification_reads_respects
-                        unbind_notification_invs unbind_maybe_notification_invs
+                        unbind_notification_invs unbind_maybe_notification_invs suspend_silc_inv
                      | simp add: when_def invs_valid_objs invs_sym_refs aag_cap_auth_def
                                  cap_auth_conferred_def cap_rights_to_auth_def cap_links_irq_def
                                  aag_has_Control_iff_owns cte_wp_at_caps_of_state
@@ -1464,7 +1474,7 @@ crunch set_original
 lemma empty_slot_globals_equiv:
   "\<lbrace>globals_equiv st and valid_arch_state\<rbrace> empty_slot s b \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding empty_slot_def post_cap_deletion_def
-  by (wpsimp wp: set_cap_globals_equiv'' set_original_globals_equiv hoare_vcg_if_lift2
+  by (wpsimp wp: set_cap_globals_equiv set_original_globals_equiv hoare_vcg_if_lift2
                  set_cdt_globals_equiv dxo_wp_weak hoare_drop_imps hoare_vcg_all_lift)
 
 crunch fast_finalise
@@ -1473,7 +1483,7 @@ crunch fast_finalise
 
 crunch cap_delete_one
   for globals_equiv: "globals_equiv st"
-  (wp: set_cap_globals_equiv'' hoare_drop_imps simp: crunch_simps unless_def)
+  (wp: set_cap_globals_equiv hoare_drop_imps simp: crunch_simps unless_def)
 
 (*FIXME: Lots of this stuff should be in arch *)
 crunch deleting_irq_handler
@@ -1505,7 +1515,7 @@ lemma finalise_cap_globals_equiv:
   by (wp cancel_all_ipc_globals_equiv cancel_all_ipc_valid_global_objs
          cancel_all_signals_globals_equiv cancel_all_signals_valid_global_objs
          arch_finalise_cap_globals_equiv unbind_maybe_notification_globals_equiv
-         unbind_notification_globals_equiv liftM_wp when_def
+         unbind_notification_invs unbind_notification_globals_equiv liftM_wp when_def
       | clarsimp simp: valid_cap_def | intro impI conjI)+
 
 end

--- a/proof/infoflow/IRQMasks_IF.thy
+++ b/proof/infoflow/IRQMasks_IF.thy
@@ -60,8 +60,6 @@ locale IRQMasks_IF_1 =
     "send_signal ntfnptr badge \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
   and handle_vm_fault_irq_masks[wp]:
     "handle_vm_fault t vmft \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
-  and handle_hypervisor_fault_irq_masks[wp]:
-    "handle_hypervisor_fault t hvft \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
   and handle_interrupt_irq_masks:
     "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and K (irq \<le> maxIRQ)\<rbrace>
      handle_interrupt irq
@@ -78,8 +76,6 @@ locale IRQMasks_IF_1 =
      \<lbrace>\<lambda>rv s :: det_state. (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)\<rbrace>"
   and activate_thread_irq_masks[wp]:
     "activate_thread \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
-  and schedule_irq_masks[wp]:
-    "schedule \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
   and handle_spurious_irq_masks[wp]:
     "handle_spurious_irq \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
 begin
@@ -287,14 +283,29 @@ locale IRQMasks_IF_2 = IRQMasks_IF_1 state_t
   for state_t :: "'s :: state_ext state" +
   assumes do_reply_transfer_irq_masks[wp]:
     "do_reply_transfer sender receiver slot grant \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
-  and arch_perform_invocation_irq_masks[wp]:
-    "arch_perform_invocation i \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and arch_perform_invocation_irq_masks:
+    "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st\<rbrace>
+     arch_perform_invocation i
+     \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
   and arch_prepare_set_domain_irq_masks_of_state[wp]:
     "arch_prepare_set_domain t new_dom \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
   and invoke_tcb_irq_masks:
     "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and tcb_inv_wf tinv\<rbrace>
      invoke_tcb tinv
      \<lbrace>\<lambda>_ s. P (irq_masks_of_state s)\<rbrace>"
+  and handle_hypervisor_fault_irq_masks[wp]:
+    "handle_hypervisor_fault t hvft \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and arch_switch_to_idle_thread_irq_masks:
+    "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and valid_irq_states\<rbrace>
+      arch_switch_to_idle_thread \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  and arch_switch_to_thread_irq_masks:
+    "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False st and valid_irq_states\<rbrace>
+     arch_switch_to_thread t
+     \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  and arch_prepare_next_domain_irq_masks[wp]:
+    "arch_prepare_next_domain \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  and arch_prepare_next_domain_valid_irq_states[wp]:
+    "arch_prepare_next_domain \<lbrace>\<lambda>s :: det_state. valid_irq_states s\<rbrace>"
 begin
 
 crunch invoke_domain
@@ -311,6 +322,7 @@ lemma perform_invocation_irq_masks:
   by (wpsimp wp: invoke_tcb_irq_masks invoke_cnode_irq_masks[where st=st]
                  invoke_irq_control_irq_masks[where st=st]
                  invoke_irq_handler_irq_masks[where st=st]
+                 arch_perform_invocation_irq_masks[where st=st]
       | fastforce)+
 
 lemma handle_invocation_irq_masks:
@@ -349,22 +361,71 @@ lemma handle_event_irq_masks:
     apply wpsimp+
   done
 
-lemma call_kernel_irq_masks:
-  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and einvs
-                                   and (\<lambda>s. ev \<noteq> Interrupt \<longrightarrow> ct_active s)\<rbrace>
-   call_kernel ev
+lemma switch_to_idle_thread_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and valid_irq_states\<rbrace>
+   switch_to_idle_thread
    \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
-  apply (simp add: call_kernel_def maybe_handle_interrupt_def)
-  apply (wpsimp wp: handle_interrupt_irq_masks[where st=st])
-    apply (rule_tac Q'="\<lambda>rv s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s \<and>
-                              (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)" in hoare_strengthen_post)
-     apply (wp | simp)+
-   apply (rule_tac Q'="\<lambda>x s. P (irq_masks_of_state s) \<and> domain_sep_inv False st s"
-               and E="E" for E in hoare_strengthen_postE)
-     apply (rule valid_validE)
-     apply (wp handle_event_irq_masks[where st=st] valid_validE[OF handle_event_domain_sep_inv]
-            | simp)+
-  done
+  unfolding switch_to_idle_thread_def
+  by (wpsimp wp: arch_switch_to_idle_thread_irq_masks[where st=st])
+
+lemma switch_to_thread_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and valid_irq_states\<rbrace>
+   switch_to_thread t
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding switch_to_thread_def
+  by (wpsimp wp: arch_switch_to_thread_irq_masks[where st=st])
+
+lemma guarded_switch_to_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and valid_irq_states\<rbrace>
+   guarded_switch_to t
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding guarded_switch_to_def
+  by (wpsimp wp: switch_to_thread_irq_masks[where st=st] hoare_drop_imps)
+
+lemma choose_thread_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and valid_irq_states\<rbrace>
+   choose_thread
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding choose_thread_def
+  by (wpsimp wp: guarded_switch_to_irq_masks[where st=st]
+                 switch_to_idle_thread_irq_masks[where st=st])
+
+lemma do_extended_op_irq_masks[wp]:
+  "do_extended_op f \<lbrace>\<lambda>s. P (irq_masks_of_state s)\<rbrace>"
+  by (wpsimp wp: dxo_wp_weak)
+
+lemma do_extended_op_valid_irq_states[wp]:
+  "do_extended_op f \<lbrace>valid_irq_states\<rbrace>"
+  by (wpsimp wp: dxo_wp_weak)
+
+lemma valid_irq_states_domain_index_update[simp]:
+  "valid_irq_states (domain_index_update f s) = valid_irq_states s"
+  by (simp add: valid_irq_states_def)
+
+lemma valid_irq_states_cur_domain_update[simp]:
+  "valid_irq_states (cur_domain_update f s) = valid_irq_states s"
+  by (simp add: valid_irq_states_def)
+
+crunch next_domain
+  for irq_masks[wp]: "\<lambda>s. P (irq_masks_of_state s)"
+  and valid_irq_states[wp]: "valid_irq_states"
+  (simp: crunch_simps)
+
+lemma schedule_choose_new_thread_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and valid_irq_states\<rbrace>
+   schedule_choose_new_thread
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding schedule_choose_new_thread_def
+  by (wpsimp wp: choose_thread_irq_masks[where st=st])
+
+lemma schedule_irq_masks:
+  "\<lbrace>(\<lambda>s. P (irq_masks_of_state s)) and domain_sep_inv False (st :: 's state) and valid_irq_states\<rbrace>
+   schedule
+   \<lbrace>\<lambda>rv s. P (irq_masks_of_state s)\<rbrace>"
+  unfolding schedule_def
+  by (wpsimp wp: schedule_choose_new_thread_irq_masks[where st=st]
+                 guarded_switch_to_irq_masks[where st=st]
+                 hoare_drop_imps gts_wp)
 
 end
 

--- a/proof/infoflow/InfoFlow.thy
+++ b/proof/infoflow/InfoFlow.thy
@@ -156,8 +156,34 @@ abbreviation aag_can_read_domain :: "'a PAS \<Rightarrow> domain \<Rightarrow> b
 
 subsection \<open>Generic equivalence\<close>
 
-definition equiv_for where
+defs equiv_for_def:
   "equiv_for P f c c' \<equiv>  \<forall>x. P x \<longrightarrow> f c x = f c' x"
+
+definition identical_updates_rv where
+  "identical_updates_rv R s t s' t' \<equiv> (\<not>R s' t' \<longrightarrow> (R s s' \<and> R t t'))"
+
+abbreviation identical_updates_for_rv where
+  "identical_updates_for_rv P R s t s' t' \<equiv> \<forall>x. P x \<longrightarrow> identical_updates_rv R (s x) (t x) (s' x) (t' x)"
+
+abbreviation identical_updates_for where
+  "identical_updates_for P \<equiv> identical_updates_for_rv P (=)"
+
+abbreviation identical_updates where
+  "identical_updates \<equiv> identical_updates_for (\<lambda>_. True)"
+
+lemmas identical_updates_def = identical_updates_rv_def
+
+abbreviation identical_kheap_updates where
+  "identical_kheap_updates s s' kh kh' \<equiv> identical_updates (kheap s) (kheap s') kh kh'"
+
+lemmas identical_kheap_updates_def = identical_updates_def
+
+
+subsection \<open>Arch equivalence\<close>
+
+arch_requalify_consts
+  equiv_hyp
+  equiv_fpu
 
 
 subsection \<open>Machine state equivalence\<close>
@@ -172,14 +198,6 @@ subsection \<open>ASID equivalence\<close>
 
 definition equiv_asids :: "(asid \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
   "equiv_asids R s s' \<equiv> \<forall>asid. asid \<noteq> 0 \<and> R asid \<longrightarrow> equiv_asid asid s s'"
-
-definition identical_updates where
-  "identical_updates k k' kh kh' \<equiv> \<forall>x. (kh x \<noteq> kh' x \<longrightarrow> (k x = kh x \<and> k' x = kh' x))"
-
-abbreviation identical_kheap_updates where
-  "identical_kheap_updates s s' kh kh' \<equiv> identical_updates (kheap s) (kheap s') kh kh'"
-
-lemmas identical_kheap_updates_def = identical_updates_def
 
 
 subsection \<open>Generic state equivalence\<close>
@@ -207,7 +225,9 @@ definition states_equiv_for ::
      equiv_for Q interrupt_states s s' \<and>
      equiv_for Q interrupt_irq_node s s' \<and>
      equiv_for S  ready_queues s s' \<and>
-     equiv_asids R s s'"
+     equiv_asids R s s' \<and>
+     equiv_hyp P s s' \<and>
+     equiv_fpu P s s'"
 
 (* This the main use of states_equiv_for : P is use to restrict the labels we want to consider *)
 abbreviation states_equiv_for_labels ::
@@ -360,6 +380,9 @@ abbreviation aag_can_affect_asid where
 abbreviation aag_can_affect_domain where
   "aag_can_affect_domain aag l \<equiv> \<lambda>x. aag_can_affect_label aag l
                                    \<and> pasDomainAbs aag x \<inter> subjectReads (pasPolicy aag) l \<noteq> {}"
+
+abbreviation (input) aag_can_read_or_affect where
+  "aag_can_read_or_affect aag l \<equiv> \<lambda>x. aag_can_read aag x \<or> aag_can_affect aag l x"
 
 
 section \<open>reads_respects\<close>

--- a/proof/infoflow/InfoFlow_IF.thy
+++ b/proof/infoflow/InfoFlow_IF.thy
@@ -78,6 +78,8 @@ lemma states_equiv_forI:
      equiv_for Q interrupt_states s s';
      equiv_for Q interrupt_irq_node s s';
      equiv_asids R s s';
+     equiv_hyp P s s';
+     equiv_fpu P s s';
      equiv_for S ready_queues s s' \<rbrakk>
      \<Longrightarrow> states_equiv_for P Q R S s s'"
   by (auto simp: states_equiv_for_def)
@@ -85,19 +87,24 @@ lemma states_equiv_forI:
 definition for_each_byte_of_word :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> obj_ref \<Rightarrow> bool" where
   "for_each_byte_of_word P w \<equiv> \<forall>y\<in>{w..w + (word_size - 1)}. P y"
 
+
 locale InfoFlow_IF_1 =
-  fixes aag :: "'a PAS"
+  fixes identical_hyp_state_updates :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> machine_state \<Rightarrow> machine_state \<Rightarrow> bool"
+  and  identical_fpu_state_updates :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> machine_state \<Rightarrow> machine_state \<Rightarrow> bool"
+  \<comment> \<open>equiv_asids lemmas\<close>
   assumes equiv_asids_refl:
     "equiv_asids R s s"
   and equiv_asids_sym:
     "equiv_asids R s t \<Longrightarrow> equiv_asids R t s"
   and equiv_asids_trans:
     "\<lbrakk> equiv_asids R s t; equiv_asids R t u \<rbrakk> \<Longrightarrow> equiv_asids R s u"
+  and equiv_asids_guard_imp:
+    "\<lbrakk> equiv_asids R s s'; \<And>x. Q x \<Longrightarrow> R x \<rbrakk> \<Longrightarrow> equiv_asids Q s s'"
   and equiv_asids_identical_kheap_updates:
     "\<lbrakk> equiv_asids R s s'; identical_kheap_updates s s' kh kh' \<rbrakk>
        \<Longrightarrow> equiv_asids R (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
   and equiv_asids_False:
-  "(\<And>x. P x \<Longrightarrow> False) \<Longrightarrow> equiv_asids P x y"
+    "(\<And>x. R x \<Longrightarrow> False) \<Longrightarrow> equiv_asids R x y"
   and equiv_asids_triv:
     "\<lbrakk> equiv_asids R s s'; kheap t = kheap s; kheap t' = kheap s';
        arch_state t = arch_state s; arch_state t' = arch_state s' \<rbrakk>
@@ -105,59 +112,129 @@ locale InfoFlow_IF_1 =
   and equiv_asids_non_asid_pool_kheap_update:
   "\<lbrakk> equiv_asids R s s'; non_asid_pool_kheap_update s kh; non_asid_pool_kheap_update s' kh' \<rbrakk>
      \<Longrightarrow> equiv_asids R (s\<lparr>kheap := kh\<rparr>) (s'\<lparr>kheap := kh'\<rparr>)"
+  \<comment> \<open>equiv_hyp lemmas\<close>
+  and equiv_hyp_refl:
+    "equiv_hyp P s s"
+  and equiv_hyp_sym:
+    "equiv_hyp P s t \<Longrightarrow> equiv_hyp P t s"
+  and equiv_hyp_trans:
+    "\<lbrakk> equiv_hyp P s t; equiv_hyp P t u \<rbrakk> \<Longrightarrow> equiv_hyp P s u"
+  and equiv_hyp_guard_imp:
+    "\<lbrakk> equiv_hyp P s s'; \<And>x. P' x \<Longrightarrow> P x \<rbrakk> \<Longrightarrow> equiv_hyp P' s s'"
+  and equiv_hypI:
+     "\<lbrakk> \<And>x. P x \<Longrightarrow> equiv_hyp ((=) x) s t \<rbrakk>
+        \<Longrightarrow> equiv_hyp P s t"
+  and equiv_hyp_triv:
+    "\<lbrakk> equiv_hyp P s s'; arch_state t = arch_state s; arch_state t' = arch_state s';
+       machine_state t = machine_state s; machine_state t' = machine_state s' \<rbrakk>
+       \<Longrightarrow> equiv_hyp P t t'"
+  and equiv_hyp_machine_state_update:
+    "\<lbrakk> equiv_hyp P s s'; identical_hyp_state_updates P s s' ms ms' \<rbrakk>
+       \<Longrightarrow> equiv_hyp P (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>)"
+  \<comment> \<open>equiv_fpu lemmas\<close>
+  and equiv_fpu_refl:
+    "equiv_fpu P s s"
+  and equiv_fpu_sym:
+    "equiv_fpu P s t \<Longrightarrow> equiv_fpu P t s"
+  and equiv_fpu_trans:
+    "\<lbrakk> equiv_fpu P s t; equiv_fpu P t u \<rbrakk> \<Longrightarrow> equiv_fpu P s u"
+  and equiv_fpu_guard_imp:
+    "\<lbrakk> equiv_fpu P s s'; \<And>x. P' x \<Longrightarrow> P x \<rbrakk> \<Longrightarrow> equiv_fpu P' s s'"
+  and equiv_fpuI:
+    "\<lbrakk> \<And>x. P x \<Longrightarrow> equiv_fpu ((=) x) s t \<rbrakk>
+    \<Longrightarrow> equiv_fpu P s t"
+  and equiv_fpu_triv:
+    "\<lbrakk> equiv_fpu P s s'; arch_state t = arch_state s; arch_state t' = arch_state s';
+       machine_state t = machine_state s; machine_state t' = machine_state s' \<rbrakk>
+       \<Longrightarrow> equiv_fpu P t t'"
+  and equiv_fpu_machine_state_update:
+    "\<lbrakk> equiv_fpu P s s'; identical_fpu_state_updates P s s' ms ms' \<rbrakk>
+       \<Longrightarrow> equiv_fpu P (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>)"
+  \<comment> \<open>globals_equiv lemmas\<close>
   and globals_equiv_refl:
     "globals_equiv s s"
   and globals_equiv_sym:
     "globals_equiv s t \<Longrightarrow> globals_equiv t s"
   and globals_equiv_trans:
     "\<lbrakk> globals_equiv s t; globals_equiv t u \<rbrakk> \<Longrightarrow> globals_equiv s u"
-  and equiv_asids_guard_imp:
-    "\<lbrakk> equiv_asids R s s'; \<And>x. Q x \<Longrightarrow> R x \<rbrakk> \<Longrightarrow> equiv_asids Q s s'"
-  and dmo_loadWord_rev:
-    "reads_equiv_valid_inv A aag (K (for_each_byte_of_word (aag_can_read aag) p))
-                                 (do_machine_op (loadWord p))"
 begin
 
+lemma equiv_hyp_False:
+  "(\<And>x. P x \<Longrightarrow> False) \<Longrightarrow> equiv_hyp P x y"
+  by (fastforce intro: equiv_hypI)
+
+lemma equiv_fpu_False:
+  "(\<And>x. P x \<Longrightarrow> False) \<Longrightarrow> equiv_fpu P x y"
+  by (fastforce intro: equiv_fpuI)
+
+lemma equiv_hyp_updates[simp]:
+  "\<And>f. equiv_hyp P st (kheap_update f s) = equiv_hyp P st s"
+  "\<And>f. equiv_hyp P (kheap_update f st) s = equiv_hyp P st s"
+  "\<And>f. equiv_hyp P st (ready_queues_update f s) = equiv_hyp P st s"
+  "\<And>f. equiv_hyp P (ready_queues_update f st) s = equiv_hyp P st s"
+  "\<And>f. equiv_hyp P st (cur_thread_update f s) = equiv_hyp P st s"
+  "\<And>f. equiv_hyp P (cur_thread_update f st) s = equiv_hyp P st s"
+  "\<And>f. equiv_hyp P st (scheduler_action_update f s) = equiv_hyp P st s"
+  "\<And>f. equiv_hyp P (scheduler_action_update f st) s = equiv_hyp P st s"
+  "\<And>f. equiv_hyp P st (domain_time_update f s) = equiv_hyp P st s"
+  "\<And>f. equiv_hyp P (domain_time_update f st) s = equiv_hyp P st s"
+  by (auto elim: equiv_hyp_triv)
+
+lemma equiv_fpu_updates[simp]:
+  "\<And>f. equiv_fpu P st (kheap_update f s) = equiv_fpu P st s"
+  "\<And>f. equiv_fpu P (kheap_update f st) s = equiv_fpu P st s"
+  "\<And>f. equiv_fpu P st (ready_queues_update f s) = equiv_fpu P st s"
+  "\<And>f. equiv_fpu P (ready_queues_update f st) s = equiv_fpu P st s"
+  "\<And>f. equiv_fpu P st (cur_thread_update f s) = equiv_fpu P st s"
+  "\<And>f. equiv_fpu P (cur_thread_update f st) s = equiv_fpu P st s"
+  "\<And>f. equiv_fpu P st (scheduler_action_update f s) = equiv_fpu P st s"
+  "\<And>f. equiv_fpu P (scheduler_action_update f st) s = equiv_fpu P st s"
+  "\<And>f. equiv_fpu P st (domain_time_update f s) = equiv_fpu P st s"
+  "\<And>f. equiv_fpu P (domain_time_update f st) s = equiv_fpu P st s"
+  by (auto elim: equiv_fpu_triv)
+
 lemma states_equiv_for_machine_state_update:
-  "\<lbrakk> states_equiv_for P Q R S s s'; equiv_machine_state P kh kh' \<rbrakk>
-     \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>machine_state := kh\<rparr>) (s'\<lparr>machine_state := kh'\<rparr>)"
-  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
-               intro: equiv_forI simp: states_equiv_for_def)
+  "\<lbrakk> states_equiv_for P Q R S s s'; equiv_machine_state P ms ms';
+     identical_hyp_state_updates P s s' ms ms'; identical_fpu_state_updates P s s' ms ms' \<rbrakk>
+     \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>)"
+  by (fastforce elim: equiv_forE
+               elim!: equiv_asids_triv equiv_hyp_machine_state_update equiv_fpu_machine_state_update
+               intro: equiv_forI simp: states_equiv_for_def)+
 
 lemma states_equiv_for_cdt_update:
   "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for (P \<circ> fst) id kh kh' \<rbrakk>
      \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>cdt := kh\<rparr>) (s'\<lparr>cdt := kh'\<rparr>)"
-  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv equiv_hyp_triv equiv_fpu_triv
                intro: equiv_forI simp: states_equiv_for_def)
 
 lemma states_equiv_for_cdt_list_update:
   "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for (P \<circ> fst) id (kh (cdt_list s)) (kh' (cdt_list s')) \<rbrakk>
      \<Longrightarrow> states_equiv_for P Q R S (cdt_list_update kh s) (cdt_list_update kh' s')"
-  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv equiv_hyp_triv equiv_fpu_triv
                intro: equiv_forI simp: states_equiv_for_def)
 
 lemma states_equiv_for_is_original_cap_update:
   "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for (P \<circ> fst) id kh kh' \<rbrakk>
      \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>is_original_cap := kh\<rparr>) (s'\<lparr>is_original_cap := kh'\<rparr>)"
-  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv equiv_hyp_triv equiv_fpu_triv
                intro: equiv_forI simp: states_equiv_for_def)
 
 lemma states_equiv_for_interrupt_states_update:
   "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for Q id kh kh' \<rbrakk>
     \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>interrupt_states := kh\<rparr>) (s'\<lparr>interrupt_states := kh'\<rparr>)"
-  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv equiv_hyp_triv equiv_fpu_triv
                intro: equiv_forI simp: states_equiv_for_def)
 
 lemma states_equiv_for_interrupt_irq_node_update:
   "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for Q id kh kh' \<rbrakk>
      \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>interrupt_irq_node := kh\<rparr>) (s'\<lparr>interrupt_irq_node := kh'\<rparr>)"
-  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv equiv_hyp_triv equiv_fpu_triv
                intro: equiv_forI simp: states_equiv_for_def)
 
 lemma states_equiv_for_ready_queues_update:
   "\<lbrakk> states_equiv_for P Q R S s s'; equiv_for S id kh kh' \<rbrakk>
      \<Longrightarrow> states_equiv_for P Q R S (s\<lparr>ready_queues := kh\<rparr>) (s'\<lparr>ready_queues := kh'\<rparr>)"
-  by (fastforce elim: equiv_forE elim!: equiv_asids_triv
+  by (fastforce elim: equiv_forE elim!: equiv_asids_triv equiv_hyp_triv equiv_fpu_triv
                intro: equiv_forI simp: states_equiv_for_def)
 
 lemma states_equiv_for_identical_kheap_updates:
@@ -180,6 +257,8 @@ lemma states_equiv_forE:
           "equiv_for Q interrupt_states s s'"
           "equiv_for Q interrupt_irq_node s s'"
           "equiv_asids R s s'"
+          "equiv_hyp P s s'"
+          "equiv_fpu P s s'"
           "equiv_for S ready_queues s s'"
   using sef[simplified states_equiv_for_def] by auto
 
@@ -249,17 +328,17 @@ context InfoFlow_IF_1 begin
 
 lemma states_equiv_for_refl:
   "states_equiv_for P Q R S s s"
-  by (auto simp: states_equiv_for_def  intro: equiv_for_refl equiv_asids_refl)
+  by (auto simp: states_equiv_for_def  intro: equiv_for_refl equiv_asids_refl equiv_hyp_refl equiv_fpu_refl)
 
 lemma states_equiv_for_sym:
   "states_equiv_for P Q R S s t \<Longrightarrow> states_equiv_for P Q R S t s"
-  by (auto simp: states_equiv_for_def intro: equiv_for_sym equiv_asids_sym simp: equiv_for_def)
+  by (auto simp: states_equiv_for_def intro: equiv_for_sym equiv_asids_sym simp: equiv_for_def equiv_hyp_sym equiv_fpu_sym)
 
 lemma states_equiv_for_trans:
   "\<lbrakk> states_equiv_for P Q R S s t; states_equiv_for P Q R S t u \<rbrakk>
      \<Longrightarrow> states_equiv_for P Q R S s u"
   by (auto simp: states_equiv_for_def
-          intro: equiv_for_trans equiv_asids_trans equiv_forI
+          intro: equiv_for_trans equiv_asids_trans equiv_hyp_trans equiv_fpu_trans equiv_forI
            elim: equiv_forE)
 
 end
@@ -288,6 +367,19 @@ lemma equiv_asids_aag_can_read_asid:
    (\<forall>d \<in> subjectReads (pasPolicy aag) (pasSubject aag). equiv_asids (\<lambda>x. d = pasASIDAbs aag x) s s')"
   by (auto simp: equiv_asids_def)
 
+
+context InfoFlow_IF_1 begin
+
+lemma equiv_hyp_aag_can_read:
+  "equiv_hyp (aag_can_read aag) s s' =
+   (\<forall>d \<in> subjectReads (pasPolicy aag) (pasSubject aag). equiv_hyp (\<lambda>x. d = pasObjectAbs aag x) s s')"
+  by (fastforce intro: equiv_hypI elim: equiv_hyp_guard_imp)
+
+lemma equiv_fpu_aag_can_read:
+  "equiv_fpu (aag_can_read aag) s s' =
+   (\<forall>d \<in> subjectReads (pasPolicy aag) (pasSubject aag). equiv_fpu (\<lambda>x. d = pasObjectAbs aag x) s s')"
+  by (fastforce intro: equiv_fpuI elim: equiv_fpu_guard_imp)
+
 lemma reads_equiv_def2:
   "reads_equiv aag s s' = (states_equiv_for (aag_can_read aag) (aag_can_read_irq aag)
                                             (aag_can_read_asid aag) (aag_can_read_domain aag) s s' \<and>
@@ -296,7 +388,8 @@ lemma reads_equiv_def2:
                            scheduler_action s = scheduler_action s' \<and>
                            work_units_completed s = work_units_completed s' \<and>
                            irq_state (machine_state s) = irq_state (machine_state s'))"
-  by (auto simp: reads_equiv_def equiv_for_def states_equiv_for_def equiv_asids_aag_can_read_asid)
+  by (auto simp: reads_equiv_def equiv_for_def states_equiv_for_def
+                 equiv_hyp_aag_can_read equiv_fpu_aag_can_read equiv_asids_aag_can_read_asid)
 
 lemma reads_equivE:
   assumes sef: "reads_equiv aag s s'"
@@ -308,6 +401,8 @@ lemma reads_equivE:
           "equiv_for (aag_can_read_irq aag) interrupt_states s s'"
           "equiv_for (aag_can_read_irq aag) interrupt_irq_node s s'"
           "equiv_asids (aag_can_read_asid aag) s s'"
+          "equiv_hyp (aag_can_read aag) s s'"
+          "equiv_fpu (aag_can_read aag) s s'"
           "equiv_for (aag_can_read_domain aag) ready_queues s s'"
           "cur_thread s = cur_thread s'"
           "cur_domain s = cur_domain s'"
@@ -315,9 +410,6 @@ lemma reads_equivE:
           "work_units_completed s = work_units_completed s'"
           "irq_state (machine_state s) = irq_state (machine_state s')"
   using sef by (auto simp: reads_equiv_def2 elim: states_equiv_forE)
-
-
-context InfoFlow_IF_1 begin
 
 lemma globals_equiv_updates[simp]:
   "\<And>f. globals_equiv st (trans_state f s) = globals_equiv st s"
@@ -329,8 +421,11 @@ lemma globals_equiv_updates[simp]:
   by (simp add: globals_equiv_def idle_equiv_def)+
 
 lemma reads_equiv_machine_state_update:
-  "\<lbrakk> reads_equiv aag s s'; equiv_machine_state (aag_can_read aag) kh kh'; irq_state kh = irq_state kh' \<rbrakk>
-     \<Longrightarrow> reads_equiv aag (s\<lparr>machine_state := kh\<rparr>) (s'\<lparr>machine_state := kh'\<rparr>)"
+  "\<lbrakk> reads_equiv aag s s'; equiv_machine_state (aag_can_read aag) ms ms';
+     irq_state ms = irq_state ms';
+     identical_hyp_state_updates (aag_can_read aag) s s' ms ms';
+     identical_fpu_state_updates (aag_can_read aag) s s' ms ms' \<rbrakk>
+     \<Longrightarrow> reads_equiv aag (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>)"
   by (fastforce simp: reads_equiv_def2 intro: states_equiv_for_machine_state_update)
 
 lemma states_equiv_for_non_asid_pool_kheap_update:
@@ -384,18 +479,21 @@ lemma reads_equiv_ready_queues_update:
 lemma reads_equiv_scheduler_action_update:
   "reads_equiv aag s s' \<Longrightarrow>
    reads_equiv aag (s\<lparr>scheduler_action := kh\<rparr>) (s'\<lparr>scheduler_action := kh\<rparr>)"
-  by (fastforce simp: reads_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
+  by (fastforce simp: reads_equiv_def2 states_equiv_for_def equiv_for_def
+               elim!: equiv_asids_triv equiv_hyp_triv equiv_fpu_triv)
 
 lemma reads_equiv_work_units_completed_update:
   "reads_equiv aag s s' \<Longrightarrow>
    reads_equiv aag (s\<lparr>work_units_completed := kh\<rparr>) (s'\<lparr>work_units_completed := kh\<rparr>)"
-  by (fastforce simp: reads_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
+  by (fastforce simp: reads_equiv_def2 states_equiv_for_def equiv_for_def
+               elim!: equiv_asids_triv equiv_hyp_triv equiv_fpu_triv)
 
 lemma reads_equiv_work_units_completed_update':
   "reads_equiv aag s s' \<Longrightarrow>
    reads_equiv aag (s\<lparr>work_units_completed := (f (work_units_completed s))\<rparr>)
                    (s'\<lparr>work_units_completed := (f (work_units_completed s'))\<rparr>)"
-  by (fastforce simp: reads_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
+  by (fastforce simp: reads_equiv_def2 states_equiv_for_def equiv_for_def
+               elim!: equiv_asids_triv equiv_hyp_triv equiv_fpu_triv)
 
 lemma affects_equiv_def2:
   "affects_equiv aag l s s' = states_equiv_for (aag_can_affect aag l)
@@ -405,7 +503,7 @@ lemma affects_equiv_def2:
   by (auto simp: affects_equiv_def
            dest: equiv_forD
           elim!: states_equiv_forE
-         intro!: states_equiv_forI equiv_forI equiv_asids_False)
+         intro!: states_equiv_forI equiv_forI equiv_asids_False equiv_hyp_False equiv_fpu_False)
 
 lemma affects_equivE:
   assumes sef: "affects_equiv aag l s s'"
@@ -417,13 +515,17 @@ lemma affects_equivE:
           "equiv_for (aag_can_affect_irq aag l) interrupt_states s s'"
           "equiv_for (aag_can_affect_irq aag l) interrupt_irq_node s s'"
           "equiv_asids (aag_can_affect_asid aag l) s s'"
+          "equiv_hyp (aag_can_affect aag l) s s'"
+          "equiv_fpu (aag_can_affect aag l) s s'"
           "equiv_for (aag_can_affect_domain aag l) ready_queues s s'"
   using sef by (auto simp: affects_equiv_def2 elim: states_equiv_forE)
 
 lemma affects_equiv_machine_state_update:
-  "\<lbrakk> affects_equiv aag l s s'; equiv_machine_state (aag_can_affect aag l) kh kh' \<rbrakk>
-     \<Longrightarrow> affects_equiv aag l (s\<lparr>machine_state := kh\<rparr>) (s'\<lparr>machine_state := kh'\<rparr>)"
-  by (fastforce simp: affects_equiv_def2 intro: states_equiv_for_machine_state_update)
+  "\<lbrakk> affects_equiv aag l s s'; equiv_machine_state (aag_can_affect aag l) ms ms';
+     identical_hyp_state_updates (aag_can_affect aag l) s s' ms ms';
+     identical_fpu_state_updates (aag_can_affect aag l) s s' ms ms' \<rbrakk>
+     \<Longrightarrow> affects_equiv aag l (s\<lparr>machine_state := ms\<rparr>) (s'\<lparr>machine_state := ms'\<rparr>)"
+  by (auto simp: affects_equiv_def2 intro: states_equiv_for_machine_state_update)
 
 lemma affects_equiv_non_asid_pool_kheap_update:
   "\<lbrakk> affects_equiv aag l s s'; equiv_for (aag_can_affect aag l) id kh kh';
@@ -470,18 +572,21 @@ lemma affects_equiv_ready_queues_update:
 lemma affects_equiv_scheduler_action_update:
   "affects_equiv aag l s s' \<Longrightarrow>
    affects_equiv aag l (s\<lparr>scheduler_action := kh\<rparr>) (s'\<lparr>scheduler_action := kh\<rparr>)"
-  by (fastforce simp: affects_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
+  by (fastforce simp: affects_equiv_def2 states_equiv_for_def equiv_for_def
+               elim!: equiv_asids_triv equiv_hyp_triv equiv_fpu_triv)
 
 lemma affects_equiv_work_units_completed_update:
   "affects_equiv aag l s s' \<Longrightarrow>
    affects_equiv aag l (s\<lparr>work_units_completed := kh\<rparr>) (s'\<lparr>work_units_completed := kh\<rparr>)"
-  by (fastforce simp: affects_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
+  by (fastforce simp: affects_equiv_def2 states_equiv_for_def equiv_for_def
+               elim!: equiv_asids_triv equiv_hyp_triv equiv_fpu_triv)
 
 lemma affects_equiv_work_units_completed_update':
   "affects_equiv aag l s s' \<Longrightarrow>
    affects_equiv aag l (s\<lparr>work_units_completed := (f (work_units_completed s))\<rparr>)
                        (s'\<lparr>work_units_completed := (f (work_units_completed s'))\<rparr>)"
-  by (fastforce simp: affects_equiv_def2 states_equiv_for_def equiv_for_def elim!: equiv_asids_triv)
+  by (fastforce simp: affects_equiv_def2 states_equiv_for_def equiv_for_def
+               elim!: equiv_asids_triv equiv_hyp_triv equiv_fpu_triv)
 
 (* reads_equiv and affects_equiv want to be equivalence relations *)
 lemma reads_equiv_refl:
@@ -601,11 +706,13 @@ lemma states_equiv_for_guard_imp:
   and "\<And>x. R' x \<Longrightarrow> R x"
   and "\<And>x. S' x \<Longrightarrow> S x"
   shows "states_equiv_for P' Q' R' S' s s'"
-  using assms by (auto simp: states_equiv_for_def intro: equiv_for_guard_imp equiv_asids_guard_imp)
+  using assms
+  by (auto simp: states_equiv_for_def
+          intro: equiv_for_guard_imp equiv_asids_guard_imp equiv_hyp_guard_imp equiv_fpu_guard_imp)
 
 lemma set_object_reads_respects:
   "reads_respects aag l \<top> (set_object ptr obj)"
-  apply(clarsimp simp: equiv_valid_def2 equiv_valid_2_def set_object_def get_object_def
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def set_object_def get_object_def
                        bind_def' get_def gets_def put_def return_def fail_def assert_def)
   apply (rule conjI)
    apply (erule reads_equiv_identical_kheap_updates)
@@ -613,9 +720,6 @@ lemma set_object_reads_respects:
   apply (erule affects_equiv_identical_kheap_updates)
   apply (clarsimp simp: identical_kheap_updates_def)
   done
-
-end
-
 
 lemma cur_subject_reads_equiv_affects_equiv:
   "\<lbrakk> pasSubject aag = l; reads_equiv aag s s' \<rbrakk> \<Longrightarrow> affects_equiv aag l s s'"
@@ -630,6 +734,12 @@ lemma reads_equiv_self_reads_respects:
 
 lemma requiv_get_tcb_eq[intro]:
   "\<lbrakk> reads_equiv aag s t; is_subject aag thread \<rbrakk>
+     \<Longrightarrow> get_tcb thread s = get_tcb thread t"
+  by (auto simp: reads_equiv_def2 get_tcb_def elim: states_equiv_forE_kheap)
+
+(* FIXME AARCH64 IF: delete if unused *)
+lemma requiv_get_tcb_eq'[intro]:
+  "\<lbrakk> reads_equiv aag s t; aag_can_read aag thread \<rbrakk>
      \<Longrightarrow> get_tcb thread s = get_tcb thread t"
   by (auto simp: reads_equiv_def2 get_tcb_def elim: states_equiv_forE_kheap)
 
@@ -722,9 +832,6 @@ lemma as_user_rev:
    apply simp_all
   done
 
-
-context InfoFlow_IF_1 begin
-
 lemma gets_kheap_revrv:
   "reads_equiv_valid_rv_inv (affects_equiv aag l) aag
                             (equiv_for (aag_can_read aag or aag_can_affect aag l) id) \<top> (gets kheap)"
@@ -789,20 +896,31 @@ lemma gets_ready_queues_revrv:
   apply (clarsimp simp: equiv_for_def disjoint_iff_not_equal elim!: reads_equivE affects_equivE)
   done
 
+lemma reads_affects_equiv_kheap_eq:
+  "\<lbrakk> reads_equiv aag s s'; affects_equiv aag l s s'; aag_can_affect aag l x \<or> aag_can_read aag x \<rbrakk>
+     \<Longrightarrow> kheap s x = kheap s' x"
+  by (fastforce elim: affects_equivE reads_equivE equiv_forE)
+
+lemma reads_affects_equiv_get_tcb_eq:
+  "\<lbrakk> aag_can_read aag t \<or> aag_can_affect aag l t; reads_equiv aag s s'; affects_equiv aag l s s' \<rbrakk>
+     \<Longrightarrow> get_tcb t s = get_tcb t s'"
+  by (fastforce simp: get_tcb_def reads_affects_equiv_kheap_eq)
+
 lemma as_user_reads_respects:
-  "reads_respects aag l (K (det f \<and> is_subject aag thread)) (as_user thread f)"
+  "reads_respects aag l (K (det f \<and> aag_can_read_or_affect aag l thread)) (as_user thread f)"
   apply (simp add: as_user_def split_def)
   apply (rule gen_asm_ev)
-  apply (wp set_object_reads_respects select_f_ev gets_the_ev)
-  apply fastforce
+  apply (wpsimp wp: set_object_reads_respects select_f_ev gets_the_ev)
+  apply (drule (2) reads_affects_equiv_get_tcb_eq)
+  apply auto
   done
-
-end
-
 
 lemma get_message_info_rev:
   "reads_equiv_valid_inv A aag (K (is_subject aag ptr)) (get_message_info ptr)"
   by (wpsimp wp: as_user_rev getRegister_inv simp: get_message_info_def det_getRegister)
+
+end
+
 
 lemma syscall_rev:
   assumes reads_res_m_fault:
@@ -853,56 +971,9 @@ lemma syscall_reads_respects_g:
 
 context InfoFlow_IF_1 begin
 
-lemma do_machine_op_spec_reads_respects':
-  assumes equiv_dmo:
-   "equiv_valid_inv (equiv_machine_state (aag_can_read aag) and equiv_irq_state)
-                    (equiv_machine_state (aag_can_affect aag l)) Q f"
-  assumes guard:
-    "\<And>s. P s \<Longrightarrow> Q (machine_state s)"
-  shows
-  "spec_reads_respects st aag l P (do_machine_op f)"
-  unfolding do_machine_op_def spec_equiv_valid_def
-  apply (rule equiv_valid_2_guard_imp)
-   apply (rule_tac  R'="\<lambda> rv rv'. equiv_machine_state (aag_can_read aag or aag_can_affect aag l) rv rv' \<and> equiv_irq_state rv rv'" and Q="\<lambda> r s. st = s \<and> Q r" and Q'="\<lambda> r s. Q r" and P="(=) st" and P'="\<top>" in equiv_valid_2_bind)
-       apply (rule gen_asm_ev2_l[simplified K_def pred_conj_def])
-       apply (rule gen_asm_ev2_r')
-       apply (rule_tac R'="\<lambda> (r, ms') (r', ms'').  r = r' \<and> equiv_machine_state (aag_can_read aag)  ms' ms'' \<and> equiv_machine_state (aag_can_affect aag l) ms' ms'' \<and> equiv_irq_state ms' ms''" and Q="\<lambda> r s. st = s" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
-            apply (clarsimp simp: modify_def get_def put_def bind_def return_def equiv_valid_2_def)
-            apply (fastforce intro: reads_equiv_machine_state_update affects_equiv_machine_state_update)
-            apply (insert equiv_dmo)[1]
-           apply (clarsimp simp: select_f_def equiv_valid_2_def equiv_valid_def2 equiv_for_or simp: split_def split: prod.splits simp: equiv_for_def)[1]
-           apply (drule_tac x=rv in spec, drule_tac x=rv' in spec)
-           apply (fastforce)
-          apply (rule select_f_inv)
-         apply (rule wp_post_taut)
-        apply simp+
-      apply (clarsimp simp: equiv_valid_2_def in_monad)
-      apply (fastforce elim: reads_equivE affects_equivE equiv_forE intro: equiv_forI)
-     apply (wp | simp add: guard)+
-  done
-
-(* most of the time (i.e. always except for getActiveIRQ) you'll want this rule *)
-lemma do_machine_op_spec_reads_respects:
-  assumes equiv_dmo:
-   "equiv_valid_inv (equiv_machine_state (aag_can_read aag)) (equiv_machine_state (aag_can_affect aag l)) \<top> f"
-  assumes irq_state_inv:
-    "\<And>P. \<lbrace>\<lambda>ms. P (irq_state ms)\<rbrace> f \<lbrace>\<lambda>_ ms. P (irq_state ms)\<rbrace>"
-  shows
-    "spec_reads_respects st aag l \<top> (do_machine_op f)"
-  apply (rule do_machine_op_spec_reads_respects'[where Q=\<top>, simplified])
-  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
-  apply (subgoal_tac "equiv_irq_state b ba", simp)
-   apply (insert equiv_dmo, fastforce simp: equiv_valid_def2 equiv_valid_2_def)
-  apply (insert irq_state_inv)
-  apply (drule_tac x="\<lambda>ms. ms = irq_state s" in meta_spec)
-  apply (clarsimp simp: valid_def)
-  apply (frule_tac x=s in spec)
-  apply (erule (1) impE)
-  apply (drule bspec, assumption, simp)
-  apply (drule_tac x=t in spec, simp)
-  apply (drule bspec, assumption)
-  apply simp
-  done
+lemma equiv_for_disj:
+  "equiv_for (\<lambda>x. P x \<or> Q x) f c c' = (equiv_for P f c c' \<and> equiv_for Q f c c')"
+  by (auto simp: equiv_for_def)
 
 lemma do_machine_op_rev:
   assumes equiv_dmo: "equiv_valid_inv (equiv_machine_state (aag_can_read aag)) \<top>\<top> \<top> f"
@@ -924,9 +995,6 @@ lemma do_machine_op_rev:
     apply (fastforce simp: select_f_def dest: state_unchanged[OF mo_inv])+
   apply wpsimp
   done
-
-end
-
 
 lemma do_machine_op_spec_rev:
   assumes equiv_dmo:
@@ -969,6 +1037,18 @@ lemma do_machine_op_spec_rev:
      apply (wp | simp)+
   done
 
+lemma modifies_at_mostI:
+  assumes hoare: "\<And>st. \<lbrace>P and equiv_but_for_labels aag L st\<rbrace> f \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
+  shows "modifies_at_most aag L P f"
+  apply (clarsimp simp: modifies_at_most_def)
+  apply (erule use_valid)
+   apply (rule hoare)
+  apply (fastforce simp: equiv_but_for_labels_def states_equiv_for_refl)
+  done
+
+end
+
+
 lemma spec_equiv_valid_hoist_guard:
   "((P st) \<Longrightarrow> spec_equiv_valid_inv st I A \<top> f) \<Longrightarrow> spec_equiv_valid_inv st I A P f"
   by (clarsimp simp: spec_equiv_valid_def equiv_valid_2_def)
@@ -989,7 +1069,19 @@ lemma invs_kernel_mappings:
   by (auto simp: invs_def valid_state_def)
 
 
-context InfoFlow_IF_1 begin
+locale InfoFlow_IF_2 = InfoFlow_IF_1 +
+  fixes no_hyp :: "'m machine_monad \<Rightarrow> bool"
+  and no_fpu :: "'m machine_monad \<Rightarrow> bool"
+  and aag :: "'a PAS"
+  assumes dmo_loadWord_rev:
+    "reads_equiv_valid_inv A aag (K (for_each_byte_of_word (aag_can_read aag) p))
+                                 (do_machine_op (loadWord p))"
+  and do_machine_op_reads_respects':
+    "\<lbrakk> equiv_valid_inv (equiv_machine_state (aag_can_read aag) and equiv_irq_state)
+                       (equiv_machine_state (aag_can_affect aag l)) Q f;
+       \<And>s. P s \<Longrightarrow> Q (machine_state s); no_hyp f; no_fpu f\<rbrakk>
+       \<Longrightarrow> reads_respects aag l P (do_machine_op f)"
+begin
 
 lemma load_word_offs_rev:
   "for_each_byte_of_word (aag_can_read aag) (a + of_nat x * of_nat word_size)
@@ -997,15 +1089,94 @@ lemma load_word_offs_rev:
   unfolding load_word_offs_def fun_app_def
   by (fastforce intro: equiv_valid_guard_imp[OF dmo_loadWord_rev])
 
-lemma modifies_at_mostI:
-  assumes hoare: "\<And>st. \<lbrace>P and equiv_but_for_labels aag L st\<rbrace> f \<lbrace>\<lambda>_. equiv_but_for_labels aag L st\<rbrace>"
-  shows "modifies_at_most aag L P f"
-  apply (clarsimp simp: modifies_at_most_def)
-  apply (erule use_valid)
-   apply (rule hoare)
-  apply (fastforce simp: equiv_but_for_labels_def states_equiv_for_refl)
+(* most of the time (i.e. always except for getActiveIRQ) you'll want this rule *)
+lemma do_machine_op_reads_respects:
+  assumes equiv_dmo:
+   "equiv_valid_inv (equiv_machine_state (aag_can_read aag))
+                    (equiv_machine_state (aag_can_affect aag l)) \<top> f"
+  assumes irq_state_inv: "\<And>P. \<lbrace>\<lambda>ms. P (irq_state ms)\<rbrace> f \<lbrace>\<lambda>_ ms. P (irq_state ms)\<rbrace>"
+  assumes no_hyp: "no_hyp f"
+  assumes no_fpu: "no_fpu f"
+  shows "reads_respects aag l \<top> (do_machine_op f)"
+  apply (rule do_machine_op_reads_respects'[where Q=\<top>, simplified, OF _ no_hyp no_fpu])
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (subgoal_tac "equiv_irq_state b ba", simp)
+   apply (insert equiv_dmo, fastforce simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (insert irq_state_inv)
+  apply (drule_tac x="\<lambda>ms. ms = irq_state s" in meta_spec)
+  apply (clarsimp simp: valid_def)
+  apply (frule_tac x=s in spec)
+  apply (erule (1) impE)
+  apply (drule bspec, assumption, simp)
+  apply (drule_tac x=t in spec, simp)
+  apply (drule bspec, assumption)
+  apply simp
   done
 
 end
+
+lemma tcb_domain_wellformed:
+  "\<lbrakk> pas_refined aag s; etcbs_of s t = Some a \<rbrakk>
+     \<Longrightarrow> pasObjectAbs aag t \<in> pasDomainAbs aag (etcb_domain a)"
+  apply (clarsimp simp add: pas_refined_def tcb_domain_map_wellformed_aux_def)
+  apply (drule_tac x="(t,etcb_domain a)" in bspec)
+  apply (rule domtcbs)
+  apply force+
+  done
+
+(* FIXME AARCH64 IF: rename (assumes A is responsible for equal rvs) *)
+lemma equiv_valid_inv_split:
+  assumes "equiv_valid_rv_inv I \<top>\<top> \<top>\<top> P f"
+  and "equiv_valid_inv \<top>\<top> A P f"
+  shows "equiv_valid_inv I A P f"
+  using assms
+  by (fastforce simp: equiv_valid_2_def equiv_valid_def2)
+
+lemma equiv_valid_rv_inv_lift:
+  assumes inv: "\<And>st. \<lbrace>P and I st and A st\<rbrace> f \<lbrace>\<lambda>_. I st and A st\<rbrace>"
+  assumes symI: "\<And>st s. I st s = I s st"
+  assumes symA: "\<And>st s. A st s = A s st"
+  shows "equiv_valid_rv_inv I A \<top>\<top> P f"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (subst symI)
+  apply (subst symA)
+  apply (erule use_valid)
+   apply (wp inv[simplified pred_conj_def])
+  apply (subst symI)
+  apply (subst symA)
+  apply (erule use_valid)
+   apply (wp inv[simplified pred_conj_def])
+  apply simp
+  done
+
+lemma equiv_valid_inv_lift:
+  assumes inv: "\<And>st. \<lbrace>P and I st and A st\<rbrace> f \<lbrace>\<lambda>_. I st and A st\<rbrace>"
+  assumes symI: "\<And>st s. I st s = I s st"
+  assumes symA: "\<And>st s. A st s = A s st"
+  shows "equiv_valid_inv I A P (f :: ('s,unit) nondet_monad)"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (subst symI)
+  apply (subst symA)
+  apply (erule use_valid)
+   apply (wp inv[simplified pred_conj_def])
+  apply (subst symI)
+  apply (subst symA)
+  apply (erule use_valid)
+   apply (wp inv[simplified pred_conj_def])
+  apply simp
+  done
+
+lemma equiv_valid_conseq:
+  "\<lbrakk> equiv_valid I' A' B' P' f;
+     \<forall>s t. I s t \<and> A s t \<and> P s \<and> P t \<longrightarrow> I' s t \<and> A' s t \<and> P' s \<and> P' t;
+     \<forall>s t. I' s t \<and> B' s t \<longrightarrow> I s t \<and> B s t \<rbrakk>
+     \<Longrightarrow> equiv_valid I A B P f"
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (erule_tac x=s in allE)
+  apply (erule_tac x=t in allE, drule mp, fastforce)
+  apply fastforce
+  done
+
+declare equiv_valid_guard_imp[wp_pre]
 
 end

--- a/proof/infoflow/Interrupt_IF.thy
+++ b/proof/infoflow/Interrupt_IF.thy
@@ -21,7 +21,7 @@ locale Interrupt_IF_1 =
     "reads_respects aag l (K (arch_authorised_irq_ctl_inv aag irq_ctl_inv))
                     (arch_invoke_irq_control irq_ctl_inv)"
   and arch_invoke_irq_control_globals_equiv:
-    "\<lbrace>globals_equiv st and valid_arch_state and valid_global_objs\<rbrace>
+    "\<lbrace>globals_equiv st and valid_arch_state\<rbrace>
      arch_invoke_irq_control ai
      \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   and arch_invoke_irq_handler_globals_equiv[wp]:
@@ -74,20 +74,20 @@ lemma invoke_irq_control_reads_respects:
   done
 
 lemma invoke_irq_control_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_arch_state and valid_global_objs\<rbrace>
+  "\<lbrace>globals_equiv st and valid_arch_state\<rbrace>
    invoke_irq_control a
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (induct a)
-   apply (wpsimp wp: set_irq_state_globals_equiv cap_insert_globals_equiv''
+   apply (wpsimp wp: set_irq_state_globals_equiv cap_insert_globals_equiv
                      set_irq_state_valid_global_objs arch_invoke_irq_control_globals_equiv)+
   done
 
 lemma invoke_irq_handler_globals_equiv:
-  "\<lbrace>globals_equiv st and valid_arch_state and valid_global_objs\<rbrace>
+  "\<lbrace>globals_equiv st and valid_arch_state\<rbrace>
    invoke_irq_handler a
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (induct a)
-  by (wpsimp wp: modify_wp cap_insert_globals_equiv''
+  by (wpsimp wp: modify_wp cap_insert_globals_equiv
                  cap_delete_one_globals_equiv cap_delete_one_valid_global_objs)+
 
 subsection "reads_respects_g"

--- a/proof/infoflow/Ipc_IF.thy
+++ b/proof/infoflow/Ipc_IF.thy
@@ -19,11 +19,6 @@ definition ipc_buffer_has_read_auth :: "'a PAS \<Rightarrow> 'a \<Rightarrow> ob
        (\<lambda>buf'. is_aligned buf' msg_align_bits \<and>
                (\<forall>x \<in> ptr_range buf' msg_align_bits. (l,Read,pasObjectAbs aag x) \<in> (pasPolicy aag)))"
 
-abbreviation aag_can_read_or_affect where
-  "aag_can_read_or_affect aag l x \<equiv>
-    aag_can_read aag x \<or> aag_can_affect aag l x"
-
-
 lemma get_cap_reads_respects:
   "reads_respects aag l (K (aag_can_read aag (fst slot) \<or> aag_can_affect aag l (fst slot))) (get_cap slot)"
   apply (simp add: get_cap_def split_def)
@@ -64,14 +59,16 @@ lemma tcb_sched_action_equiv_but_for_labels:
   apply (simp add: tcb_sched_action_def, wp)
   apply (clarsimp simp: etcb_at_def equiv_but_for_labels_def split: option.splits)
   apply (rule states_equiv_forI)
-          apply (fastforce intro!: equiv_forI elim!: states_equiv_forE dest: equiv_forD[where f=kheap])
-         apply (simp add: states_equiv_for_def)
-        apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt])
-       apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt_list])
-      apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=is_original_cap])
-     apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_states])
-    apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_irq_node])
-   apply (fastforce simp: equiv_asids_def elim: states_equiv_forE)
+            apply (fastforce intro!: equiv_forI elim!: states_equiv_forE dest: equiv_forD[where f=kheap])
+           apply (simp add: states_equiv_for_def)
+          apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt])
+         apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt_list])
+        apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=is_original_cap])
+       apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_states])
+      apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_irq_node])
+     apply (fastforce simp: equiv_asids_def elim: states_equiv_forE)
+    apply (fastforce elim: states_equiv_forE)
+   apply (fastforce elim: states_equiv_forE)
   apply (clarsimp simp: pas_refined_def tcb_domain_map_wellformed_aux_def split: option.splits)
   apply (rule equiv_forI)
   apply (erule_tac x="(thread, etcb_domain (the (etcbs_of s thread)))" in ballE)
@@ -159,7 +156,7 @@ locale Ipc_IF_1 =
   and handle_arch_fault_reply_reads_respects:
     "reads_respects aag l (K (aag_can_read aag thread)) (handle_arch_fault_reply afault thread x y)"
   and arch_get_sanitise_register_info_reads_respects[wp]:
-    "reads_respects aag l \<top> (arch_get_sanitise_register_info t)"
+    "reads_respects aag l (K (aag_can_read_or_affect aag l t)) (arch_get_sanitise_register_info t)"
   and arch_get_sanitise_register_info_valid_global_objs[wp]:
     "arch_get_sanitise_register_info t \<lbrace>\<lambda>s :: det_state. valid_global_objs s\<rbrace>"
   and handle_arch_fault_reply_valid_global_objs[wp]:
@@ -1171,14 +1168,6 @@ lemma load_word_offs_reads_respects:
 end
 
 
-lemma as_user_reads_respects:
-  "reads_respects aag l (K (det f \<and> aag_can_read_or_affect aag l thread)) (as_user thread f)"
-  apply (simp add: as_user_def split_def)
-  apply (rule gen_asm_ev)
-  apply (wp set_object_reads_respects select_f_ev gets_the_ev)
-  apply (auto intro: reads_affects_equiv_get_tcb_eq[where aag=aag])
-  done
-
 lemma get_mi_length':
    "\<lbrace>\<top>\<rbrace> get_message_info sender \<lbrace>\<lambda>rv s. buffer_cptr_index + unat (mi_extra_caps rv)
                                          < 2 ^ (msg_align_bits - word_size_bits)\<rbrace>"
@@ -1666,7 +1655,7 @@ lemma setup_caller_cap_globals_equiv:
    setup_caller_cap sender receiver grant
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding setup_caller_cap_def
-  apply (wp cap_insert_globals_equiv'' set_thread_state_globals_equiv)
+  apply (wp cap_insert_globals_equiv set_thread_state_globals_equiv)
   apply (simp_all)
   done
 
@@ -1694,7 +1683,7 @@ next
       apply (wp set_extra_badge_globals_equiv)+
          apply (rule Cons.hyps)
         apply (simp)
-        apply (wp cap_insert_globals_equiv'')
+        apply (wp cap_insert_globals_equiv)
        apply (rule_tac Q'="\<lambda>_. globals_equiv st and valid_arch_state and valid_global_objs"
                    and E'="\<lambda>_. globals_equiv st and valid_arch_state and valid_global_objs"
                     in hoare_strengthen_postE)

--- a/proof/infoflow/Noninterference.thy
+++ b/proof/infoflow/Noninterference.thy
@@ -386,15 +386,6 @@ lemma kernel_entry_if_globals_equiv_scheduler:
   apply fastforce
   done
 
-lemma domain_fields_equiv_lift:
-  assumes a: "\<And>P. \<lbrace>domain_fields P and Q\<rbrace> f \<lbrace>\<lambda>_. domain_fields P\<rbrace>"
-  assumes b: "\<And>P. \<lbrace>(\<lambda>s. P (cur_domain s)) and R\<rbrace> f \<lbrace>\<lambda>_ s. P (cur_domain s)\<rbrace>"
-  shows "\<lbrace>domain_fields_equiv st and Q and R\<rbrace> f \<lbrace>\<lambda>_. domain_fields_equiv st\<rbrace>"
-  apply (clarsimp simp: valid_def domain_fields_equiv_def)
-  apply (erule use_valid, wp a b)
-  apply simp
-  done
-
 lemma check_active_irq_if_partitionIntegrity:
   "check_active_irq_if tc \<lbrace>partitionIntegrity aag st\<rbrace>"
   apply (simp add: check_active_irq_if_def)
@@ -570,7 +561,13 @@ lemmas integrity_subjects_device =
   integrity_subjects_def[THEN meta_eq_to_obj_eq, THEN iffD1, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct1]
 
 lemmas integrity_subjects_asids =
-  integrity_subjects_def[THEN meta_eq_to_obj_eq, THEN iffD1, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2]
+  integrity_subjects_def[THEN meta_eq_to_obj_eq, THEN iffD1, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct1]
+
+lemmas integrity_subjects_hyps =
+  integrity_subjects_def[THEN meta_eq_to_obj_eq, THEN iffD1, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct1]
+
+lemmas integrity_subjects_fpus =
+  integrity_subjects_def[THEN meta_eq_to_obj_eq, THEN iffD1, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2, THEN conjunct2]
 
 lemma pas_wellformed_pasSubject_update_Control:
   "\<lbrakk> pas_wellformed (aag\<lparr>pasSubject := pasObjectAbs aag p\<rparr>);
@@ -595,7 +592,6 @@ lemma pas_wellformed_noninterference_control_to_eq:
 lemma fun_noteqD:
   "f \<noteq> g \<Longrightarrow> \<exists>a. f a \<noteq> g a"
   by blast
-
 
 locale Noninterference_1 =
   fixes current_aag :: "det_state \<Rightarrow> 'a subject_label PAS"
@@ -634,10 +630,12 @@ locale Noninterference_1 =
   and integrity_fpu_update_reference_state:
    "is_subject aag t
     \<Longrightarrow> integrity_fpu aag {pasSubject aag} x s (s\<lparr>kheap := (kheap s)(t \<mapsto> blah)\<rparr>)"
+(*
   and partitionIntegrity_subjectAffects_aobj:
     "\<lbrakk> partitionIntegrity aag s s'; kheap s x = Some (ArchObj ao); kheap s x \<noteq> kheap s' x;
        silc_inv aag st s; pas_refined aag s; pas_wellformed_noninterference aag \<rbrakk>
        \<Longrightarrow> subject_can_affect_label_directly aag (pasObjectAbs aag x)"
+*)
   and partitionIntegrity_subjectAffects_asid:
     "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; valid_objs s; valid_arch_state s;
        valid_arch_state s'; pas_wellformed_noninterference aag; silc_inv aag st s'; invs s';
@@ -647,7 +645,7 @@ locale Noninterference_1 =
     "equiv_valid (reads_equiv_g aag) (affects_equiv aag l)
                  (\<lambda>s s'. affects_equiv aag l s s' \<and>
                          arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
-                 (\<lambda>s. is_subject aag t) (arch_switch_to_thread t)"
+                 (\<lambda>s. invs s \<and> is_subject aag t) (arch_switch_to_thread t)"
   and arch_globals_equiv_strengthener_thread_independent:
     "arch_globals_equiv_strengthener (machine_state s) (machine_state s')
      \<Longrightarrow> \<forall>ct ct' it it'. arch_globals_equiv ct it (kheap s) (kheap s')
@@ -668,7 +666,7 @@ locale Noninterference_1 =
                                  arch_globals_equiv_strengthener (machine_state s) (machine_state s'))
                          (W :: unit \<Rightarrow> unit \<Rightarrow> bool) (P and Q) (P' and Q') f g"
   and arch_switch_to_idle_thread_reads_respects_g[wp]:
-    "reads_respects_g aag l \<top> (arch_switch_to_idle_thread)"
+    "reads_respects_g aag l valid_arch_state (arch_switch_to_idle_thread)"
   and arch_globals_equiv_threads_eq:
     "arch_globals_equiv t' t'' kh kh' as as' ms ms'
      \<Longrightarrow> arch_globals_equiv t t kh kh' as as' ms ms'"
@@ -683,14 +681,48 @@ locale Noninterference_1 =
                              (do_machine_op (getActiveIRQ in_kernel))"
   and handle_spurious_irq_reads_respects_scheduler[wp]:
     "reads_respects_scheduler aag l \<top> handle_spurious_irq"
-  (* FIXME IF: precludes ARM_HYP *)
-  and getActiveIRQ_no_non_kernel_IRQs:
-    "getActiveIRQ True = getActiveIRQ False"
-  and valid_cur_hyp_triv:
-    "valid_cur_hyp s"
-  and arch_tcb_get_registers_equality:
-    "arch_tcb_get_registers (tcb_arch tcb) = arch_tcb_get_registers (tcb_arch tcb')
-     \<Longrightarrow> tcb_arch (tcb :: tcb) = tcb_arch (tcb' :: tcb)"
+  and getActiveIRQ_ev2:
+    "equiv_valid_2 (scheduler_equiv aag)
+                   (scheduler_affects_equiv aag l) (scheduler_affects_equiv aag l)
+                   (\<lambda>irq irq'. irq = irq' \<or> irq = None \<and> irq' \<in> Some ` non_kernel_IRQs)
+                   (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+                   (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+     (do_machine_op (getActiveIRQ True)) (do_machine_op (getActiveIRQ False))"
+  and arch_prepare_next_domain_reads_respects_g:
+    "reads_equiv_valid_g_inv (affects_equiv aag l) aag invs
+     arch_prepare_next_domain"
+  and partitionIntegrity_subjectAffects_aobj:
+    "\<lbrakk>partitionIntegrity aag s s'; kheap s x = Some (ArchObj ao);
+     kheap s x \<noteq> kheap s' x; silc_inv aag st s;
+     pas_wellformed_noninterference aag; pas_refined aag s;
+     pas_refined aag s'; pas_cur_domain aag s; pas_cur_domain aag s';
+     cur_hyp_in_cur_domain s; cur_hyp_in_cur_domain s'; invs s; invs s'\<rbrakk>
+    \<Longrightarrow> subject_can_affect_label_directly aag (pasObjectAbs aag x)"
+  and partitionIntegrity_subjectAffects_hyp:
+    "\<lbrakk>partitionIntegrity aag s s'; invs s; invs s';
+     cur_hyp_in_cur_domain s; cur_hyp_in_cur_domain s';
+     pas_refined aag s; pas_refined aag s'; pas_cur_domain aag s;
+     pas_cur_domain aag s'; pas_domains_distinct aag;
+     \<not> equiv_hyp (\<lambda>x. pasObjectAbs aag x = a) s s'\<rbrakk>
+    \<Longrightarrow> subject_can_affect_label_directly aag a"
+  and partitionIntegrity_subjectAffects_fpu:
+    "\<lbrakk>partitionIntegrity aag s s'; invs s; invs s';
+     cur_fpu_in_cur_domain s; cur_fpu_in_cur_domain s'; pas_refined aag s;
+     pas_refined aag s'; pas_cur_domain aag s; pas_cur_domain aag s';
+     pas_domains_distinct aag;
+     \<not> equiv_fpu (\<lambda>x. pasObjectAbs aag x = a) s s'\<rbrakk>
+    \<Longrightarrow> subject_can_affect_label_directly aag a"
+  and partitionIntegrity_subjectAffects_tcb_fpu:
+    "\<lbrakk>partitionIntegrity aag s s'; kheap s x = Some (TCB tcb);
+     kheap s' x = Some (TCB tcb'); tcb' = tcb\<lparr>tcb_arch := new_arch\<rparr>;
+     arch_tcb_get_registers new_arch =
+     arch_tcb_get_registers (tcb_arch tcb);
+     tcb_hyp_refs new_arch = tcb_hyp_refs (tcb_arch tcb);
+     kheap s x \<noteq> kheap s' x; silc_inv aag st s;
+     pas_wellformed_noninterference aag; pas_refined aag s;
+     pas_refined aag s'; pas_cur_domain aag s; pas_cur_domain aag s';
+     cur_fpu_in_cur_domain s; cur_fpu_in_cur_domain s'; invs s; invs s'\<rbrakk>
+    \<Longrightarrow> subject_can_affect_label_directly aag (pasObjectAbs aag x)"
 begin
 
 lemma integrity_update_reference_state:
@@ -706,7 +738,7 @@ lemma integrity_update_reference_state:
    be identical to the initial one, but it isn't because we first update the
    context of cur_thread *)
 lemma kernel_entry_if_integrity:
-  "\<lbrace>einvs and schact_is_rct and pas_refined aag and is_subject aag \<circ> cur_thread
+  "\<lbrace>einvs and valid_cur_hyp and schact_is_rct and pas_refined aag and is_subject aag \<circ> cur_thread
           and domain_sep_inv (pasMaySendIrqs aag) st' and guarded_pas_domain aag
           and (\<lambda>s. e \<noteq> Interrupt \<longrightarrow> ct_active s) and (=) st\<rbrace>
    kernel_entry_if e tc
@@ -721,9 +753,9 @@ lemma kernel_entry_if_integrity:
                        \<and> cur_thread s = cur_thread st" in hoare_strengthen_post)
       apply (wp handle_event_integrity handle_event_cur_thread | simp)+
      apply (fastforce intro: integrity_update_reference_state)
-    apply (wp thread_set_integrity_autarch thread_set_pas_refined guarded_pas_domain_lift
+    apply (wp thread_set_integrity_autarch thread_set_context_pas_refined guarded_pas_domain_lift
               thread_set_invs_trivial thread_set_not_state_valid_sched
-           | simp add: tcb_cap_cases_def schact_is_rct_def arch_tcb_update_aux2 valid_cur_hyp_triv)+
+           | simp add: tcb_cap_cases_def schact_is_rct_def arch_tcb_update_aux2)+
     apply (wp thread_set_tcb_context_update_wp)+
   apply (clarsimp simp: schact_is_rct_def)
   apply (rule conjI)
@@ -801,9 +833,8 @@ lemma kernel_entry_if_domain_fields_equiv:
              simp: ran_tcb_cap_cases arch_tcb_update_aux2)
      fastforce
 
-
 lemma kernel_entry_if_partitionIntegrity:
-  "\<lbrace>silc_inv aag st and pas_refined aag and einvs and schact_is_rct
+  "\<lbrace>silc_inv aag st and pas_refined aag and einvs and valid_cur_hyp and schact_is_rct
                     and is_subject aag \<circ> cur_thread and domain_sep_inv (pasMaySendIrqs aag) st'
                     and guarded_pas_domain aag and (\<lambda>s. ev \<noteq> Interrupt \<and> ct_active s) and (=) st\<rbrace>
    kernel_entry_if ev tc
@@ -835,149 +866,144 @@ text \<open>
 \<close>
 lemma partitionIntegrity_subjectAffects_obj:
   assumes par_inte: "partitionIntegrity (aag :: 'a subject_label PAS) s s'"
-  assumes pas_ref: "pas_refined aag s"
-  assumes invs: "invs s"
+  assumes pas_ref: "pas_refined aag s" "pas_refined aag s'"
+  assumes pas_dom: "pas_cur_domain aag s" "pas_cur_domain aag s'"
+  assumes cur_vcpu: "cur_hyp_in_cur_domain s" "cur_hyp_in_cur_domain s'"
+  assumes cur_fpu: "cur_fpu_in_cur_domain s" "cur_fpu_in_cur_domain s'"
+  assumes invs: "invs s" "invs s'"
   assumes pwni: "pas_wellformed_noninterference aag"
   assumes silc_inv: "silc_inv aag st s"
   assumes kh_diff: "kheap s x \<noteq> kheap s' x"
   notes inte_obj = par_inte[THEN partitionIntegrity_integrity, THEN integrity_subjects_obj,
-                            THEN spec[where x=x], simplified integrity_obj_def, simplified]
+                            THEN spec[where x=x], simplified]
   shows "pasObjectAbs aag x \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
-
 proof -
+  note hyps = pwni pas_ref invs silc_inv kh_diff
+    hence sym_helper: "\<And>auth tcb. kheap s x = Some (TCB tcb) \<Longrightarrow>
+                                  (pasObjectAbs aag x, auth, pasObjectAbs aag x) \<in> pasPolicy aag"
+      by (fastforce elim!: pas_wellformed_noninterference_policy_refl
+                           silc_inv_cnode_onlyE obj_atE
+                     simp: is_cap_table_def)
   show ?thesis
-    using inte_obj
-  proof (induct "kheap s x" rule: converse_rtranclp_induct)
-    case base
-    thus ?case using kh_diff by force
+    using tro_tro_alt[OF inte_obj]
+  proof (induct rule: integrity_obj_alt.induct)
+    case tro_alt_lrefl
+    thus ?case by (simp add: subjectAffects.intros(1))
   next
-    case (step z)
-    note troa = step.hyps(1)
-    show ?case
-    proof (cases "z = kheap s x")
-      case True
-      thus ?thesis using step.hyps by blast
-    next
-      case False
-      note hyps = this pwni pas_ref invs silc_inv kh_diff
-      hence sym_helper: "\<And>auth tcb. kheap s x = Some (TCB tcb) \<Longrightarrow>
-                                    (pasObjectAbs aag x, auth, pasObjectAbs aag x) \<in> pasPolicy aag"
-        by (fastforce elim!: pas_wellformed_noninterference_policy_refl
-                             silc_inv_cnode_onlyE obj_atE
-                       simp: is_cap_table_def)
-      show ?thesis
-        using troa
-      proof (cases rule: integrity_obj_atomic.cases)
-        case troa_lrefl
-        thus ?thesis by (fastforce intro: subjectAffects.intros)
-      next
-        case (troa_ntfn ntfn ntfn' auth s)
-        thus ?thesis by (fastforce intro: affects_ep)
-      next
-        case (troa_ep ep ep' auth s)
-        thus ?thesis by (fastforce intro: affects_ep)
-      next
-        case (troa_ep_unblock ep ep' tcb ntfn)
-        thus ?thesis by (fastforce intro: affects_ep_bound_trans)
-      next
-        case (troa_tcb_send tcb tcb' ctxt' ep)
-        thus ?thesis using hyps
-          apply (clarsimp simp: direct_send_def indirect_send_def)
-          apply (erule disjE)
-           apply (clarsimp simp: receive_blocked_on_def2)
-           apply (frule (2) pas_refined_tcb_st_to_auth)
-           apply (fastforce intro!: affects_send sym_helper)
-          apply (fastforce intro!: affects_send bound_tcb_at_implies_receive
-                                   pred_tcb_atI sym_helper)
-          done
-      next
-        case (troa_tcb_call tcb tcb' caller R ctxt' ep)
-        thus ?thesis using hyps
-          apply (clarsimp simp add: direct_call_def ep_recv_blocked_def)
-          apply (rule affects_send[rotated 2])
-             apply (erule (1) pas_refined_tcb_st_to_auth[rotated 2]; force)
-            apply (fastforce intro: sym_helper)
-           apply assumption
-          apply blast
-          done
-      next
-        case (troa_tcb_reply tcb tcb' new_st ctxt')
-        thus ?thesis using hyps
-          apply clarsimp
-          apply (erule affects_reply)
-          by (rule sym_helper)
-      next
-        case (troa_tcb_receive tcb tcb' new_st ep)
-        thus ?thesis using hyps
-          by (auto intro: affects_recv pas_refined_tcb_st_to_auth simp: send_blocked_on_def2)
-      next
-        case (troa_tcb_restart tcb tcb' ep)
-        thus ?thesis using hyps
-          by (fastforce intro: affects_reset[where auth=Receive] affects_reset[where auth=SyncSend]
-                         elim: blocked_on.elims pas_refined_tcb_st_to_auth[rotated 2]
-                       intro!: sym_helper)
-      next
-        case (troa_tcb_unbind tcb tcb')
-        thus ?thesis using hyps
-          apply -
-          by (cases "tcb_bound_notification tcb" ;
-              fastforce intro: affects_reset[where auth=Receive] bound_tcb_at_implies_receive
+    case tro_alt_orefl
+    thus ?case by (simp add: assms)
+  next
+    case (tro_alt_ntfn ntfn ntfn' auth)
+    thus ?case by (fastforce intro: affects_ep)
+  next
+    case (tro_alt_ep ep ep' auth)
+    thus ?case by (fastforce intro: affects_ep)
+  next
+    case (tro_alt_ep_unblock ep ep')
+    thus ?case by (fastforce intro: affects_ep_bound_trans)
+  next
+    case (tro_alt_tcb_send tcb tcb' ccap' cap' ntfn' new_arch ep)
+    thus ?case using hyps
+      apply (clarsimp simp: direct_send_def indirect_send_def)
+      apply (erule disjE)
+       apply (clarsimp simp: receive_blocked_on_def2)
+       apply (frule (2) pas_refined_tcb_st_to_auth)
+       apply (fastforce intro!: affects_send sym_helper)
+      apply (fastforce intro!: affects_send bound_tcb_at_implies_receive
                                pred_tcb_atI sym_helper)
-      next
-        case (troa_tcb_empty_ctable tcb tcb' cap')
-        thus ?thesis using hyps
-          apply (clarsimp simp:reply_cap_deletion_integrity_def; elim disjE; clarsimp)
-          apply (rule affects_delete_derived)
-          apply (rule aag_wellformed_delete_derived[rotated -1, OF pas_refined_wellformed],
-                 assumption)
-          apply (frule cap_auth_caps_of_state[rotated,where p ="(x,tcb_cnode_index 0)"],
-                 force simp: caps_of_state_def')
-          by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def reply_cap_rights_to_auth_def
-                       split: if_splits)
-      next
-        case (troa_tcb_empty_caller tcb tcb' cap')
-        thus ?thesis using hyps
-          apply (clarsimp simp:reply_cap_deletion_integrity_def)
-          apply (elim disjE; clarsimp)
-          apply (rule affects_delete_derived)
-          apply (rule aag_wellformed_delete_derived[rotated -1, OF pas_refined_wellformed],
-                 assumption)
-          apply (frule cap_auth_caps_of_state[rotated,where p ="(x,tcb_cnode_index 3)"],
-                 force simp: caps_of_state_def')
-          by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def
-                              reply_cap_rights_to_auth_def
-                       split: if_splits)
-      next
-        case (troa_tcb_activate tcb tcb')
-        thus ?thesis by blast
-      next
-        case (troa_tcb_fpu tcb tcb' new_arch)
-        thus ?thesis
-          by (auto intro!: step tcb.equality arch_tcb_get_registers_equality)
-      next
-        case (troa_arch ao ao')
-        thus ?thesis
-          using assms by (fastforce dest: partitionIntegrity_subjectAffects_aobj)
-      next
-        case (troa_cnode n content content')
-        thus ?thesis
-          using hyps unfolding cnode_integrity_def
-          apply clarsimp
-          apply (drule fun_noteqD)
-          apply (erule exE, rename_tac l)
-          apply (drule_tac x=l in spec)
-          apply (clarsimp dest!:not_sym[where t=None])
-          apply (clarsimp simp:reply_cap_deletion_integrity_def)
-          apply (rule affects_delete_derived)
-          apply (rule aag_wellformed_delete_derived[rotated -1, OF pas_refined_wellformed],
-                 assumption)
-          apply (frule_tac p="(x,l)" in cap_auth_caps_of_state[rotated])
-           apply (force simp: caps_of_state_def' intro:well_formed_cnode_invsI)
-          by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def
-                              reply_cap_rights_to_auth_def
-                       split: if_splits)
-      qed
-    qed
+      done
+  next
+    case (tro_alt_tcb_call tcb tcb' ccap' cap' ntfn' new_arch caller R ep)
+    thus ?case using hyps
+      apply (clarsimp simp add: direct_call_def ep_recv_blocked_def)
+      apply (rule affects_send[rotated 2])
+         apply (erule (1) pas_refined_tcb_st_to_auth[rotated 2]; force)
+        apply (fastforce intro: sym_helper)
+       apply assumption
+      apply blast
+      done
+  next
+    case (tro_alt_tcb_reply tcb tcb' ccap' cap' ntfn' new_st new_arch)
+    thus ?case using hyps
+      apply (clarsimp simp: direct_reply_def)
+      apply (erule affects_reply)
+      by (rule sym_helper)
+  next
+    case (tro_alt_tcb_receive tcb tcb' ccap' cap' ntfn' new_arch new_st ep)
+    thus ?case using hyps
+      by (auto intro: affects_recv pas_refined_tcb_st_to_auth simp: send_blocked_on_def2)
+  next
+    case (tro_alt_tcb_restart tcb tcb' ccap' cap' ntfn' new_arch ep)
+    thus ?case using hyps
+      by (fastforce intro: affects_reset[where auth=Receive] affects_reset[where auth=SyncSend]
+                     elim: blocked_on.elims pas_refined_tcb_st_to_auth[rotated 2]
+                   intro!: sym_helper)
+  next
+    case (tro_alt_tcb_generic tcb tcb' ccap' cap' ntfn' new_arch)
+    have "tcb_bound_notification tcb \<noteq> ntfn' \<Longrightarrow> ?case"
+      using tro_alt_tcb_generic hyps
+      apply (clarsimp simp: tcb_bound_notification_reset_integrity_def)
+      by (cases "tcb_bound_notification tcb" ;
+          fastforce intro: affects_reset[where auth=Receive] bound_tcb_at_implies_receive
+                           pred_tcb_atI sym_helper)
+    moreover have "tcb_caller tcb \<noteq> cap' \<Longrightarrow> ?case"
+      using tro_alt_tcb_generic(2,3,4,5,8) hyps
+      apply (clarsimp simp:reply_cap_deletion_integrity_def)
+      apply (rule affects_delete_derived)
+      apply (rule aag_wellformed_delete_derived[rotated -1, OF pas_refined_wellformed],
+             assumption)
+      apply (frule cap_auth_caps_of_state[rotated,where p ="(x,tcb_cnode_index 3)"],
+             force simp: caps_of_state_def')
+      by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def
+                          reply_cap_rights_to_auth_def
+                   split: if_splits)
+    moreover have "tcb_ctable tcb \<noteq> ccap' \<Longrightarrow> ?case"
+      using tro_alt_tcb_generic(2,3,4,5,9) hyps
+      apply (clarsimp simp: reply_cap_deletion_integrity_def)
+      apply (rule affects_delete_derived)
+      apply (rule aag_wellformed_delete_derived[rotated -1, OF pas_refined_wellformed],
+             assumption)
+      apply (frule cap_auth_caps_of_state[rotated,where p ="(x,tcb_cnode_index 0)"],
+             force simp: caps_of_state_def')
+      by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def reply_cap_rights_to_auth_def
+                   split: if_splits)
+    moreover have "\<lbrakk> tcb_ctable tcb = ccap'; tcb_caller tcb = cap';
+                     tcb_bound_notification tcb = ntfn'; tcb_arch tcb \<noteq> new_arch \<rbrakk> \<Longrightarrow> ?case"
+      using tro_alt_tcb_generic(2,3,4,5,6) assms
+      by (fastforce intro: partitionIntegrity_subjectAffects_tcb_fpu)
+    ultimately show ?case
+      using tro_alt_tcb_generic(2,3,4) kh_diff
+      apply clarsimp
+      apply (case_tac "tcb_ctable tcb \<noteq> ccap'", fastforce)
+      apply (case_tac "tcb_caller tcb \<noteq> cap'", fastforce)
+      apply (case_tac "tcb_bound_notification tcb \<noteq> ntfn'", fastforce)
+      apply (case_tac "tcb_arch tcb \<noteq> new_arch", fastforce)
+      apply simp
+      done
+  next
+    case (tro_alt_tcb_activate tcb tcb' ntfn' ccap' cap' new_arch)
+    thus ?case by simp
+  next
+    case (tro_alt_cnode n content content')
+    thus ?case
+      using hyps unfolding cnode_integrity_def
+      apply clarsimp
+      apply (drule fun_noteqD)
+      apply (erule exE, rename_tac l)
+      apply (drule_tac x=l in spec)
+      apply (clarsimp dest!:not_sym[where t=None])
+      apply (clarsimp simp:reply_cap_deletion_integrity_def)
+      apply (rule affects_delete_derived)
+      apply (rule aag_wellformed_delete_derived[rotated -1, OF pas_refined_wellformed],
+             assumption)
+      apply (frule_tac p="(x,l)" in cap_auth_caps_of_state[rotated])
+       apply (force simp: caps_of_state_def' intro:well_formed_cnode_invsI)
+      by (fastforce simp: aag_cap_auth_def cap_auth_conferred_def
+                          reply_cap_rights_to_auth_def
+                   split: if_splits)
+  next
+    case (tro_alt_arch ao ao')
+     thus ?case using assms by (fastforce dest: partitionIntegrity_subjectAffects_aobj)
   qed
 qed
 
@@ -1225,19 +1251,32 @@ lemma valid_sched_valid_blocked: "valid_sched s \<Longrightarrow> valid_blocked 
 context Noninterference_1 begin
 
 lemma partitionIntegrity_subjectAffects_etcbs:
-  "\<lbrakk> partitionIntegrity (aag :: 'a subject_label PAS) s s'; pas_refined aag s;
-     valid_objs s; einvs s; einvs s'; pas_wellformed_noninterference aag;
+  assumes par_inte: "partitionIntegrity (aag :: 'a subject_label PAS) s s'"
+ notes inte_obj = par_inte[THEN partitionIntegrity_integrity, THEN integrity_subjects_obj,
+                            THEN spec[where x=x], simplified integrity_obj_def, simplified]
+  shows
+  "\<lbrakk> pas_refined aag s; pas_refined aag s';
+     pas_cur_domain aag s; pas_cur_domain aag s';
+     cur_hyp_in_cur_domain s; cur_hyp_in_cur_domain s';
+     cur_fpu_in_cur_domain s; cur_fpu_in_cur_domain s';
+     einvs s; einvs s'; pas_wellformed_noninterference aag;
      silc_inv aag st s; silc_inv aag st' s'; etcbs_of s x \<noteq> etcbs_of s' x \<rbrakk>
      \<Longrightarrow> pasObjectAbs aag x \<in> subjectAffects (pasPolicy aag) (pasSubject aag)"
+  apply (insert par_inte)
   apply (prop_tac "kheap s x \<noteq> kheap s' x")
    apply (clarsimp simp: etcbs_of'_def)
+  apply (case_tac "is_subject aag x")
+  using affects_lrefl apply fastforce
   apply (erule partitionIntegrity_subjectAffects_obj; simp)
   done
 
 lemma partitionIntegrity_subjectAffects_ready_queues:
   assumes domains_distinct: "pas_domains_distinct (aag :: 'a subject_label PAS)"
-  shows "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; valid_objs s; einvs s; einvs s';
-           pas_refined aag s'; pas_cur_domain aag s; pas_wellformed_noninterference aag;
+  shows "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; pas_refined aag s';
+           pas_cur_domain aag s; pas_cur_domain aag s';
+           cur_hyp_in_cur_domain s; cur_hyp_in_cur_domain s';
+           cur_fpu_in_cur_domain s; cur_fpu_in_cur_domain s';
+           einvs s; einvs s'; pas_wellformed_noninterference aag;
            silc_inv aag st s; silc_inv aag st' s'; ready_queues s d \<noteq> ready_queues s' d;
            cur_thread s \<noteq> idle_thread s \<longrightarrow> is_subject aag (cur_thread s);
            cur_thread s' \<noteq> idle_thread s' \<longrightarrow> is_subject aag (cur_thread s') \<rbrakk>
@@ -1267,12 +1306,12 @@ lemma partitionIntegrity_subjectAffects_ready_queues:
     apply (fastforce dest: domains_distinct[THEN pas_domains_distinct_inj])
    apply (case_tac "etcbs_of s tcb_ptr \<noteq> etcbs_of s' tcb_ptr")
     apply (rule_tac s=s and s'=s' in partitionIntegrity_subjectAffects_etcbs)
-            apply (simp add: partitionIntegrity_def)+
+                apply (simp add: partitionIntegrity_def)+
    apply (subgoal_tac "kheap s tcb_ptr \<noteq> kheap s' tcb_ptr")
     apply (rule partitionIntegrity_subjectAffects_obj)
-         apply (fastforce simp add: partitionIntegrity_def valid_sched_def)+
-   apply (rule_tac threads="tcb_ptr # tcbs" in ready_queues_alters_kheap)
                apply (fastforce simp add: partitionIntegrity_def valid_sched_def)+
+   apply (rule_tac threads="tcb_ptr # tcbs" in ready_queues_alters_kheap)
+             apply (fastforce simp add: partitionIntegrity_def valid_sched_def)+
   done
 
 end
@@ -1319,10 +1358,18 @@ lemma sameFor_subject_def2:
   apply (rule conjI, rule refl)
   apply (rule conjI)
    apply (rule states_equiv_forI)
-            apply ((fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+)[5]
-       apply (fastforce intro: equiv_forI elim: states_equiv_forE_is_original_cap)
-      apply ((fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+)[2]
-    apply (solves \<open>clarsimp simp: equiv_asids_def states_equiv_for_def\<close>)
+             apply ((fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+)[4]
+         apply (fastforce intro: equiv_forI elim: states_equiv_forE_is_original_cap)
+        apply ((fastforce intro: equiv_forI elim: states_equiv_forE equiv_forD)+)[2]
+      apply (solves \<open>clarsimp simp: equiv_asids_def states_equiv_for_def\<close>)
+     apply (rule equiv_hypI)
+     apply (clarsimp simp: states_equiv_for_def)
+     apply (drule (1) bspec)
+     apply (fastforce elim!: equiv_hyp_guard_imp)
+    apply (rule equiv_fpuI)
+    apply (clarsimp simp: states_equiv_for_def)
+    apply (drule (1) bspec)
+    apply (fastforce elim!: equiv_fpu_guard_imp)
    apply (fastforce intro: equiv_forI elim: states_equiv_forE_ready_queues)
   apply fastforce
   done
@@ -1366,9 +1413,12 @@ context Noninterference_1 begin
 
 lemma partsSubjectAffects_bounds_subjects_affects:
   assumes domains_distinct: "pas_domains_distinct (aag :: 'a subject_label PAS)"
-  shows "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; pas_refined aag s'; valid_objs s;
-           valid_arch_state s'; einvs s; einvs s'; silc_inv aag st s; silc_inv aag st' s';
-           pas_wellformed_noninterference aag; pas_cur_domain aag s;
+  shows "\<lbrakk> partitionIntegrity aag s s'; pas_refined aag s; pas_refined aag s';
+           einvs s; einvs s';
+           cur_hyp_in_cur_domain s; cur_hyp_in_cur_domain s';
+           cur_fpu_in_cur_domain s; cur_fpu_in_cur_domain s';
+           silc_inv aag st s; silc_inv aag st' s';
+           pas_wellformed_noninterference aag; pas_cur_domain aag s; pas_cur_domain aag s';
            guarded_is_subject_cur_thread aag s; guarded_is_subject_cur_thread aag s';
            d \<notin> partsSubjectAffects (pasPolicy aag) (label_of (pasSubject aag)); d \<noteq> PSched \<rbrakk>
            \<Longrightarrow> (((uc,s),mode),((uc',s'),mode')) \<in> same_for aag d"
@@ -1377,12 +1427,16 @@ lemma partsSubjectAffects_bounds_subjects_affects:
   apply (cases d)
    prefer 2
    apply simp
+  apply (unfold sameFor_def sameFor_subject_def2)
   apply (clarsimp simp: sameFor_def sameFor_subject_def2 states_equiv_for_def equiv_for_def
-                       partsSubjectAffects_def image_def label_can_affect_partition_def)
+                        partsSubjectAffects_def image_def label_can_affect_partition_def)
   apply (safe del: iffI notI)
+                              apply (drule partitionIntegrity_subjectAffects_hyp)
+                                    apply (simp add: domains_distinct)+
+                              apply fastforce
+                             apply (fastforce dest: partitionIntegrity_subjectAffects_asid)
                              apply (fastforce dest: partitionIntegrity_subjectAffects_obj)
-                            apply ((auto dest: partitionIntegrity_subjectAffects_obj
-                                               partitionIntegrity_subjectAffects_mem
+                            apply ((auto dest: partitionIntegrity_subjectAffects_mem
                                                partitionIntegrity_subjectAffects_device
                                                partitionIntegrity_subjectAffects_cdt
                                                partitionIntegrity_subjectAffects_cdt_list
@@ -1395,7 +1449,10 @@ lemma partsSubjectAffects_bounds_subjects_affects:
                                                   OF domains_distinct]
                                                domains_distinct[THEN pas_domains_distinct_inj]
                                     | fastforce simp: partitionIntegrity_def
-                                                      silc_dom_equiv_def equiv_for_def)+)[11]
+                                                      silc_dom_equiv_def equiv_for_def)+)[10]
+                  apply (drule partitionIntegrity_subjectAffects_fpu)
+                          apply (simp add: domains_distinct)+
+                  apply fastforce
                  apply ((fastforce intro: affects_lrefl
                                    simp: partitionIntegrity_def domain_fields_equiv_def
                                    dest: domains_distinct[THEN pas_domains_distinct_inj])+)[16]
@@ -1403,17 +1460,6 @@ lemma partsSubjectAffects_bounds_subjects_affects:
 
 end
 
-
-lemma cur_thread_not_SilcLabel:
-  "\<lbrakk> silc_inv aag st s; invs s \<rbrakk> \<Longrightarrow> pasObjectAbs aag (cur_thread s) \<noteq> SilcLabel"
-  apply (rule notI)
-  apply (simp add: silc_inv_def)
-  apply (drule tcb_at_invs)
-  apply clarify
-  apply (drule_tac x="cur_thread s" in spec, erule (1) impE)
-  apply (auto simp: obj_at_def is_tcb_def is_cap_table_def)
-  apply (case_tac ko, simp_all)
-  done
 
 lemma ev_add_pre:
   "equiv_valid_inv I A P f \<Longrightarrow> equiv_valid_inv I A (P and Q) f"
@@ -1424,7 +1470,7 @@ lemma ev_add_pre:
 
 crunch check_active_irq_if
   for invs[wp]: "einvs"
-  (wp: dmo_getActiveIRQ_wp ignore: do_machine_op)
+  (ignore: do_machine_op)
 
 crunch thread_set
   for schact_is_rct[wp]: "schact_is_rct"
@@ -1946,10 +1992,14 @@ lemma integrity_part:
             apply (fastforce dest!: reachable_invs_if[OF reachable_Step'] simp: invs_if_def Invs_def)
            apply (fastforce dest!: reachable_invs_if simp: invs_if_def Invs_def)
           apply (fastforce dest!: reachable_invs_if[OF reachable_Step'] simp: invs_if_def Invs_def)
+           apply (fastforce dest!: reachable_invs_if simp: invs_if_def Invs_def)
+          apply (fastforce dest!: reachable_invs_if[OF reachable_Step'] simp: invs_if_def Invs_def)
          apply (fastforce dest: silc_inv_initial_aag_reachable simp: silc_inv_cur)
-        apply (frule Step_current_aag_unchanged[symmetric];simp)
+        apply (frule Step_current_aag_unchanged[symmetric]; simp)
         apply (fastforce dest: silc_inv_initial_aag_reachable[OF reachable_Step'] simp: silc_inv_cur)
        apply (rule pas_wellformed_cur)
+      apply (simp add: current_aag_def)
+    apply (frule Step_current_aag_unchanged[symmetric];simp)
       apply (simp add: current_aag_def)
      apply (fastforce dest!: reachable_invs_if domains_distinct[THEN pas_domains_distinct_inj]
                        simp: invs_if_def Invs_def guarded_pas_domain_def
@@ -2148,11 +2198,12 @@ lemma tcb_sched_action_reads_respects_g':
    apply (wp set_tcb_queue_reads_respects_g')
          apply (rule_tac Q="\<lambda>s. pasObjectAbs aag thread \<in> pasDomainAbs aag (tcb_domain rv)"
                       in equiv_valid_guard_imp)
-          apply (wp gets_apply_ev')
+          apply (wp gets_apply_ev)
           apply (clarsimp simp: reads_equiv_g_def)
           apply (elim reads_equivE affects_equivE equiv_forE)
           apply (clarsimp simp: disjoint_iff_not_equal)
-          apply metis (* only one that works *)
+           apply (erule_tac x="tcb_domain rv" in meta_allE)+
+          apply blast
          apply (wp | simp)+
    apply (intro conjI impI allI
           | fastforce simp: get_tcb_def reads_equiv_g_def
@@ -2185,7 +2236,7 @@ lemma tcb_sched_action_reads_respects_g':
 lemma switch_to_thread_reads_respects_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows "reads_respects_g aag (l :: 'a subject_label)
-                          (pas_refined aag and (\<lambda>s. is_subject aag t)) (switch_to_thread t)"
+                          (pas_refined aag and invs and (\<lambda>s. is_subject aag t)) (switch_to_thread t)"
   apply (simp add: switch_to_thread_def)
   apply (subst bind_assoc[symmetric])
   apply (rule equiv_valid_guard_imp)
@@ -2202,7 +2253,7 @@ lemma switch_to_thread_reads_respects_g:
 lemma guarded_switch_to_reads_respects_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows "reads_respects_g aag (l :: 'a subject_label)
-                          (pas_refined aag and valid_idle and (\<lambda>s. is_subject aag t))
+                          (pas_refined aag and invs and (\<lambda>s. is_subject aag t))
                           (guarded_switch_to t)"
   apply (simp add: guarded_switch_to_def)
   apply (wp switch_to_thread_reads_respects_g get_thread_state_reads_respects_g gts_wp)
@@ -2219,7 +2270,7 @@ lemma cur_thread_update_idle_reads_respects_g':
   done
 
 lemma switch_to_idle_thread_reads_respects_g[wp]:
-  "reads_respects_g aag (l :: 'a subject_label) \<top> (switch_to_idle_thread)"
+  "reads_respects_g aag (l :: 'a subject_label) valid_arch_state (switch_to_idle_thread)"
   apply (simp add: switch_to_idle_thread_def)
   apply (wp cur_thread_update_idle_reads_respects_g')
   apply (fastforce simp: reads_equiv_g_def globals_equiv_idle_thread_ptr)
@@ -2239,7 +2290,7 @@ lemma choose_thread_reads_respects_g:
    apply (clarsimp simp: reads_equiv_g_def reads_equiv_def2
                          states_equiv_for_def equiv_for_def disjoint_iff_not_equal)
    apply (metis reads_lrefl)
-  apply (simp add: invs_valid_idle)
+  apply (simp add: invs_arch_state)
   (* everything from here clagged from Syscall_AC.choose_thread_respects *)
   apply (clarsimp simp: pas_refined_def)
   apply (clarsimp simp: tcb_domain_map_wellformed_aux_def)
@@ -2299,7 +2350,7 @@ lemma reads_equiv_valid_g_inv_schedule_switch_thread_fastfail:
 lemma reads_respects_gets_ready_queues:
   "reads_respects aag l (\<lambda>s. pasSubject aag \<in> pasDomainAbs aag d)
      (gets (\<lambda>s. f (ready_queues s d)))"
-  apply (wp gets_ev'')
+  apply (wp gets_ev)
   apply (force elim: reads_equivE simp: equiv_for_def)
   done
 
@@ -2330,7 +2381,7 @@ lemma schedule_choose_new_thread_reads_respects_g:
   apply (subst gets_app_rewrite[where y=domain_time and f="\<lambda>x. x = 0"])+
   apply (wp gets_domain_time_zero_ev set_scheduler_action_reads_respects_g
             choose_thread_reads_respects_g ev_pre_cont[where f=next_domain]
-            arch_prepare_next_domain_ev hoare_pre_cont[where f=next_domain] when_ev)
+            arch_prepare_next_domain_reads_respects_g hoare_pre_cont[where f=next_domain] when_ev)
   apply (clarsimp simp: valid_sched_def word_neq_0_conv)
   done
 
@@ -2832,52 +2883,32 @@ lemma kernel_schedule_if_confidentiality':
 end
 
 
-lemma thread_set_tcb_context_update_runnable_globals_equiv:
-  "\<lbrace>globals_equiv st and st_tcb_at runnable t and invs\<rbrace>
-   thread_set (tcb_arch_update (arch_tcb_context_set uc)) t
-   \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
-  apply (rule hoare_pre)
-  apply (rule thread_set_context_globals_equiv)
-  apply clarsimp
-  apply (frule invs_valid_idle)
-  apply (fastforce simp: valid_idle_def pred_tcb_at_def obj_at_def)
-  done
-
-lemma thread_set_tcb_context_update_reads_respects_g:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "reads_respects_g aag (l :: 'a subject_label) (st_tcb_at runnable t and invs)
-                          (thread_set (tcb_arch_update (arch_tcb_context_set uc)) t)"
+lemma thread_set_reads_respects_g:
+  "reads_respects_g aag (l :: 'a subject_label) (st_tcb_at runnable t and invs) (thread_set f t)"
   apply (rule equiv_valid_guard_imp)
    apply (rule reads_respects_g)
-    apply (rule thread_set_reads_respects[OF domains_distinct])
+    apply (rule thread_set_reads_respects)
    apply (rule doesnt_touch_globalsI)
-   apply (wp thread_set_tcb_context_update_runnable_globals_equiv)
+   apply (wp thread_set_globals_equiv')
    apply simp+
+  apply (fastforce dest: invs_valid_idle simp: valid_idle_def pred_tcb_at_def obj_at_def)
   done
 
-lemma thread_set_tcb_context_update_silc_inv[wp]:
-  "thread_set (tcb_arch_update (arch_tcb_context_set f)) t \<lbrace>silc_inv aag st\<rbrace>"
-  apply (rule thread_set_silc_inv)
-  apply (simp add: tcb_cap_cases_def)
-  done
-
-lemmas thread_set_tcb_context_update_reads_respects_f_g =
-  reads_respects_f_g'[where Q="\<top>", simplified,
-                      OF thread_set_tcb_context_update_reads_respects_g,
-                      OF _ thread_set_tcb_context_update_silc_inv]
+lemmas thread_set_reads_respects_f_g =
+  reads_respects_f_g'[where Q="\<top>", simplified, OF thread_set_reads_respects_g]
 
 lemma kernel_entry_if_reads_respects_f_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "reads_respects_f_g aag l (ct_active and silc_inv aag st and einvs
+  shows "reads_respects_f_g aag l (ct_active and silc_inv aag st and einvs and valid_cur_hyp
                                              and only_timer_irq_inv irq st'
                                              and schact_is_rct and pas_refined aag
                                              and pas_cur_domain aag and guarded_pas_domain aag
                                              and K (ev \<noteq> Interrupt \<and> \<not> pasMaySendIrqs aag))
                             (kernel_entry_if ev tc)"
   apply (simp add: kernel_entry_if_def)
-  apply (wp handle_event_reads_respects_f_g thread_set_tcb_context_update_reads_respects_f_g
-            thread_set_tcb_context_update_silc_inv only_timer_irq_inv_pres[where P="\<top>" and Q="\<top>"]
-            thread_set_invs_trivial thread_set_not_state_valid_sched thread_set_pas_refined
+  apply (wp handle_event_reads_respects_f_g thread_set_reads_respects_f_g
+            only_timer_irq_inv_pres[where P="\<top>" and Q="\<top>"]
+            thread_set_invs_trivial thread_set_not_state_valid_sched thread_set_context_pas_refined
          | simp add: tcb_cap_cases_def arch_tcb_update_aux2)+
   apply (elim conjE)
   apply (frule (1) ct_active_cur_thread_not_idle_thread[OF invs_valid_idle])
@@ -3500,6 +3531,22 @@ lemma handle_preemption_agnostic_tc:
 
 context Noninterference_1 begin
 
+lemma handle_non_kernel_IRQ_ev2:
+  "equiv_valid_2 I A A R P (domain_sep_inv False st and K (irq \<le> maxIRQ \<and> irq \<in> non_kernel_IRQs))
+                           LHS (handle_interrupt irq >>= RHS)"
+  unfolding handle_interrupt_def
+  apply (rule EquivValid.gen_asm_ev2_r)
+  apply (prop_tac "\<not>maxIRQ < irq")
+   apply (clarsimp simp: not_less)
+  apply (clarsimp simp: bind_assoc)
+  apply (rule_tac Q="\<lambda>irq _. irq = IRQInactive" in equiv_valid_2_bind_right)
+       apply (rule gen_asm_ev2_r)
+       apply (clarsimp simp: fail_ev2_r)
+      apply (wpsimp simp: get_irq_state_def)+
+   apply (fastforce simp: domain_sep_inv_def)
+  apply simp
+  done
+
 lemma preemption_interrupt_scheduler_invisible:
   assumes domains_distinct[wp]: "pas_domains_distinct (aag :: 'a subject_label PAS)"
   shows "equiv_valid_2 (scheduler_equiv aag) (scheduler_affects_equiv aag l)
@@ -3515,21 +3562,24 @@ lemma preemption_interrupt_scheduler_invisible:
                               and (\<lambda>s. ct_idle s \<longrightarrow> uc' = idle_context s)
                               and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s))
                        (handle_preemption_if uc) (kernel_entry_if Interrupt uc')"
-  apply (simp add: kernel_entry_if_def handle_preemption_if_def maybe_handle_interrupt_def
-                   getActiveIRQ_no_non_kernel_IRQs)
+  apply (simp add: kernel_entry_if_def handle_preemption_if_def maybe_handle_interrupt_def)
   apply (rule equiv_valid_2_bind_right)
        apply (rule equiv_valid_2_bind_right)
             apply (simp add: liftE_def bind_assoc)
             apply (simp only: option.case_eq_if)
-            apply (rule equiv_valid_2_bind_pre[where R'="(=)"])
+            apply (rule equiv_valid_2_bind_pre[OF _ getActiveIRQ_ev2])
+                apply (elim disjE)
                  apply (simp split del: if_split)
                  apply (rule equiv_valid_2_bind_pre[where R'="(=)" and Q="\<top>\<top>" and Q'="\<top>\<top>"])
                       apply (rule return_ev2)
                       apply simp
                      apply (rule equiv_valid_2)
                      apply (wp handle_interrupt_reads_respects_scheduler[where st=st and st'=st'] | simp)+
-                apply (rule equiv_valid_2)
-                apply (rule dmo_getActive_IRQ_reads_respect_scheduler)
+                apply clarsimp
+                apply (rule equiv_valid_2_guard_imp)
+                  apply (rule handle_non_kernel_IRQ_ev2)
+                 apply simp
+                apply fastforce
                apply (wp dmo_getActiveIRQ_return_axiom[simplified try_some_magic]
                       | simp  add: imp_conjR arch_tcb_update_aux2
                       | elim conjE
@@ -3592,7 +3642,7 @@ lemma kernel_entry_scheduler_equiv_2:
                   | wp (once) hoare_drop_imps)+
           apply (rule context_update_cur_thread_snippit)
          apply (wp thread_set_invs_trivial guarded_pas_domain_lift
-                   thread_set_pas_refined thread_set_not_state_valid_sched
+                   thread_set_context_pas_refined thread_set_not_state_valid_sched
                 | simp add: tcb_cap_cases_def arch_tcb_update_aux2)+
    apply (fastforce simp: silc_inv_not_cur_thread cur_thread_idle)+
   done
@@ -3894,9 +3944,10 @@ lemma schedule_step:
   done
 
 lemma schedule_if_reads_respects_scheduler:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
   shows "reads_respects_scheduler aag l
-           (einvs and pas_refined aag and silc_inv aag st and guarded_pas_domain aag and tick_done)
+           (einvs and pas_refined aag and silc_inv aag st and guarded_pas_domain aag and tick_done and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain)
            (schedule_if uc)"
   apply (simp add: schedule_if_def)
   apply (wp schedule_reads_respects_scheduler schedule_guarded_pas_domain)
@@ -4015,7 +4066,7 @@ lemma scheduler_step_2_confidentiality:
   apply (rule equiv_valid_2E[where s="internal_state_if s" and t="internal_state_if t",
                              OF schedule_if_reads_respects_scheduler_2
                                   [where aag="initial_aag" and st="s0_internal"
-                                     and l="label_for_partition u", OF domains_distinct]],
+                                     and l="label_for_partition u", OF policy_wellformed]],
          assumption,assumption)
      apply (rule uwr_scheduler_affects_equiv,simp+)
     apply ((clarsimp simp: blob)+)[2]

--- a/proof/infoflow/RISCV64/ArchADT_IF.thy
+++ b/proof/infoflow/RISCV64/ArchADT_IF.thy
@@ -19,6 +19,67 @@ context Arch begin global_naming RISCV64
 
 named_theorems ADT_IF_assms
 
+lemma dmo_getActiveIRQ_wp'[ADT_IF_assms]:
+  "\<lbrace>(\<lambda>s. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
+           (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>))
+    and domain_sep_inv False st and valid_irq_states\<rbrace>
+   do_machine_op (getActiveIRQ in_kernel)
+   \<lbrace>P\<rbrace>"
+  apply (simp add: do_machine_op_def getActiveIRQ_def non_kernel_IRQs_def)
+  apply (wp modify_wp | wpc)+
+  apply clarsimp
+  apply (erule use_valid)
+   apply (wp modify_wp)
+  apply (auto simp: Let_def non_kernel_IRQs_def irq_at_def split: if_splits)
+  done
+
+lemma dmo_getActiveIRQ_wp[ADT_IF_assms]:
+  "\<lbrace>(\<lambda>s. P (irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)))
+           (s\<lparr>machine_state := (machine_state s\<lparr>irq_state := irq_state (machine_state s) + 1\<rparr>)\<rparr>))\<rbrace>
+   do_machine_op (getActiveIRQ False)
+   \<lbrace>P\<rbrace>"
+  apply (simp add: do_machine_op_def getActiveIRQ_def non_kernel_IRQs_def)
+  apply (wp modify_wp | wpc)+
+  apply clarsimp
+  apply (erule use_valid)
+   apply (wp modify_wp)
+  apply (auto simp: Let_def non_kernel_IRQs_def irq_at_def split: if_splits)
+  done
+
+lemma deleted_irq_handler_valid_irq_states[wp]:
+  "deleted_irq_handler irq \<lbrace>valid_irq_states\<rbrace>"
+  unfolding deleted_irq_handler_def set_irq_state_def valid_irq_states_def valid_irq_masks_def maskInterrupt_def
+  by (wpsimp wp: dmo_wp)
+
+lemma dmo_valid_irq_states[wp]:
+  "(\<And>P. f \<lbrace>\<lambda>s. P (irq_masks s)\<rbrace>) \<Longrightarrow> do_machine_op f \<lbrace>valid_irq_states\<rbrace>"
+  unfolding valid_irq_states_def do_machine_op_def
+  by (wpsimp, erule use_valid; assumption)
+
+lemma dmo_getActiveIRQ_valid_irq_states[wp]:
+  "do_machine_op (getActiveIRQ in_kernel) \<lbrace>valid_irq_states\<rbrace>"
+  unfolding getActiveIRQ_def by wpsimp
+
+crunch setVSpaceRoot, sfence, hwASIDFlush
+  for irq_masks[wp]: "\<lambda>s. P (irq_masks s)"
+
+crunch prepare_thread_delete, arch_finalise_cap, arch_post_cap_deletion
+  for valid_irq_states[wp]: "\<lambda>s :: det_state. valid_irq_states s"
+  (wp: crunch_wps mapM_x_wp hoare_drop_imps simp: crunch_simps)
+
+end
+
+
+global_interpretation ADT_IF_1?: ADT_IF_1
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (unfold valid_cur_hyp_def cur_hyp_in_cur_domain_def)?; (fact ADT_IF_assms | wpsimp)?)
+qed
+
+
+context Arch begin global_naming RISCV64
+
 (* FIXME: clagged from AInvs.do_user_op_invs *)
 lemma do_user_op_if_invs[ADT_IF_assms]:
   "\<lbrace>invs and ct_running\<rbrace>
@@ -100,14 +161,14 @@ lemma arch_invoke_irq_control_noErr[ADT_IF_assms, wp]:
   by (cases a; wpsimp)
 
 lemma getActiveIRQ_None[ADT_IF_assms]:
-  "(None,s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) s)  \<Longrightarrow>
+  "(None,s') \<in> fst (do_machine_op (getActiveIRQ False) s)  \<Longrightarrow>
    irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = None"
   apply (erule use_valid)
    apply (wp dmo_getActiveIRQ_wp)
   by simp
 
 lemma getActiveIRQ_Some[ADT_IF_assms]:
-  "(Some i, s') \<in> fst (do_machine_op (getActiveIRQ in_kernel) s)
+  "(Some i, s') \<in> fst (do_machine_op (getActiveIRQ False) s)
    \<Longrightarrow> irq_at (irq_state (machine_state s) + 1) (irq_masks (machine_state s)) = Some i"
   apply (erule use_valid)
    apply (wp dmo_getActiveIRQ_wp)
@@ -229,11 +290,18 @@ lemma do_user_op_if_irq_measure_if[ADT_IF_assms]:
          | wps |wp dmo_wp | wpc)+
   done
 
-crunch set_flags
+crunch set_flags, arch_post_set_flags
   for irq_states_of_state[wp]: "\<lambda>s. P (irq_state_of_state s)"
 
+lemma checked_cap_insert_valid_irq_states[wp]:
+  "check_cap_at a b (check_cap_at c d (cap_insert a b e)) \<lbrace>valid_irq_states\<rbrace>"
+  by (wpsimp simp: check_cap_at_def)+
+
+crunch set_mcpriority
+  for valid_irq_states[wp]: valid_irq_states
+
 lemma invoke_tcb_irq_state_inv[ADT_IF_assms]:
-  "\<lbrace>(\<lambda>s. irq_state_inv st s) and domain_sep_inv False sta
+  "\<lbrace>(\<lambda>s. irq_state_inv st s) and domain_sep_inv False (sta :: det_state) and valid_irq_states
                              and tcb_inv_wf tinv and K (irq_is_recurring irq st)\<rbrace>
    invoke_tcb tinv
    \<lbrace>\<lambda>_ s. irq_state_inv st s\<rbrace>, \<lbrace>\<lambda>_. irq_state_next st\<rbrace>"
@@ -246,7 +314,8 @@ lemma invoke_tcb_irq_state_inv[ADT_IF_assms]:
     defer
       apply ((wp irq_state_inv_triv | simp)+)[2]
     apply (simp add: split_def cong: option.case_cong)
-  by (wp hoare_vcg_all_liftE_R hoare_vcg_all_lift hoare_vcg_const_imp_liftE_R
+ by (clarsimp split del: if_split cong: conj_cong
+     | wp hoare_vcg_all_liftE_R hoare_vcg_all_lift hoare_vcg_const_imp_liftE_R
          checked_cap_insert_domain_sep_inv cap_delete_deletes
          cap_delete_irq_state_inv[where st=st and sta=sta and irq=irq]
          cap_delete_irq_state_next[where st=st and sta=sta and irq=irq]
@@ -258,19 +327,33 @@ lemma invoke_tcb_irq_state_inv[ADT_IF_assms]:
       | wp (once) irq_state_inv_triv hoare_drop_imps
       | clarsimp split: option.splits | intro impI conjI allI)+
 
+crunch freeMemory
+  for irq_masks[wp]: "\<lambda>s. P (irq_masks s)"
+  (wp: mapM_x_wp)
+
+lemma valid_irq_states_kheap_update[simp]:
+  "valid_irq_states (kheap_update f s) = valid_irq_states s"
+  by (simp add: valid_irq_states_def)
+
+crunch delete_objects
+  for valid_irq_states[wp]: valid_irq_states
+  (wp: dmo_machine_state_lift simp: crunch_simps detype_def)
+
 lemma reset_untyped_cap_irq_state_inv[ADT_IF_assms]:
-  "\<lbrace>irq_state_inv st and K (irq_is_recurring irq st)\<rbrace>
+  "\<lbrace>irq_state_inv st and domain_sep_inv False (sta :: det_state) and valid_irq_states and K (irq_is_recurring irq st)\<rbrace>
    reset_untyped_cap slot
    \<lbrace>\<lambda>y. irq_state_inv st\<rbrace>, \<lbrace>\<lambda>y. irq_state_next st\<rbrace>"
   apply (cases "irq_is_recurring irq st", simp_all)
   apply (simp add: reset_untyped_cap_def)
   apply (rule hoare_pre)
-   apply (wp no_irq_clearMemory mapME_x_wp' hoare_vcg_const_imp_lift
-             get_cap_wp preemption_point_irq_state_inv'[where irq=irq]
-          | rule irq_state_inv_triv
-          | simp add: unless_def
-          | wp (once) dmo_wp)+
-  done
+  by (wp no_irq_clearMemory hoare_vcg_const_imp_lift set_cap_domain_sep_inv
+         hoare_post_addE[where Q'="domain_sep_inv False sta and valid_irq_states", OF mapME_x_wp']
+         get_cap_wp preemption_point_irq_state_inv'[where irq=irq]
+      | rule hoare_vcg_conj_lift
+      | rule irq_state_inv_triv
+      | simp add: unless_def
+      | wp (once) dmo_wp
+      | fastforce)+
 
 crunch
   handle_vm_fault, handle_hypervisor_fault
@@ -305,20 +388,41 @@ lemma thread_set_pas_refined[ADT_IF_assms]:
             thread_set_thread_st_auth_trivT[OF st]
             thread_set_thread_bound_ntfns_trivT[OF ntfn])+
 
+
+lemma thread_set_context_state_hyp_refs_of:
+  "thread_set (tcb_arch_update (arch_tcb_context_set ctxt)) t \<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>"
+  by (wpsimp simp: thread_set_def wp: set_object_wp )
+
+lemma thread_set_context_pas_refined[ADT_IF_assms]:
+  "thread_set (tcb_arch_update (arch_tcb_context_set ctxt)) t \<lbrace>pas_refined aag\<rbrace>"
+  unfolding pas_refined_def state_objs_to_policy_def
+  apply (rule hoare_weaken_pre)
+   apply (wpsimp wp: tcb_domain_map_wellformed_lift_strong thread_set_edomains)
+   apply (wps thread_set_state_vrefs thread_set_context_state_hyp_refs_of)
+   apply (rule hoare_lift_Pf2[where f="caps_of_state"])
+    apply (rule hoare_lift_Pf2[where f="thread_st_auth"])
+     apply (rule hoare_lift_Pf2[where f="thread_bound_ntfns"])
+      apply wp
+     apply (wpsimp wp: thread_set_thread_bound_ntfns_trivT )
+    apply (wpsimp wp: thread_set_thread_st_auth_trivT)
+   apply (wpsimp wp: thread_set_caps_of_state_trivial simp: ran_tcb_cap_cases)
+  apply simp
+  done
+
 end
 
 
-global_interpretation ADT_IF_1?: ADT_IF_1
+global_interpretation ADT_IF_2?: ADT_IF_2
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact ADT_IF_assms | wp init_arch_objects_inv)?)
+    by (unfold_locales; (fact ADT_IF_assms | wpsimp wp: init_arch_objects_inv)?)
 qed
 
 sublocale valid_initial_state \<subseteq> valid_initial_state?: ADT_valid_initial_state ..
 
 
-hide_fact ADT_IF_1.do_user_op_silc_inv
+hide_fact ADT_IF_2.do_user_op_silc_inv
 requalify_facts RISCV64.do_user_op_silc_inv
 declare do_user_op_silc_inv[wp]
 

--- a/proof/infoflow/RISCV64/ArchArch_IF.thy
+++ b/proof/infoflow/RISCV64/ArchArch_IF.thy
@@ -106,11 +106,10 @@ lemma store_word_offs_reads_respects[Arch_IF_assms]:
   apply (simp add: storeWord_def)
   apply (simp add: do_machine_op_bind)
   apply wp
-     apply (rule use_spec_ev)
-     apply (rule do_machine_op_spec_reads_respects)
+     apply (rule do_machine_op_reads_respects)
       apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def in_monad)
       apply (fastforce intro: equiv_forI elim: equiv_forE simp: upto.simps comp_def)
-     apply (rule use_spec_ev do_machine_op_spec_reads_respects assert_ev2
+     apply (rule do_machine_op_reads_respects assert_ev2
             | simp add: spec_equiv_valid_def | wp modify_wp)+
   done
 
@@ -137,17 +136,6 @@ lemma set_thread_state_globals_equiv[Arch_IF_assms]:
     apply (fastforce simp: valid_arch_state_def obj_at_def tcb_at_def2 get_tcb_def is_tcb_def
                      dest: get_tcb_SomeD valid_global_arch_objs_pt_at
                     split: option.splits kernel_object.splits)+
-  done
-
-lemma set_cap_globals_equiv''[Arch_IF_assms]:
-  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
-   set_cap cap p
-   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_cap_def
-  apply (simp only: split_def)
-  apply (wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
-  apply (fastforce simp: valid_arch_state_def obj_at_def is_tcb_def
-                   dest: valid_global_arch_objs_pt_at)+
   done
 
 lemma as_user_globals_equiv[Arch_IF_assms]:
@@ -180,7 +168,7 @@ global_interpretation Arch_IF_1?: Arch_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Arch_IF_assms)?)
+    by (unfold_locales; (fact Arch_IF_assms | solves simp)?)
 qed
 
 
@@ -397,9 +385,9 @@ lemma perform_page_invocation_reads_respects:
             perform_pg_inv_unmap_def perform_pg_inv_get_addr_def
   apply (rule equiv_valid_guard_imp)
    apply (wp dmo_mol_reads_respects mapM_x_ev'' store_pte_reads_respects set_cap_reads_respects
-             mapM_ev'' store_pte_reads_respects unmap_page_reads_respects  dmo_mol_2_reads_respects
+             mapM_ev'' store_pte_reads_respects unmap_page_reads_respects
              get_cap_rev set_mrs_reads_respects set_message_info_reads_respects
-          | simp add: sfence_def
+          | simp add: sfence_def dmo_distr
           | wpc | wp (once) hoare_drop_imps[where Q'="\<lambda>r s. r"])+
   apply (clarsimp simp: authorised_page_inv_def valid_page_inv_def)
   apply (auto simp: cte_wp_at_caps_of_state authorised_slots_def cap_links_asid_slot_def
@@ -815,14 +803,14 @@ lemma perform_pt_inv_map_globals_equiv:
    perform_pt_inv_map x11 x12 x13 x14
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding perform_pt_inv_map_def
-  by (wpsimp wp: store_pte_globals_equiv set_cap_globals_equiv'' simp: sfence_def)
+  by (wpsimp wp: store_pte_globals_equiv set_cap_globals_equiv simp: sfence_def)
 
 lemma perform_pt_inv_unmap_globals_equiv:
   "\<lbrace>invs and globals_equiv st and cte_wp_at ((=) (ArchObjectCap cap)) ct_slot\<rbrace>
    perform_pt_inv_unmap cap ct_slot
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding perform_pt_inv_unmap_def
-  apply (wpsimp wp: set_cap_globals_equiv'' mapM_x_swp_store_pte_globals_equiv)
+  apply (wpsimp wp: set_cap_globals_equiv mapM_x_swp_store_pte_globals_equiv)
      apply (strengthen invs_imps invs_valid_global_vspace_mappings)
      apply (clarsimp cong: conj_cong)
      apply (wpsimp wp: unmap_page_table_globals_equiv unmap_page_table_invs)
@@ -852,7 +840,7 @@ lemma perform_page_table_invocation_globals_equiv:
    perform_page_table_invocation pti
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding perform_page_table_invocation_def
-  apply (wpsimp wp: store_pte_globals_equiv set_cap_globals_equiv''
+  apply (wpsimp wp: store_pte_globals_equiv set_cap_globals_equiv
                     perform_pt_inv_map_globals_equiv
                     perform_pt_inv_unmap_globals_equiv)
   apply (case_tac pti; clarsimp simp: authorised_for_globals_page_table_inv_def valid_pti_def)
@@ -991,7 +979,7 @@ lemma perform_pg_inv_unmap_globals_equiv:
   unfolding perform_pg_inv_unmap_def
   apply (rule hoare_weaken_pre)
    apply (wp mapM_swp_store_pte_globals_equiv hoare_vcg_all_lift mapM_x_swp_store_pte_globals_equiv
-             set_cap_globals_equiv'' unmap_page_globals_equiv store_pte_globals_equiv
+             set_cap_globals_equiv unmap_page_globals_equiv store_pte_globals_equiv
              store_pte_globals_equiv hoare_weak_lift_imp set_message_info_globals_equiv
              unmap_page_valid_arch_state perform_pg_inv_get_addr_globals_equiv
           | wpc | simp add: do_machine_op_bind sfence_def)+
@@ -1008,7 +996,7 @@ lemma perform_pg_inv_map_globals_equiv:
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding perform_pg_inv_map_def
   by (wp mapM_swp_store_pte_globals_equiv hoare_vcg_all_lift mapM_x_swp_store_pte_globals_equiv
-         set_cap_globals_equiv'' unmap_page_globals_equiv store_pte_globals_equiv
+         set_cap_globals_equiv unmap_page_globals_equiv store_pte_globals_equiv
          store_pte_globals_equiv hoare_weak_lift_imp set_message_info_globals_equiv
          unmap_page_valid_arch_state perform_pg_inv_get_addr_globals_equiv
       | wpc | simp add: do_machine_op_bind sfence_def | fastforce)+
@@ -1052,7 +1040,7 @@ lemma perform_asid_control_invocation_globals_equiv:
   apply (rule hoare_pre)
    apply wpc
    apply (rename_tac word1 cslot_ptr1 cslot_ptr2 word2)
-   apply (wp modify_wp cap_insert_globals_equiv''
+   apply (wp modify_wp cap_insert_globals_equiv
              retype_region_ASIDPoolObj_globals_equiv[simplified]
              retype_region_invs_extras(5)[where sz=pageBits]
              retype_region_invs_extras(6)[where sz=pageBits]
@@ -1135,7 +1123,7 @@ lemma store_asid_pool_entry_globals_equiv:
    store_asid_pool_entry pool_ptr asid ptr
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding store_asid_pool_entry_def
-  by (wp modify_wp set_asid_pool_globals_equiv set_cap_globals_equiv'' get_cap_wp | wpc | simp)+
+  by (wp modify_wp set_asid_pool_globals_equiv set_cap_globals_equiv get_cap_wp | wpc | simp)+
 
 lemma perform_asid_pool_invocation_globals_equiv:
   "\<lbrace>globals_equiv s and invs and valid_apinv api\<rbrace>
@@ -1143,7 +1131,7 @@ lemma perform_asid_pool_invocation_globals_equiv:
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding perform_asid_pool_invocation_def
   apply (rule hoare_weaken_pre)
-   apply (wp modify_wp set_asid_pool_globals_equiv set_cap_globals_equiv''
+   apply (wp modify_wp set_asid_pool_globals_equiv set_cap_globals_equiv
              store_asid_pool_entry_globals_equiv copy_global_mappings_globals_equiv
              copy_global_mappings_valid_arch_state get_cap_wp
           | wpc | simp)+

--- a/proof/infoflow/RISCV64/ArchCNode_IF.thy
+++ b/proof/infoflow/RISCV64/ArchCNode_IF.thy
@@ -34,25 +34,15 @@ lemma set_object_globals_equiv'':
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   by (wpsimp wp: set_object_globals_equiv)
 
-lemma set_cap_globals_equiv':
-  "\<lbrace>globals_equiv s and (\<lambda> s. fst p \<noteq> riscv_global_pt (arch_state s))\<rbrace>
-   set_cap cap p
-   \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
-  unfolding set_cap_def
-  apply (simp only: split_def)
-  apply (wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
-  apply (fastforce simp: obj_at_def is_tcb_def)
-  done
-
 lemma set_cap_globals_equiv[CNode_IF_assms]:
-  "\<lbrace>globals_equiv s and valid_global_objs and valid_arch_state\<rbrace>
+  "\<lbrace>globals_equiv s and valid_arch_state\<rbrace>
    set_cap cap p
    \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
   unfolding set_cap_def
   apply (simp only: split_def)
   apply (wp set_object_globals_equiv hoare_vcg_all_lift get_object_wp | wpc | simp)+
-  apply (fastforce simp: is_tcb_def obj_at_def valid_arch_state_def
-                   dest: valid_global_arch_objs_pt_at)
+  apply (fastforce simp: valid_arch_state_def obj_at_def is_tcb_def
+                   dest: valid_global_arch_objs_pt_at)+
   done
 
 definition irq_at :: "nat \<Rightarrow> (irq \<Rightarrow> bool) \<Rightarrow> irq option" where
@@ -124,14 +114,22 @@ lemma dmo_getActiveIRQ_reads_respects[CNode_IF_assms]:
   notes gets_ev[wp del]
   shows "reads_respects aag l (invs and only_timer_irq_inv irq st)
                        (do_machine_op (getActiveIRQ in_kernel))"
-  apply (rule use_spec_ev)
-  apply (rule do_machine_op_spec_reads_respects')
+  apply (rule do_machine_op_reads_respects')
    apply (simp add: getActiveIRQ_def)
    apply (wp irq_state_increment_reads_respects_memory irq_state_increment_reads_respects_device
              gets_ev[where f="irq_oracle \<circ> irq_state"] equiv_valid_inv_conj_lift
              gets_irq_masks_equiv_valid modify_wp
           | simp add: no_irq_def)+
   apply (rule only_timer_irq_inv_determines_irq_masks, blast+)
+  done
+
+lemma dmo_getActiveIRQ_globals_equiv[CNode_IF_assms]:
+  "do_machine_op (getActiveIRQ in_kernel) \<lbrace>globals_equiv st\<rbrace>"
+  unfolding globals_equiv_def arch_globals_equiv_def idle_equiv_def
+  apply (rule hoare_weaken_pre)
+   apply wps
+   apply wpsimp
+  apply clarsimp
   done
 
 end

--- a/proof/infoflow/RISCV64/ArchFinalCaps.thy
+++ b/proof/infoflow/RISCV64/ArchFinalCaps.thy
@@ -315,6 +315,10 @@ lemma invoke_tcb_silc_inv[FinalCaps_assms]:
                        authorised_tcb_inv_def emptyable_def
                  split: cap.splits option.splits)+
 
+lemma handle_reserved_irq_non_kernel_IRQs[FinalCaps_assms]:
+  "\<lbrace>P and K (irq \<notin> non_kernel_IRQs)\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_. P\<rbrace>"
+  unfolding handle_reserved_irq_def by wpsimp
+
 end
 
 
@@ -323,6 +327,14 @@ proof goal_cases
   interpret Arch .
   case 1 show ?case
     by (unfold_locales; (fact FinalCaps_assms)?)
+qed
+
+
+global_interpretation FinalCaps_3?: FinalCaps_3
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact FinalCaps_assms | wpsimp)?)
 qed
 
 end

--- a/proof/infoflow/RISCV64/ArchFinalise_IF.thy
+++ b/proof/infoflow/RISCV64/ArchFinalise_IF.thy
@@ -19,8 +19,7 @@ crunch arch_post_cap_deletion
 lemma dmo_maskInterrupt_reads_respects[Finalise_IF_assms]:
   "reads_respects aag l \<top> (do_machine_op (maskInterrupt m irq))"
   unfolding maskInterrupt_def
-  apply (rule use_spec_ev)
-  apply (rule do_machine_op_spec_reads_respects)
+  apply (rule do_machine_op_reads_respects)
    apply (simp add: equiv_valid_def2)
    apply (rule modify_ev2)
    apply (fastforce simp: equiv_for_def)
@@ -165,21 +164,15 @@ lemma set_notification_equiv_but_for_labels[Finalise_IF_assms]:
   done
 
 lemma thread_set_reads_respects[Finalise_IF_assms]:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "reads_respects aag l \<top> (thread_set x y)"
-  unfolding thread_set_def fun_app_def
-  apply (case_tac "aag_can_read aag y \<or> aag_can_affect aag l y")
-   apply (wp set_object_reads_respects)
-   apply (clarsimp, rule reads_affects_equiv_get_tcb_eq, simp+)[1]
-  apply (simp add: equiv_valid_def2)
-  apply (rule equiv_valid_rv_guard_imp)
-   apply (rule_tac L="{pasObjectAbs aag y}" and L'="{pasObjectAbs aag y}"
-                in ev2_invisible[OF domains_distinct])
-       apply (assumption | simp add: labels_are_invisible_def)+
-     apply (rule modifies_at_mostI[where P="\<top>"]
-            | wp set_object_equiv_but_for_labels
-            | simp
-            | (clarify, drule get_tcb_not_asid_pool_at))+
+  "reads_respects aag l \<top> (thread_set f thread)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule_tac ptr=thread in reads_respects_unit_cases)
+  unfolding thread_set_def
+     apply (wpsimp wp: set_object_reads_respects)
+    apply (wpsimp wp: set_object_equiv_but_for_labels)
+    apply (clarsimp simp: get_tcb_def obj_at_def)
+   apply wpsimp+
+  apply (auto intro: reads_affects_equiv_get_tcb_eq)
   done
 
 lemma aag_cap_auth_ASIDPoolCap:
@@ -356,7 +349,7 @@ global_interpretation Finalise_IF_1?: Finalise_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Finalise_IF_assms)?)
+    by (unfold_locales; (fact Finalise_IF_assms | wpsimp wp: Finalise_IF_assms)?)
 qed
 
 end

--- a/proof/infoflow/RISCV64/ArchIRQMasks_IF.thy
+++ b/proof/infoflow/RISCV64/ArchIRQMasks_IF.thy
@@ -158,6 +158,9 @@ lemma init_arch_objects_irq_masks:
 crunch arch_prepare_set_domain
   for inv[IRQMasks_IF_assms,wp]: P
 
+crunch arch_prepare_next_domain
+  for valid_irq_states[wp]: valid_irq_states
+
 end
 
 
@@ -165,7 +168,7 @@ global_interpretation IRQMasks_IF_2?: IRQMasks_IF_2
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact IRQMasks_IF_assms)?)
+    by (unfold_locales; (fact IRQMasks_IF_assms | solves wpsimp)?)
 qed
 
 

--- a/proof/infoflow/RISCV64/ArchInfoFlow.thy
+++ b/proof/infoflow/RISCV64/ArchInfoFlow.thy
@@ -10,6 +10,8 @@ imports
   "Lib.EquivValid"
 begin
 
+consts equiv_for :: "('a \<Rightarrow> bool) \<Rightarrow> ('b \<Rightarrow> 'a \<Rightarrow> 'c) \<Rightarrow> 'b \<Rightarrow> 'b \<Rightarrow> bool"
+
 context Arch begin global_naming RISCV64
 
 section \<open>Arch-specific equivalence properties\<close>
@@ -61,6 +63,12 @@ definition arch_globals_equiv :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kh
      kh (riscv_global_pt as) = kh' (riscv_global_pt as)"
 
 declare arch_globals_equiv_def[simp]
+
+definition equiv_hyp :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "equiv_hyp P s s' \<equiv> True"
+
+definition equiv_fpu :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> bool" where
+  "equiv_fpu P s s' \<equiv> True"
 
 end
 

--- a/proof/infoflow/RISCV64/ArchInfoFlow_IF.thy
+++ b/proof/infoflow/RISCV64/ArchInfoFlow_IF.thy
@@ -83,6 +83,70 @@ lemma equiv_asids_guard_imp[InfoFlow_IF_assms]:
   "\<lbrakk> equiv_asids R s s'; \<And>x. Q x \<Longrightarrow> R x \<rbrakk> \<Longrightarrow> equiv_asids Q s s'"
   by (auto simp: equiv_asids_def)
 
+
+definition identical_hyp_state_updates :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> machine_state \<Rightarrow> machine_state \<Rightarrow> bool" where
+  "identical_hyp_state_updates _ _ _ _ _ \<equiv> True"
+
+definition identical_fpu_state_updates :: "(obj_ref \<Rightarrow> bool) \<Rightarrow> det_state \<Rightarrow> det_state \<Rightarrow> machine_state \<Rightarrow> machine_state \<Rightarrow> bool" where
+  "identical_fpu_state_updates _ _ _ _ _ \<equiv> True"
+
+definition no_hyp :: "'m machine_monad \<Rightarrow> bool" where
+  "no_hyp f \<equiv> True"
+
+definition no_fpu :: "'m machine_monad \<Rightarrow> bool" where
+  "no_fpu f \<equiv> True"
+
+lemma equiv_hyp_dummy[intro!,simp]:
+  "equiv_hyp P s s'"
+  by (simp add: equiv_hyp_def)
+
+lemma equiv_fpu_dummy[intro!,simp]:
+  "equiv_fpu P s s'"
+  by (simp add: equiv_fpu_def)
+
+lemma identical_hyp_states_updates_dummy[intro!,simp]:
+  "identical_hyp_state_updates P s s' ms ms'"
+  by (simp add: identical_hyp_state_updates_def)
+
+lemma identical_fpu_states_updates_dummy[intro!,simp]:
+  "identical_fpu_state_updates P s s' ms ms'"
+  by (simp add: identical_fpu_state_updates_def)
+
+lemma no_hyp_dummy[intro!,simp]:
+  "no_hyp f"
+  by (simp add: no_hyp_def)
+
+lemma no_fpu_dummy[intro!,simp]:
+  "no_fpu f"
+  by (simp add: no_fpu_def)
+
+lemmas equiv_arch_dummy =
+  equiv_hyp_dummy
+  equiv_fpu_dummy
+  identical_hyp_states_updates_dummy
+  identical_fpu_states_updates_dummy
+  no_hyp_dummy
+  no_fpu_dummy
+
+end
+
+arch_requalify_consts
+  identical_hyp_state_updates
+  identical_fpu_state_updates
+  no_hyp
+  no_fpu
+
+
+global_interpretation InfoFlow_IF_1?: InfoFlow_IF_1 identical_hyp_state_updates identical_fpu_state_updates
+proof goal_cases
+  interpret Arch .
+  case 1 show ?case
+    by (unfold_locales; (fact InfoFlow_IF_assms | solves \<open>rule equiv_arch_dummy\<close>)?)
+qed
+
+
+context Arch begin arch_global_naming
+
 lemma dmo_loadWord_rev[InfoFlow_IF_assms]:
   "reads_equiv_valid_inv A aag (K (for_each_byte_of_word (aag_can_read aag) p))
                                (do_machine_op (loadWord p))"
@@ -109,14 +173,45 @@ lemma dmo_loadWord_rev[InfoFlow_IF_assms]:
       apply (wp wp_post_taut loadWord_inv | simp)+
   done
 
+lemma do_machine_op_reads_respects'[InfoFlow_IF_assms]:
+  assumes equiv_dmo:
+   "equiv_valid_inv (equiv_machine_state (aag_can_read aag) and equiv_irq_state)
+                    (equiv_machine_state (aag_can_affect aag l)) Q f"
+  assumes guard:
+    "\<And>s. P s \<Longrightarrow> Q (machine_state s)"
+  and no_hyp: "no_hyp f"
+  and no_fpu: "no_fpu f"
+  shows
+  "reads_respects aag l P (do_machine_op f)"
+  apply (rule use_spec_ev)
+  unfolding do_machine_op_def spec_equiv_valid_def
+  apply (rule equiv_valid_2_guard_imp)
+   apply (rule_tac  R'="\<lambda> rv rv'. equiv_machine_state (aag_can_read aag or aag_can_affect aag l) rv rv' \<and> equiv_irq_state rv rv'" and Q="\<lambda> r s. st = s \<and> Q r" and Q'="\<lambda> r s. Q r" and P="(=) st" and P'="\<top>" in equiv_valid_2_bind)
+       apply (rule gen_asm_ev2_l[simplified K_def pred_conj_def])
+       apply (rule gen_asm_ev2_r')
+       apply (rule_tac R'="\<lambda> (r, ms') (r', ms'').  r = r' \<and> equiv_machine_state (aag_can_read aag)  ms' ms'' \<and> equiv_machine_state (aag_can_affect aag l) ms' ms'' \<and> equiv_irq_state ms' ms''" and Q="\<lambda> r s. st = s" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
+            apply (clarsimp simp: modify_def get_def put_def bind_def return_def equiv_valid_2_def)
+            apply (fastforce intro: reads_equiv_machine_state_update affects_equiv_machine_state_update)
+            apply (insert equiv_dmo)[1]
+           apply (clarsimp simp: select_f_def equiv_valid_2_def equiv_valid_def2 equiv_for_or simp: split_def split: prod.splits simp: equiv_for_def)[1]
+           apply (drule_tac x=rv in spec, drule_tac x=rv' in spec)
+           apply (fastforce)
+          apply (rule select_f_inv)
+         apply (rule wp_post_taut)
+        apply simp+
+      apply (clarsimp simp: equiv_valid_2_def in_monad)
+      apply (fastforce elim: reads_equivE affects_equivE equiv_forE intro: equiv_forI)
+     apply (wp | simp add: guard)+
+  done
+
 end
 
 
-global_interpretation InfoFlow_IF_1?: InfoFlow_IF_1
+global_interpretation InfoFlow_IF_1?: InfoFlow_IF_2 identical_hyp_state_updates identical_fpu_state_updates no_hyp no_fpu
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact InfoFlow_IF_assms)?)
+    by (unfold_locales; (fact InfoFlow_IF_assms | solves \<open>rule equiv_arch_dummy\<close>)?)
 qed
 
 end

--- a/proof/infoflow/RISCV64/ArchInterrupt_IF.thy
+++ b/proof/infoflow/RISCV64/ArchInterrupt_IF.thy
@@ -29,13 +29,13 @@ lemma arch_invoke_irq_control_reads_respects[Interrupt_IF_assms]:
   done
 
 lemma arch_invoke_irq_control_globals_equiv[Interrupt_IF_assms]:
-  "\<lbrace>globals_equiv st and valid_arch_state and valid_global_objs\<rbrace>
+  "\<lbrace>globals_equiv st and valid_arch_state\<rbrace>
    arch_invoke_irq_control ai
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   apply (induct ai)
   apply (simp add: setIRQTrigger_def)
   apply (wpsimp wp: set_irq_state_globals_equiv set_irq_state_valid_global_objs
-                    cap_insert_globals_equiv'' dmo_mol_globals_equiv)
+                    cap_insert_globals_equiv dmo_mol_globals_equiv)
   done
 
 lemma arch_invoke_irq_handler_globals_equiv[Interrupt_IF_assms, wp]:

--- a/proof/infoflow/RISCV64/ArchIpc_IF.thy
+++ b/proof/infoflow/RISCV64/ArchIpc_IF.thy
@@ -36,24 +36,25 @@ lemma storeWord_equiv_but_for_labels[Ipc_IF_assms]:
   apply (wp modify_wp)
   apply (clarsimp simp: equiv_but_for_labels_def)
   apply (rule states_equiv_forI)
-          apply (fastforce intro!: equiv_forI elim!: states_equiv_forE dest: equiv_forD)
-         apply (simp add: states_equiv_for_def)
-         apply (rule conjI)
-          apply (rule equiv_forI)
-          apply clarsimp
-          apply (drule_tac f=underlying_memory in equiv_forD,fastforce)
-          apply (fastforce intro: is_aligned_no_wrap' word_plus_mono_right
-                            simp: is_aligned_mask for_each_byte_of_word_def word_size_def upto.simps)
-         apply (rule equiv_forI)
-         apply clarsimp
-         apply (drule_tac f=device_state in equiv_forD,fastforce)
-         apply clarsimp
-        apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt])
-       apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt_list])
-      apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=is_original_cap])
-     apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_states])
-    apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_irq_node])
-   apply (fastforce simp: equiv_asids_def equiv_asid_def elim: states_equiv_forE)
+            apply (fastforce intro!: equiv_forI elim!: states_equiv_forE dest: equiv_forD)
+           apply (simp add: states_equiv_for_def)
+           apply (rule conjI)
+            apply (rule equiv_forI)
+            apply clarsimp
+            apply (drule_tac f=underlying_memory in equiv_forD,fastforce)
+            apply (fastforce intro: is_aligned_no_wrap' word_plus_mono_right
+                              simp: is_aligned_mask for_each_byte_of_word_def word_size_def upto.simps)
+           apply (rule equiv_forI)
+           apply clarsimp
+           apply (drule_tac f=device_state in equiv_forD,fastforce)
+           apply clarsimp
+          apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt])
+         apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=cdt_list])
+        apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=is_original_cap])
+       apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_states])
+      apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=interrupt_irq_node])
+     apply (fastforce simp: equiv_asids_def equiv_asid_def elim: states_equiv_forE)
+    apply auto[2]
   apply (fastforce elim: states_equiv_forE intro: equiv_forI dest: equiv_forD[where f=ready_queues])
   done
 
@@ -202,24 +203,22 @@ lemma dmo_loadWord_reads_respects[Ipc_IF_assms]:
   "reads_respects aag l (K (for_each_byte_of_word (\<lambda> x. aag_can_read_or_affect aag l x) p))
                   (do_machine_op (loadWord p))"
   apply (rule gen_asm_ev)
-  apply (rule use_spec_ev)
-  apply (rule spec_equiv_valid_hoist_guard)
-  apply (rule do_machine_op_spec_reads_respects)
-   apply (simp add: loadWord_def equiv_valid_def2 spec_equiv_valid_def)
-   apply (rule_tac R'="\<lambda>rv rv'. for_each_byte_of_word (\<lambda>y. rv y = rv' y) p"
-               and Q="\<top>\<top>" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
-        apply (rule_tac R'="(=)" and Q="\<lambda> r s. p && mask 3 = 0" and Q'="\<lambda> r s. p && mask 3 = 0"
-                    and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
-             apply (rule return_ev2)
-             apply (rule_tac f="word_rcat" in arg_cong)
-             apply (fastforce simp: upto.simps is_aligned_mask for_each_byte_of_word_def word_size_def
-                             intro: is_aligned_no_wrap' word_plus_mono_right)
-            apply (rule assert_ev2[OF refl])
-           apply (rule assert_wp)+
-         apply simp+
-       apply (clarsimp simp: equiv_valid_2_def in_monad for_each_byte_of_word_def)
-       apply (fastforce elim: equiv_forD orthD1 simp: ptr_range_def add.commute)
-      apply (wp wp_post_taut loadWord_inv | simp)+
+  apply (rule do_machine_op_reads_respects)
+     apply (simp add: loadWord_def equiv_valid_def2 spec_equiv_valid_def)
+     apply (rule_tac R'="\<lambda>rv rv'. for_each_byte_of_word (\<lambda>y. rv y = rv' y) p"
+                 and Q="\<top>\<top>" and Q'="\<top>\<top>" and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
+          apply (rule_tac R'="(=)" and Q="\<lambda> r s. p && mask 3 = 0" and Q'="\<lambda> r s. p && mask 3 = 0"
+                      and P="\<top>" and P'="\<top>" in equiv_valid_2_bind_pre)
+               apply (rule return_ev2)
+               apply (rule_tac f="word_rcat" in arg_cong)
+               apply (fastforce simp: upto.simps is_aligned_mask for_each_byte_of_word_def word_size_def
+                               intro: is_aligned_no_wrap' word_plus_mono_right)
+              apply (rule assert_ev2[OF refl])
+             apply (rule assert_wp)+
+           apply simp+
+         apply (clarsimp simp: equiv_valid_2_def in_monad for_each_byte_of_word_def)
+         apply (fastforce elim: equiv_forD orthD1 simp: ptr_range_def add.commute)
+        apply (wp wp_post_taut loadWord_inv | simp)+
   done
 
 lemma complete_signal_reads_respects[Ipc_IF_assms]:
@@ -287,7 +286,7 @@ global_interpretation Ipc_IF_1?: Ipc_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Ipc_IF_assms)?)
+    by (unfold_locales; (fact Ipc_IF_assms | wpsimp wp: Ipc_IF_assms)?)
 qed
 
 
@@ -441,7 +440,7 @@ lemma set_mrs_reads_respects'[Ipc_IF_assms]:
   apply (simp add: equiv_valid_def2)
   apply (rule equiv_valid_rv_guard_imp)
    apply (case_tac buf)
-    apply (rule_tac Q="\<top>" and P="\<top>" and L="{pasObjectAbs aag thread}" in ev_invisible[OF domains_distinct])
+    apply (rule_tac Q="\<top>" and P="\<top>" and L="{pasObjectAbs aag thread}" in revrv_invisible[OF domains_distinct])
       apply (clarsimp simp: labels_are_invisible_def)
      apply (rule modifies_at_mostI)
      apply (simp add: set_mrs_def)
@@ -451,7 +450,7 @@ lemma set_mrs_reads_respects'[Ipc_IF_assms]:
    apply (rename_tac buf')
    apply (rule_tac Q="\<top>" and L="{pasObjectAbs aag thread} \<union> (pasObjectAbs aag)
                                  ` (ptr_range buf' msg_align_bits)"
-                in ev_invisible[OF domains_distinct])
+                in revrv_invisible[OF domains_distinct])
      apply (auto simp: labels_are_invisible_def ipc_buffer_has_auth_def
                  dest: reads_read_page_read_thread simp: aag_can_affect_label_def)[1]
     apply (rule modifies_at_mostI)

--- a/proof/infoflow/RISCV64/ArchNoninterference.thy
+++ b/proof/infoflow/RISCV64/ArchNoninterference.thy
@@ -285,8 +285,10 @@ lemma dmo_storeWord_reads_respects_g[Noninterference_assms, wp]:
                            equiv_for_def equiv_asids_def equiv_asid_def silc_dom_equiv_def upto.simps)
    apply (rule affects_equiv_machine_state_update, assumption)
    apply (fastforce simp: equiv_for_def affects_equiv_def states_equiv_for_def upto.simps)
+    apply auto[2]
   apply (simp add: equiv_valid_def2 equiv_valid_2_def)
   done
+
 
 lemma set_vm_root_reads_respects:
   "reads_respects aag l \<top> (set_vm_root tcb)"
@@ -399,6 +401,56 @@ lemma arch_tcb_get_registers_equality[Noninterference_assms]:
    \<Longrightarrow> tcb_arch tcb = tcb_arch tcb'"
   by (auto simp: arch_tcb_get_registers_def intro: arch_tcb.equality user_context.expand)
 
+lemma getActiveIRQ_ev2[Noninterference_assms]:
+  "equiv_valid_2 (scheduler_equiv aag)
+                 (scheduler_affects_equiv aag l) (scheduler_affects_equiv aag l)
+                 (\<lambda>irq irq'. irq = irq' \<or> irq = None \<and> irq' \<in> Some ` non_kernel_IRQs)
+                 (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+                 (\<lambda>s. irq_masks_of_state st = irq_masks_of_state s)
+   (do_machine_op (getActiveIRQ True)) (do_machine_op (getActiveIRQ False))"
+  apply (simp add: getActiveIRQ_no_non_kernel_IRQs)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  apply (erule use_valid, rule dmo_getActiveIRQ_wp)+
+  apply clarsimp
+  apply (clarsimp simp: scheduler_equiv_def irq_at_def Let_def)
+   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
+                         silc_dom_equiv_def equiv_for_def)
+  apply (clarsimp simp: scheduler_affects_equiv_def)
+  apply (intro conjI impI)
+    apply (clarsimp simp: states_equiv_for_def equiv_for_def equiv_asids_def)
+   apply (clarsimp simp: scheduler_globals_frame_equiv_def)
+  apply (clarsimp simp: arch_scheduler_affects_equiv_def)
+  done
+
+lemma arch_prepare_next_domain_reads_respects_g[Noninterference_assms]:
+  "reads_respects_g aag l invs arch_prepare_next_domain"
+  unfolding arch_prepare_next_domain_def by wpsimp
+
+lemma partitionIntegrity_subjectAffects_tcb_fpu[Noninterference_assms]:
+  assumes par_inte: "partitionIntegrity aag s s'"
+  and "kheap s x = Some (TCB tcb)"
+      "kheap s' x = Some (TCB tcb')"
+      "tcb' = tcb\<lparr>tcb_arch := new_arch\<rparr>"
+      "arch_tcb_get_registers new_arch = arch_tcb_get_registers (tcb_arch tcb)"
+      "tcb_hyp_refs new_arch = tcb_hyp_refs (tcb_arch tcb)"
+      "kheap s x \<noteq> kheap s' x"
+      "silc_inv aag st s"
+      "pas_wellformed_noninterference aag"
+      "pas_refined aag s" "pas_refined aag s'"
+      "pas_cur_domain aag s" "pas_cur_domain aag s'"
+      "cur_fpu_in_cur_domain s" "cur_fpu_in_cur_domain s'"
+      "invs s" "invs s'"
+  notes inte_obj = par_inte[THEN partitionIntegrity_integrity, THEN integrity_subjects_obj,
+                            THEN spec[where x=x], simplified integrity_obj_def, simplified]
+  shows "subject_can_affect_label_directly aag (pasObjectAbs aag x)"
+  apply (insert assms(2,3,4,5,7))
+  apply (clarsimp simp: arch_tcb_get_registers_def)
+  apply (subgoal_tac "new_arch = tcb_arch tcb")
+   apply clarsimp
+  apply (rule arch_tcb.equality; clarsimp?)
+  apply (rule user_context.expand; clarsimp)
+  done
+
 end
 
 
@@ -410,7 +462,7 @@ global_interpretation Noninterference_1?: Noninterference_1 _ arch_globals_equiv
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Noninterference_assms | solves \<open>rule integrity_arch_triv\<close>)?)
+    by (unfold_locales; (fact Noninterference_assms | solves \<open>wpsimp wp: Noninterference_assms\<close> | solves \<open>rule integrity_arch_triv\<close>)?)
 qed
 
 

--- a/proof/infoflow/RISCV64/ArchRetype_IF.thy
+++ b/proof/infoflow/RISCV64/ArchRetype_IF.thy
@@ -167,7 +167,8 @@ lemma copy_global_mappings_reads_respects_g:
                             pspace_aligned s \<and> valid_global_arch_objs s" in hoare_weaken_pre)
       apply (rule gets_sp)
      apply (assumption)
-    apply (wp mapM_x_ev store_pte_reads_respects_g get_pte_revg)
+    apply (rule mapM_x_ev)
+    apply (wp store_pte_reads_respects_g get_pte_revg)
      apply (simp only: pt_index_def)
      apply (subst table_base_offset_id)
        apply clarsimp
@@ -352,7 +353,7 @@ global_interpretation Retype_IF_1?: Retype_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Retype_IF_assms)?)
+    by (unfold_locales; (fact Retype_IF_assms | solves wpsimp)?)
 qed
 
 
@@ -423,7 +424,6 @@ lemma reset_untyped_cap_reads_respects_g:
         apply (clarsimp simp: valid_cap_simps cap_aligned_def field_simps
                               free_index_of_def invs_valid_global_objs)
        apply (simp add: aligned_add_aligned is_aligned_shiftl)
-       apply (clarsimp simp: Kernel_Config.resetChunkBits_def)
        apply (rule hoare_pre)
         apply (wp preemption_point_inv' set_untyped_cap_invs_simple set_cap_cte_wp_at
                   set_cap_no_overlap only_timer_irq_inv_pres[where Q=\<top>, OF _ set_cap_domain_sep_inv]
@@ -619,7 +619,6 @@ lemma reset_untyped_cap_globals_equiv:
                  preemption_point_inv | simp add: if_apply_def2)+
     apply (clarsimp simp: is_cap_simps ptr_range_def[symmetric]
                           cap_aligned_def bits_of_def free_index_of_def)
-    apply (clarsimp simp: Kernel_Config.resetChunkBits_def)
     apply (strengthen invs_valid_global_objs invs_arch_state)
     apply (wp delete_objects_invs_ex hoare_vcg_const_imp_lift get_cap_wp)+
   apply (clarsimp simp: cte_wp_at_caps_of_state descendants_range_def2 is_cap_simps bits_of_def

--- a/proof/infoflow/RISCV64/ArchScheduler_IF.thy
+++ b/proof/infoflow/RISCV64/ArchScheduler_IF.thy
@@ -143,7 +143,7 @@ global_interpretation Scheduler_IF_1?:
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Scheduler_IF_assms)?)
+    by (unfold_locales; (fact Scheduler_IF_assms | wpsimp)?)
 qed
 
 
@@ -215,8 +215,8 @@ lemma store_cur_thread_fragment_midstrength_reads_respects:
                  simp del: split_paired_All)
   done
 
-lemma arch_switch_to_thread_globals_equiv_scheduler':
-  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
+lemma set_vm_root_globals_equiv_scheduler:
+  "\<lbrace>valid_arch_state and globals_equiv_scheduler sta\<rbrace>
    set_vm_root t
    \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
   by (rule globals_equiv_scheduler_inv', wpsimp)
@@ -263,11 +263,11 @@ lemma arch_switch_to_thread_midstrength_reads_respects_scheduler[Scheduler_IF_as
   done
 
 lemma arch_switch_to_idle_thread_globals_equiv_scheduler[Scheduler_IF_assms, wp]:
-  "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
+  "\<lbrace>valid_arch_state and globals_equiv_scheduler sta\<rbrace>
    arch_switch_to_idle_thread
    \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
   unfolding arch_switch_to_idle_thread_def storeWord_def
-  by (wp dmo_wp modify_wp thread_get_wp' arch_switch_to_thread_globals_equiv_scheduler')
+  by (wp dmo_wp modify_wp thread_get_wp' set_vm_root_globals_equiv_scheduler)
 
 lemma arch_switch_to_idle_thread_unobservable[Scheduler_IF_assms]:
   "\<lbrace>(\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l = {}) and
@@ -302,6 +302,19 @@ lemma next_domain_midstrength_equiv_scheduler[Scheduler_IF_assms]:
                         globals_equiv_scheduler_def silc_dom_equiv_def domain_fields_equiv_def
                         weak_scheduler_affects_equiv_def midstrength_scheduler_affects_equiv_def
                         states_equiv_for_def idle_equiv_def)
+  done
+
+lemma arch_switch_to_idle_thread_midstrength_reads_respects[Scheduler_IF_assms]:
+  "equiv_valid_inv (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+                   (valid_arch_state and valid_silc_label aag) arch_switch_to_idle_thread"
+  apply (rule equiv_valid_inv_unobservable)
+   apply (rule hoare_pre)
+           apply (rule scheduler_equiv_lift')
+            apply (wpsimp wp: silc_dom_lift)+
+      apply assumption
+ apply (wp midstrength_scheduler_affects_equiv_unobservable
+                | simp | wps)+
+    apply (auto simp: scheduler_equiv_sym midstrength_scheduler_affects_equiv_sym)
   done
 
 lemma resetTimer_irq_state[wp]:
@@ -365,6 +378,32 @@ lemma thread_set_scheduler_affects_equiv[Scheduler_IF_assms, wp]:
             apply simp+
   done
 
+lemma thread_set_reads_respects_scheduler[Scheduler_IF_assms]:
+  "reads_respects_scheduler aag l (valid_arch_state and K (valid_tcb_context_update f))
+                                  (thread_set f t)"
+  apply (rule gen_asm_ev)
+  apply (clarsimp simp: equiv_valid_def2 equiv_valid_2_def)
+  unfolding thread_set_def gets_the_def gets_def get_def return_def assert_opt_def fail_def set_object_def get_object_def assert_def put_def
+  apply (clarsimp simp: bind_def split: option.splits if_splits)
+  apply (clarsimp simp: get_tcb_ko_at obj_at_def)
+  unfolding valid_tcb_context_update_def
+  apply (rename_tac s' tcb tcb')
+  apply (erule_tac x=tcb in allE)
+  apply (erule_tac x=tcb' in allE)
+  apply (rule conjI)
+   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def)
+   apply (intro conjI)
+     apply (clarsimp simp: valid_global_arch_objs_def arch_globals_equiv_scheduler_def)
+    apply (clarsimp simp: idle_equiv_def tcb_at_def get_tcb_def arch_tcb_context_get_def)
+   apply (clarsimp simp: silc_dom_equiv_def equiv_for_def)
+  apply (clarsimp simp: scheduler_affects_equiv_def)
+  apply (intro conjI)
+  apply (clarsimp simp: states_equiv_for_def equiv_for_def)
+  apply (intro conjI; clarsimp?)
+    apply (clarsimp simp: equiv_asids_def equiv_asid_def obj_at_def)
+  apply (clarsimp simp: scheduler_globals_frame_equiv_def arch_scheduler_affects_equiv_def)
+  done
+
 lemma set_object_reads_respects_scheduler[Scheduler_IF_assms, wp]:
   "reads_respects_scheduler aag l \<top> (set_object ptr obj)"
   unfolding equiv_valid_def2 equiv_valid_2_def
@@ -383,15 +422,50 @@ lemma arch_prepare_next_domain_ev[Scheduler_IF_assms]:
   "equiv_valid_inv I A (\<lambda>_. True) arch_prepare_next_domain"
   unfolding arch_prepare_next_domain_def by wp
 
+lemma arch_switch_to_thread_silc_dom_equiv[wp]:
+  "arch_switch_to_thread t \<lbrace>silc_dom_equiv aag (st :: det_state)\<rbrace>"
+  by (wpsimp wp: silc_dom_lift)
+
+lemma arch_switch_to_idle_thread_silc_dom_equiv[wp]:
+  "arch_switch_to_idle_thread \<lbrace>silc_dom_equiv aag (st :: det_state)\<rbrace>"
+  by (wpsimp wp: silc_dom_lift)
+
+
+definition cur_hyp_in_cur_domain :: "det_state \<Rightarrow> bool" where
+  "cur_hyp_in_cur_domain s \<equiv> True"
+
+definition cur_fpu_in_cur_domain :: "det_state \<Rightarrow> bool" where
+  "cur_fpu_in_cur_domain s \<equiv> True"
+
+lemma cur_hyp_in_cur_domain_dummy[intro!,simp]:
+  "cur_hyp_in_cur_domain s"
+  by (simp add: cur_hyp_in_cur_domain_def)
+
+lemma cur_fpu_in_cur_domain_dummy[intro!,simp]:
+  "cur_fpu_in_cur_domain s"
+  by (simp add: cur_fpu_in_cur_domain_def)
+
+lemma cur_hyp_in_cur_domain_wp[wp]:
+  "\<lbrace>\<top>\<rbrace> f \<lbrace>\<lambda>_. cur_hyp_in_cur_domain\<rbrace>"
+  unfolding cur_hyp_in_cur_domain_def by wp
+
+lemma cur_fpu_in_cur_domain_wp[wp]:
+  "\<lbrace>\<top>\<rbrace> f \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
+  unfolding cur_fpu_in_cur_domain_def by wp
+
 end
+
+arch_requalify_consts
+  cur_hyp_in_cur_domain
+  cur_fpu_in_cur_domain
 
 
 global_interpretation Scheduler_IF_2?:
-  Scheduler_IF_2 arch_globals_equiv_scheduler arch_scheduler_affects_equiv
+  Scheduler_IF_2 arch_globals_equiv_scheduler arch_scheduler_affects_equiv _ cur_hyp_in_cur_domain cur_fpu_in_cur_domain
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Scheduler_IF_assms)?)
+    by (unfold_locales; (fact Scheduler_IF_assms |solves \<open>wpsimp wp: Scheduler_IF_assms simp: pas_wellformed_noninterference_domains_distinct\<close>)?)
 qed
 
 

--- a/proof/infoflow/RISCV64/ArchSyscall_IF.thy
+++ b/proof/infoflow/RISCV64/ArchSyscall_IF.thy
@@ -204,7 +204,7 @@ global_interpretation Syscall_IF_1?: Syscall_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Syscall_IF_assms)?)
+    by (unfold_locales; (fact Syscall_IF_assms | wpsimp wp: Syscall_IF_assms)?)
 qed
 
 end

--- a/proof/infoflow/RISCV64/ArchTcb_IF.thy
+++ b/proof/infoflow/RISCV64/ArchTcb_IF.thy
@@ -75,7 +75,7 @@ global_interpretation Tcb_IF_1?: Tcb_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Tcb_IF_assms)?)
+    by (unfold_locales; (fact Tcb_IF_assms | wpsimp wp: Tcb_IF_assms)?)
 qed
 
 
@@ -263,7 +263,7 @@ global_interpretation Tcb_IF_2?: Tcb_IF_2
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact Tcb_IF_assms)?)
+    by (unfold_locales; (fact Tcb_IF_assms | wpsimp wp: Tcb_IF_assms)?)
 qed
 
 end

--- a/proof/infoflow/RISCV64/ArchUserOp_IF.thy
+++ b/proof/infoflow/RISCV64/ArchUserOp_IF.thy
@@ -109,7 +109,7 @@ global_interpretation UserOp_IF_1?: UserOp_IF_1
 proof goal_cases
   interpret Arch .
   case 1 show ?case
-    by (unfold_locales; (fact UserOp_IF_assms)?)
+    by (unfold_locales; (fact UserOp_IF_assms | wpsimp)?)
 qed
 
 
@@ -566,9 +566,20 @@ proof -
     apply (frule_tac level=level in valid_vspace_objs_pte)
       apply clarsimp
      apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def)
-     apply (fastforce simp: table_base_pt_slot_offset[OF vs_lookup_table_is_aligned]
-                      dest: valid_arch_state_asid_table dest!: pt_lookup_vs_lookupI
-                     intro: vs_lookup_level)
+     apply (drule pt_lookup_vs_lookupI)
+     apply (fastforce simp: table_base_pt_slot_offset[OF vs_lookup_table_is_aligned])
+      apply (clarsimp simp: table_base_pt_slot_offset[OF vs_lookup_table_is_aligned])
+    apply (rule_tac x=asid in exI)
+     apply (rule_tac x=x in exI)
+     apply (subst table_base_pt_slot_offset[OF vs_lookup_table_is_aligned])
+           apply fastforce
+           apply fastforce
+           apply fastforce
+           apply fastforce
+       apply (fastforce dest: valid_arch_state_asid_table)
+      apply fastforce
+     apply clarsimp
+     apply (erule vs_lookup_level)
     apply (erule disjE[OF _  _ FalseE])
      prefer 2
      apply (clarsimp simp: pt_lookup_slot_def pt_lookup_slot_from_level_def in_omonad pt_walk.simps)

--- a/proof/infoflow/RISCV64/Example_Valid_State.thy
+++ b/proof/infoflow/RISCV64/Example_Valid_State.thy
@@ -1232,7 +1232,7 @@ lemma domain_sep_inv_s0:
   "domain_sep_inv False s0_internal s0_internal"
   apply (clarsimp simp: domain_sep_inv_def)
   apply (force dest: cte_wp_at_caps_of_state' s0_caps_of_state
-         | rule conjI allI | clarsimp simp: s0_internal_def)+
+         | rule conjI allI | clarsimp simp: s0_internal_def non_kernel_IRQs_def)+
   done
 
 lemma only_timer_irq_inv_s0:
@@ -1904,17 +1904,17 @@ lemma Sys1_valid_initial_state_noenabled:
   assumes det_inv_s0: "det_inv KernelExit (cur_context s0_internal) s0_internal"
   shows "valid_initial_state_noenabled det_inv utf s0_internal Sys1PAS timer_irq s0_context"
   apply (unfold_locales, simp_all only: pasMaySendIrqs_Sys1PAS)
-                      apply (insert det_inv_invariant)[9]
-                      apply (erule(2) invariant_over_ADT_if.det_inv_abs_state)
-                     apply ((erule invariant_over_ADT_if.det_inv_abs_state
-                                   invariant_over_ADT_if.check_active_irq_if_Idle_det_inv
-                                   invariant_over_ADT_if.check_active_irq_if_User_det_inv
-                                   invariant_over_ADT_if.do_user_op_if_det_inv
-                                   invariant_over_ADT_if.handle_preemption_if_det_inv
-                                   invariant_over_ADT_if.kernel_entry_if_Interrupt_det_inv
-                                   invariant_over_ADT_if.kernel_entry_if_det_inv
-                                   invariant_over_ADT_if.kernel_exit_if_det_inv
-                                   invariant_over_ADT_if.schedule_if_det_inv)+)[8]
+                     apply (insert det_inv_invariant)[9]
+                     apply (erule(2) invariant_over_ADT_if.det_inv_abs_state)
+                    apply ((erule invariant_over_ADT_if.det_inv_abs_state
+                                  invariant_over_ADT_if.check_active_irq_if_Idle_det_inv
+                                  invariant_over_ADT_if.check_active_irq_if_User_det_inv
+                                  invariant_over_ADT_if.do_user_op_if_det_inv
+                                  invariant_over_ADT_if.handle_preemption_if_det_inv
+                                  invariant_over_ADT_if.kernel_entry_if_Interrupt_det_inv
+                                  invariant_over_ADT_if.kernel_entry_if_det_inv
+                                  invariant_over_ADT_if.kernel_exit_if_det_inv
+                                  invariant_over_ADT_if.schedule_if_det_inv)+)[8]
             apply (rule Sys1_pas_cur_domain)
            apply (rule Sys1_pas_wellformed_noninterference)
           apply (simp only: einvs_s0)
@@ -1922,7 +1922,7 @@ lemma Sys1_valid_initial_state_noenabled:
           apply (simp add: only_timer_irq_inv_s0 silc_inv_s0 Sys1_pas_cur_domain
                            domain_sep_inv_s0 Sys1_pas_refined Sys1_guarded_pas_domain
                            idle_equiv_refl)
-          apply (clarsimp simp: valid_domain_list_2_def s0_internal_def exst0_def)
+          apply (clarsimp simp: valid_domain_list_2_def s0_internal_def exst0_def valid_cur_hyp_def)
          apply (simp add: det_inv_s0)
         apply (simp add: s0_internal_def exst0_def)
        apply (simp add: ct_in_state_def st_tcb_at_tcb_states_of_state_eq

--- a/proof/infoflow/Retype_IF.thy
+++ b/proof/infoflow/Retype_IF.thy
@@ -72,15 +72,6 @@ lemma machine_op_lift_irq_state[wp]:
   "machine_op_lift mop \<lbrace>\<lambda>ms. P (irq_state ms)\<rbrace>"
   by (simp add: machine_op_lift_def machine_rest_lift_def | wp | wpc)+
 
-lemma dmo_mol_reads_respects:
-  "reads_respects aag l \<top> (do_machine_op (machine_op_lift mop))"
-  apply (rule use_spec_ev)
-  apply (rule do_machine_op_spec_reads_respects)
-   apply (rule equiv_valid_guard_imp[OF machine_op_lift_ev])
-   apply simp
-  apply wp
-  done
-
 lemma dmo_bind_ev:
   "equiv_valid_inv I A P (do_machine_op (a >>= b)) =
    equiv_valid_inv I A P (do_machine_op a >>= (\<lambda>rv. do_machine_op (b rv)))"
@@ -134,7 +125,6 @@ lemma dmo_mapM_x_ev:
   shows "equiv_valid_inv D A I (do_machine_op (mapM_x m lst))"
   using assms by (auto intro: dmo_mapM_x_ev_pre)
 
-
 locale Retype_IF_1 =
   assumes clearMemory_ev:
     "equiv_valid_inv (equiv_machine_state P) (equiv_machine_state Q) \<top> (clearMemory ptr bits)"
@@ -159,23 +149,31 @@ locale Retype_IF_1 =
                       and K (range_cover p sz (obj_bits_api type o_bits) num \<and> 0 < num)\<rbrace>
      retype_region p num o_bits type dev
      \<lbrace>\<lambda>_. globals_equiv s\<rbrace>"
+  and machine_op_lift_no_hyp[wp]:
+    "no_hyp (machine_op_lift mop)"
+  and machine_op_lift_no_fpu[wp]:
+    "no_fpu (machine_op_lift mop)"
+  and clearMemory_no_hyp[wp]:
+    "no_hyp (clearMemory ptr bits)"
+  and clearMemory_no_fpu[wp]:
+    "no_fpu (clearMemory ptr bits)"
+  and freeMemory_no_hyp[wp]:
+    "no_hyp (freeMemory ptr bits)"
+  and freeMemory_no_fpu[wp]:
+    "no_fpu (freeMemory ptr bits)"
 begin
+
+lemma dmo_mol_reads_respects:
+  "reads_respects aag l \<top> (do_machine_op (machine_op_lift mop))"
+  by (wpsimp wp: do_machine_op_reads_respects equiv_valid_guard_imp[OF machine_op_lift_ev])
 
 lemma dmo_clearMemory_reads_respects:
   "reads_respects aag l \<top> (do_machine_op (clearMemory ptr bits))"
-  apply (rule use_spec_ev)
-  apply (rule do_machine_op_spec_reads_respects)
-   apply (rule equiv_valid_guard_imp[OF clearMemory_ev], rule TrueI)
-  apply wp
-  done
+  by (wpsimp wp: do_machine_op_reads_respects equiv_valid_guard_imp[OF clearMemory_ev])
 
 lemma dmo_freeMemory_reads_respects:
   "reads_respects aag l \<top> (do_machine_op (freeMemory ptr bits))"
-  apply (rule use_spec_ev)
-  apply (rule do_machine_op_spec_reads_respects)
-   apply (rule equiv_valid_guard_imp[OF freeMemory_ev], rule TrueI)
-  apply wp
-  done
+  by (wpsimp wp: do_machine_op_reads_respects equiv_valid_guard_imp[OF freeMemory_ev])
 
 lemma dmo_clearMemory_reads_respects_g:
   "reads_respects_g aag l \<top> (do_machine_op (clearMemory ptr (2 ^bits)))"
@@ -560,7 +558,7 @@ lemma invoke_untyped_reads_respects_g:
    apply (clarsimp simp: is_cap_simps)
    apply (rule equiv_valid_guard_imp, rule invoke_untyped_reads_respects_g_wcap)
    apply (cases ui, clarsimp simp: cte_wp_at_caps_of_state valid_untyped_inv_wcap)
-   apply auto[1]
+   apply (intro impI conjI, simp+)
   apply (rule equiv_valid_guard_imp, rule gen_asm_ev'[where Q=False])
    apply simp
   apply (cases ui, clarsimp simp: valid_untyped_inv_wcap cte_wp_at_caps_of_state)

--- a/proof/infoflow/Scheduler_IF.thy
+++ b/proof/infoflow/Scheduler_IF.thy
@@ -8,6 +8,56 @@ theory Scheduler_IF
 imports "ArchSyscall_IF" "ArchPasUpdates"
 begin
 
+definition valid_silc_label where
+  "valid_silc_label aag s \<equiv> (SilcLabel \<noteq> pasSubject aag) \<and>
+                             (\<forall>x. pasObjectAbs aag x = SilcLabel \<longrightarrow>  (\<exists>sz. cap_table_at sz x s))"
+
+lemma valid_silc_label_lift:
+  assumes "\<And>P T p. f \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace>"
+  shows "f \<lbrace>valid_silc_label aag\<rbrace>"
+  unfolding valid_silc_label_def
+  by (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_all_lift hoare_vcg_ex_lift assms simp: cap_table_at_typ)
+
+
+lemma valid_silc_label_silc_dom_equiv:
+  assumes "\<And>P T p. f \<lbrace>\<lambda>s. P (typ_at T p s)\<rbrace>"
+  shows "f \<lbrace>valid_silc_label aag\<rbrace>"
+  unfolding valid_silc_label_def
+  by (wpsimp wp: hoare_vcg_imp_lift hoare_vcg_all_lift hoare_vcg_ex_lift assms simp: cap_table_at_typ)
+
+lemma silc_dom_equiv_upds[simp]:
+  "\<And>f. silc_dom_equiv aag st (arch_state_update f s) = silc_dom_equiv aag st s"
+  "\<And>f. silc_dom_equiv aag st (cur_thread_update f s) = silc_dom_equiv aag st s"
+  "\<And>f. silc_dom_equiv aag st (ready_queues_update f s) = silc_dom_equiv aag st s"
+  "\<And>f. silc_dom_equiv aag st (machine_state_update f s) = silc_dom_equiv aag st s"
+  by (auto simp add: silc_dom_equiv_def equiv_for_def)
+
+lemma set_object_silc_dom_equiv:
+  "\<lbrace>silc_dom_equiv aag st and valid_silc_label aag and K (\<forall>sz. \<not>is_cap_table sz obj)\<rbrace>
+   set_object ptr obj
+   \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
+  apply (wp set_object_wp_strong)
+  apply (clarsimp simp: valid_silc_label_def silc_dom_equiv_def equiv_for_def obj_at_def)
+  apply (erule_tac x=ptr in allE)+
+  apply clarsimp
+  apply (case_tac obj; case_tac ko; clarsimp simp: is_cap_table_def a_type_def)
+  done
+
+lemma as_user_silc_dom_equiv[wp]:
+  "\<lbrace>silc_dom_equiv aag st and valid_silc_label aag\<rbrace> as_user ptr f \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
+  unfolding as_user_def
+  by (wpsimp wp: set_object_silc_dom_equiv simp: is_cap_table_def)
+
+lemma arch_thread_set_silc_dom_equiv[wp]:
+  "\<lbrace>silc_dom_equiv aag st and valid_silc_label aag\<rbrace> arch_thread_set ptr f \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
+  unfolding arch_thread_set_def
+  by (wpsimp wp: set_object_silc_dom_equiv simp: is_cap_table_def)
+
+lemma valid_silc_label_arch_state_update[simp]:
+  "valid_silc_label aag (arch_state_update f s) = valid_silc_label aag s"
+  by (simp add: valid_silc_label_def)
+
+
 (* After SELFOUR-553 scheduler no longer writes to shared memory *)
 abbreviation scheduler_affects_globals_frame where
   "scheduler_affects_globals_frame s \<equiv> {}"
@@ -25,6 +75,15 @@ definition domain_fields_equiv :: "det_state \<Rightarrow> det_state \<Rightarro
                             \<and> domain_index s = domain_index s'
                             \<and> domain_start_index s = domain_start_index s'
                             \<and> domain_list s = domain_list s'"
+
+lemma domain_fields_equiv_lift:
+  assumes a: "\<And>P. \<lbrace>domain_fields P and Q\<rbrace> f \<lbrace>\<lambda>_. domain_fields P\<rbrace>"
+  assumes b: "\<And>P. \<lbrace>(\<lambda>s. P (cur_domain s)) and R\<rbrace> f \<lbrace>\<lambda>_ s. P (cur_domain s)\<rbrace>"
+  shows "\<lbrace>domain_fields_equiv st and Q and R\<rbrace> f \<lbrace>\<lambda>_. domain_fields_equiv st\<rbrace>"
+  apply (clarsimp simp: valid_def domain_fields_equiv_def)
+  apply (erule use_valid, wp a b)
+  apply simp
+  done
 
 definition reads_scheduler where
 "reads_scheduler aag l \<equiv> if (l = SilcLabel) then {} else subjectReads (pasPolicy aag) l"
@@ -82,10 +141,12 @@ locale Scheduler_IF_1 =
           arch_scheduler_affects_equiv s s'"
     "\<And>f. arch_scheduler_affects_equiv s (domain_time_update f s') =
           arch_scheduler_affects_equiv s s'"
+(*
   and arch_switch_to_thread_kheap[wp]:
     "\<And>P t. arch_switch_to_thread t \<lbrace>\<lambda>s :: det_state. P (kheap s)\<rbrace>"
   and arch_switch_to_idle_thread_kheap[wp]:
     "\<And>P. arch_switch_to_idle_thread \<lbrace>\<lambda>s :: det_state. P (kheap s)\<rbrace>"
+*)
   and arch_switch_to_thread_idle_thread[wp]:
     "\<And>P t. arch_switch_to_thread t \<lbrace>\<lambda>s :: det_state. P (idle_thread s)\<rbrace>"
   and arch_switch_to_idle_thread_idle_thread[wp]:
@@ -93,9 +154,7 @@ locale Scheduler_IF_1 =
   and arch_switch_to_idle_thread_cur_domain[wp]:
     "\<And>P. arch_switch_to_idle_thread \<lbrace>\<lambda>s :: det_state. P (cur_domain s)\<rbrace>"
   and arch_switch_to_idle_thread_globals_equiv[wp]:
-    "arch_switch_to_idle_thread \<lbrace>globals_equiv st\<rbrace>"
-  and arch_switch_to_idle_thread_states_equiv_for[wp]:
-    "\<And>P Q R S. arch_switch_to_idle_thread \<lbrace>states_equiv_for P Q R S st\<rbrace>"
+    "\<lbrace>valid_arch_state and globals_equiv st\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   and arch_switch_to_idle_thread_work_units_completed[wp]:
     "\<And>P. arch_switch_to_idle_thread \<lbrace>\<lambda>s. P (work_units_completed s)\<rbrace>"
   and equiv_asid_equiv_update:
@@ -119,8 +178,8 @@ locale Scheduler_IF_1 =
     "\<And>P. arch_activate_idle_thread t \<lbrace>\<lambda>s :: det_state. P (idle_thread s)\<rbrace>"
   and arch_activate_idle_thread_irq_state_of_state[wp]:
     "\<And>P. arch_activate_idle_thread t \<lbrace>\<lambda>s. P (irq_state_of_state s)\<rbrace>"
-  and arch_prepare_next_domain_kheap[wp]:
-    "\<And>P. arch_prepare_next_domain \<lbrace>\<lambda>s :: det_state. P (kheap s)\<rbrace>"
+  and arch_activate_idle_thread_domain_fields[wp]:
+    "\<And>P. arch_activate_idle_thread t \<lbrace>domain_fields P\<rbrace>"
   and arch_prepare_next_domain_idle_thread[wp]:
     "\<And>P. arch_prepare_next_domain \<lbrace>\<lambda>s :: det_state. P (idle_thread s)\<rbrace>"
 begin
@@ -370,15 +429,6 @@ lemma silc_dom_equiv_cur_thread_update'[simp]:
   "silc_dom_equiv aag (st\<lparr>cur_thread := x\<rparr>) s = silc_dom_equiv aag st s"
   by (simp add: silc_dom_equiv_def equiv_for_def)
 
-lemma tcb_domain_wellformed:
-  "\<lbrakk> pas_refined aag s; etcbs_of s t = Some a \<rbrakk>
-     \<Longrightarrow> pasObjectAbs aag t \<in> pasDomainAbs aag (etcb_domain a)"
-  apply (clarsimp simp add: pas_refined_def tcb_domain_map_wellformed_aux_def)
-  apply (drule_tac x="(t,etcb_domain a)" in bspec)
-  apply (rule domtcbs)
-  apply force+
-  done
-
 lemma silc_dom_equiv_trans_state[simp]:
   "silc_dom_equiv aag st (trans_state f s) = silc_dom_equiv aag st s"
   by (simp add: silc_dom_equiv_def equiv_for_def)
@@ -522,6 +572,8 @@ definition midstrength_scheduler_affects_equiv ::
      (reads_scheduler_cur_domain aag l s \<or> reads_scheduler_cur_domain aag l s'
       \<longrightarrow> work_units_completed s = work_units_completed s')"
 
+declare equiv_hyp_False[simp] equiv_fpu_False[simp]
+
 lemma globals_frame_equiv_as_states_equiv:
   "scheduler_globals_frame_equiv st s =
    states_equiv_for (\<lambda>x. x \<in> scheduler_affects_globals_frame s) \<bottom> \<bottom> \<bottom>
@@ -531,7 +583,7 @@ lemma globals_frame_equiv_as_states_equiv:
 lemma silc_dom_equiv_as_states_equiv:
   "silc_dom_equiv aag st s =
    states_equiv_for (\<lambda>x. pasObjectAbs aag x = SilcLabel) \<bottom> \<bottom> \<bottom> (s\<lparr>kheap := kheap st\<rparr>) s"
-  by (simp add: states_equiv_for_def equiv_for_def silc_dom_equiv_def equiv_asids_def)
+  by (auto simp add: states_equiv_for_def equiv_for_def silc_dom_equiv_def equiv_asids_def equiv_hyp_refl equiv_fpu_refl)
 
 lemma silc_dom_equiv_states_equiv_lift:
   assumes a: "\<And>P Q R S st. f \<lbrace>states_equiv_for P Q R S st\<rbrace>"
@@ -540,7 +592,7 @@ lemma silc_dom_equiv_states_equiv_lift:
   apply (clarsimp simp add: valid_def)
   apply (frule use_valid[OF _ a])
    apply assumption
-  apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def)
+  apply (auto simp add: states_equiv_for_def equiv_for_def equiv_asids_def equiv_hyp_refl equiv_fpu_refl)
   done
 
 
@@ -592,7 +644,7 @@ proof -
     apply (clarsimp simp add: valid_def)
     apply (frule use_valid[OF _ a])
      apply assumption
-    apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def)
+    apply (simp add: states_equiv_for_def equiv_for_def equiv_asids_def equiv_hyp_False equiv_fpu_False)
     done
   show ?thesis
     apply (simp add: scheduler_affects_equiv_def[abs_def])
@@ -617,10 +669,6 @@ lemma midstrength_scheduler_affects_equiv_unobservable:
 crunch guarded_switch_to,schedule
   for idle_thread[wp]: "\<lambda>(s :: det_state). P (idle_thread s)"
   (wp: crunch_wps simp: crunch_simps)
-
-crunch guarded_switch_to, schedule
-  for kheap[wp]: "\<lambda>s :: det_state. P (kheap s)"
-  (wp: dxo_wp_weak crunch_wps simp: crunch_simps)
 
 end
 
@@ -798,6 +846,19 @@ lemma midstrength_cur_domain_unobservable:
   apply (drule_tac x="(aa,ba)" in bspec,clarsimp+)
   done
 
+lemma weak_cur_domain_unobservable:
+  "reads_respects_scheduler aag l (P and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)) f
+   \<Longrightarrow> weak_reads_respects_scheduler aag l
+         (P and (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)) f"
+  apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def scheduler_affects_equiv_def
+                        equiv_valid_def2 equiv_valid_2_def weak_scheduler_affects_equiv_def)
+  apply (drule_tac x=s in spec)
+  apply (drule_tac x=t in spec)
+  apply clarsimp
+  apply (drule_tac x="(a,b)" in bspec,clarsimp+)
+  apply (drule_tac x="(aa,ba)" in bspec,clarsimp+)
+  done
+
 lemma midstrength_reads_respects_scheduler_cases:
   assumes domains_distinct: "pas_domains_distinct aag"
   assumes b: "pasObjectAbs aag t \<in> reads_scheduler aag l
@@ -967,8 +1028,16 @@ lemma globals_equiv_scheduler[wp]:
 end
 
 
+definition valid_tcb_context_update where
+  "valid_tcb_context_update f \<equiv>
+     \<forall>tcb tcb'. arch_tcb_context_get (tcb_arch tcb) = arch_tcb_context_get (tcb_arch tcb')
+            \<longrightarrow> arch_tcb_context_get (tcb_arch (f tcb)) = arch_tcb_context_get (tcb_arch (f tcb'))"
+
+
 locale Scheduler_IF_2 = Scheduler_IF_1 +
   fixes aag :: "'a subject_label PAS"
+  and cur_hyp_in_cur_domain :: "det_state \<Rightarrow> bool"
+  and cur_fpu_in_cur_domain :: "det_state \<Rightarrow> bool"
   assumes arch_switch_to_thread_globals_equiv_scheduler:
     "\<lbrace>invs and globals_equiv_scheduler sta\<rbrace>
      arch_switch_to_thread thread
@@ -978,31 +1047,44 @@ locale Scheduler_IF_2 = Scheduler_IF_1 +
      arch_switch_to_idle_thread
      \<lbrace>\<lambda>_. globals_equiv_scheduler sta\<rbrace>"
   and arch_switch_to_thread_midstrength_reads_respects_scheduler[wp]:
-    "pas_domains_distinct aag
-     \<Longrightarrow> midstrength_reads_respects_scheduler aag l
-           (invs and pas_refined aag and (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
-           (do _ <- arch_switch_to_thread t;
-               _ <- modify (cur_thread_update (\<lambda>_. t));
-               modify (scheduler_action_update (\<lambda>_. resume_cur_thread))
-            od)"
+    "pas_wellformed_noninterference aag \<Longrightarrow>
+ midstrength_reads_respects_scheduler aag l
+  (invs and pas_refined aag and valid_silc_label aag and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain and
+   (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
+  (do _ <- arch_switch_to_thread t;
+      _ <- modify (cur_thread_update (\<lambda>_. t));
+      modify (scheduler_action_update (\<lambda>_. resume_cur_thread))
+   od)"
   and globals_equiv_scheduler_inv':
     "(\<And>st. \<lbrace>P and globals_equiv st\<rbrace> (f :: (det_state, unit) nondet_monad) \<lbrace>\<lambda>_. globals_equiv st\<rbrace>)
      \<Longrightarrow> \<lbrace>P and globals_equiv_scheduler s\<rbrace> f \<lbrace>\<lambda>_. globals_equiv_scheduler s\<rbrace>"
   and arch_switch_to_idle_thread_unobservable:
+  (*
     "\<lbrace>(\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l = {}) and
       scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and invs\<rbrace>
      arch_switch_to_idle_thread
      \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
-  and arch_switch_to_thread_unobservable:
-    "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
-      scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and invs\<rbrace>
-     arch_switch_to_thread t
+  *)
+  "pas_wellformed_noninterference aag
+   \<Longrightarrow> \<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
+      scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and
+      invs and cur_hyp_in_cur_domain and valid_silc_label aag and pas_refined aag\<rbrace>
+     arch_switch_to_idle_thread
      \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
+  and arch_switch_to_thread_unobservable:
+    "pas_wellformed_noninterference aag
+     \<Longrightarrow> \<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
+          (\<lambda>s. pasObjectAbs aag t \<notin> reads_scheduler aag l) and
+          scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and
+          invs and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain and
+          valid_silc_label aag and pas_refined aag\<rbrace>
+         arch_switch_to_thread t
+         \<lbrace>\<lambda>_ s. scheduler_affects_equiv aag l st s\<rbrace>"
   and next_domain_midstrength_equiv_scheduler:
     "equiv_valid (scheduler_equiv aag) (weak_scheduler_affects_equiv aag l)
                  (midstrength_scheduler_affects_equiv aag l) \<top> next_domain"
-  and arch_prepare_next_domain_ev:
-    "equiv_valid_inv (I :: det_state \<Rightarrow> det_state \<Rightarrow> bool) A \<top> arch_prepare_next_domain"
+  and arch_prepare_next_domain_weak_scheduler_reads_respects:
+    "weak_reads_respects_scheduler aag l (invs and valid_silc_label aag) arch_prepare_next_domain"
   and dmo_resetTimer_reads_respects_scheduler:
     "reads_respects_scheduler aag l \<top> (do_machine_op resetTimer)"
   and ackInterrupt_reads_respects_scheduler:
@@ -1012,8 +1094,13 @@ locale Scheduler_IF_2 = Scheduler_IF_1 +
       (\<lambda>s. x = idle_thread s \<longrightarrow> tc = idle_context s) and scheduler_affects_equiv aag l st\<rbrace>
      thread_set (tcb_arch_update (arch_tcb_context_set tc)) x
      \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
-  and set_object_reads_respects_scheduler[wp]:
+(*
+  and set_object_reads_respects_scheduler:
     "reads_respects_scheduler aag l \<top> (set_object ptr obj)"
+*)
+  and thread_set_reads_respects_scheduler:
+    "\<And>f. reads_respects_scheduler aag l (valid_arch_state and K (valid_tcb_context_update f))
+                                  (thread_set f t)"
   and arch_activate_idle_thread_reads_respects_scheduler[wp]:
     "reads_respects_scheduler aag l \<top> (arch_activate_idle_thread rv)"
   and arch_activate_idle_thread_silc_dom_equiv[wp]:
@@ -1021,14 +1108,43 @@ locale Scheduler_IF_2 = Scheduler_IF_1 +
   and arch_activate_idle_thread_scheduler_affects_equiv[wp]:
     "arch_activate_idle_thread t \<lbrace>scheduler_affects_equiv aag l s\<rbrace>"
   and arch_prepare_next_domain_globals_equiv_scheduler[wp]:
-    "arch_prepare_next_domain \<lbrace>\<lambda>s:: det_state. globals_equiv_scheduler st s\<rbrace>"
+    "\<lbrace>invs and globals_equiv_scheduler st\<rbrace> arch_prepare_next_domain \<lbrace>\<lambda>_. globals_equiv_scheduler st\<rbrace>"
+  and arch_switch_to_idle_thread_midstrength_reads_respects:
+  "equiv_valid_inv (scheduler_equiv aag) (midstrength_scheduler_affects_equiv aag l)
+                   (valid_arch_state and valid_silc_label aag) arch_switch_to_idle_thread"
+
+  and arch_switch_to_thread_silc_dom_equiv[wp]:
+    "\<lbrace>silc_dom_equiv aag st and valid_silc_label aag\<rbrace> arch_switch_to_thread t \<lbrace>\<lambda>_. silc_dom_equiv aag (st :: det_state)\<rbrace>"
+  and arch_switch_to_idle_thread_silc_dom_equiv[wp]:
+    "\<lbrace>silc_dom_equiv aag st and valid_silc_label aag\<rbrace> arch_switch_to_idle_thread \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
+  and set_scheduler_action_cur_hyp_in_cur_domain[wp]:
+    "set_scheduler_action act \<lbrace>cur_hyp_in_cur_domain\<rbrace>"
+  and set_scheduler_action_cur_fpu_in_cur_domain[wp]:
+    "set_scheduler_action act \<lbrace>cur_fpu_in_cur_domain\<rbrace>"
+  and tcb_sched_action_cur_hyp_in_cur_domain[wp]:
+    "tcb_sched_action a t \<lbrace>cur_hyp_in_cur_domain\<rbrace>"
+  and tcb_sched_action_cur_fpu_in_cur_domain[wp]:
+    "tcb_sched_action a t \<lbrace>cur_fpu_in_cur_domain\<rbrace>"
+  and next_domain_snippet_cur_hyp_in_cur_domain:
+    "\<lbrace>\<top>\<rbrace> do y <- arch_prepare_next_domain; next_domain od \<lbrace>\<lambda>_. cur_hyp_in_cur_domain\<rbrace>"
+  and next_domain_snippet_cur_fpu_in_cur_domain:
+    "\<lbrace>\<top>\<rbrace> do y <- arch_prepare_next_domain; next_domain od \<lbrace>\<lambda>_. cur_fpu_in_cur_domain\<rbrace>"
+  and arch_prepare_next_domain_silc_dom_equiv[wp]:
+    "\<lbrace>silc_dom_equiv aag st and valid_silc_label aag\<rbrace> arch_prepare_next_domain \<lbrace>\<lambda>_. silc_dom_equiv aag st\<rbrace>"
+  and arch_prepare_next_domain_typ_at[wp]:
+    "\<And>P. arch_prepare_next_domain \<lbrace>\<lambda>s :: det_state. P (typ_at T ptr s)\<rbrace>"
 begin
 
+crunch choose_thread
+   for silc_dom_equiv[wp]: "silc_dom_equiv aag (st :: det_state)"
+  (wp: crunch_wps valid_silc_label_lift simp: crunch_simps)
+
 lemma switch_to_thread_midstrength_reads_respects_scheduler[wp]:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+ assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
   shows
   "midstrength_reads_respects_scheduler aag l
-     (invs and pas_refined aag and (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
+     (invs and pas_refined aag and valid_silc_label aag and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain and (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
      (switch_to_thread t >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
   apply (simp add: switch_to_thread_def)
   apply (subst oblivious_modify_swap[symmetric, OF tcb_action_oblivious_cur_thread])
@@ -1056,9 +1172,11 @@ lemma switch_to_thread_globals_equiv_scheduler[wp]:
   done
 
 lemma guarded_switch_to_thread_midstrength_reads_respects_scheduler[wp]:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "midstrength_reads_respects_scheduler aag l
-           (invs and pas_refined aag and (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
+ assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows
+   "midstrength_reads_respects_scheduler aag l
+           (invs and pas_refined aag and valid_silc_label aag and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain and (\<lambda>s. pasObjectAbs aag t \<in> pasDomainAbs aag (cur_domain s)))
            (guarded_switch_to t >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
   apply (simp add: guarded_switch_to_def bind_assoc)
   apply (subst bind_assoc[symmetric])
@@ -1077,7 +1195,7 @@ lemma switch_to_idle_thread_globals_equiv_scheduler[wp]:
 lemmas globals_equiv_scheduler_inv = globals_equiv_scheduler_inv'[where P="\<top>",simplified]
 
 lemma switch_to_idle_thread_midstrength_reads_respects_scheduler[wp]:
-  "midstrength_reads_respects_scheduler aag l (invs and pas_refined aag)
+  "midstrength_reads_respects_scheduler aag l (invs and pas_refined aag and valid_silc_label aag)
      (switch_to_idle_thread >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
   apply (simp add: switch_to_idle_thread_def)
   apply (rule equiv_valid_guard_imp)
@@ -1085,12 +1203,7 @@ lemma switch_to_idle_thread_midstrength_reads_respects_scheduler[wp]:
    apply (rule bind_ev_general)
      apply (rule bind_ev_general)
        apply (rule store_cur_thread_midstrength_reads_respects)
-      apply (rule_tac P="\<top>" and P'="\<top>" in equiv_valid_inv_unobservable)
-          apply (rule hoare_pre)
-           apply (rule scheduler_equiv_lift'[where P=\<top>])
-                apply (wp globals_equiv_scheduler_inv silc_dom_lift | simp)+
-         apply (wp midstrength_scheduler_affects_equiv_unobservable
-                | simp | wps)+
+      apply (rule arch_switch_to_idle_thread_midstrength_reads_respects)
         apply (wp cur_thread_update_not_subject_reads_respects_scheduler arch_stit_invs
                | assumption | simp | fastforce)+
   apply (clarsimp simp: scheduler_equiv_def)
@@ -1219,9 +1332,10 @@ end
 context Scheduler_IF_2 begin
 
 lemma choose_thread_reads_respects_scheduler_cur_domain:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "midstrength_reads_respects_scheduler aag l
-           (invs and pas_refined aag and valid_queues
+ assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+    shows "midstrength_reads_respects_scheduler aag l
+           (invs and pas_refined aag and valid_silc_label aag and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain and valid_queues
                  and (\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {}))
            (choose_thread >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
   apply (simp add: choose_thread_def bind_assoc)
@@ -1241,8 +1355,12 @@ lemma choose_thread_reads_respects_scheduler_cur_domain:
   done
 
 lemma switch_to_idle_thread_unobservable:
-  "\<lbrace>(\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l = {}) and
-         scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain s = cur_domain st) and invs\<rbrace>
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows
+    "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
+      scheduler_affects_equiv aag l st and (\<lambda>s. cur_domain st = cur_domain s) and
+      invs and cur_hyp_in_cur_domain and valid_silc_label aag and pas_refined aag\<rbrace>
    switch_to_idle_thread
    \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
   apply (simp add: switch_to_idle_thread_def)
@@ -1270,29 +1388,33 @@ lemma tcb_sched_action_unobservable:
   done
 
 lemma switch_to_thread_unobservable:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
   shows "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and
           (\<lambda>s. pasObjectAbs aag t \<notin> reads_scheduler aag l) and
-          scheduler_affects_equiv aag l st and scheduler_equiv aag st and invs and pas_refined aag\<rbrace>
+          scheduler_affects_equiv aag l st and scheduler_equiv aag st and
+          invs and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain and
+          valid_silc_label aag and pas_refined aag\<rbrace>
          switch_to_thread t
          \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
   apply (simp add: switch_to_thread_def)
-  apply (wp cur_thread_update_unobservable arch_switch_to_idle_thread_unobservable
-            tcb_sched_action_unobservable arch_switch_to_thread_unobservable)
+  apply (wp cur_thread_update_unobservable tcb_sched_action_unobservable arch_switch_to_thread_unobservable)
   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def)
   done
 
+(* need a wellformedness condition on silc labels so silc dom can be preserved *)
 lemma choose_thread_reads_respects_scheduler_other_domain:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "reads_respects_scheduler aag l ( invs and pas_refined aag and valid_queues and
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows "reads_respects_scheduler aag l (invs and pas_refined aag and valid_silc_label aag and valid_queues and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain and
                                   (\<lambda>s. \<not> reads_scheduler_cur_domain aag l s)) choose_thread"
   apply (rule reads_respects_scheduler_unobservable''
                 [where P'="\<lambda>s. \<not> reads_scheduler_cur_domain aag l s \<and>
-                               invs s \<and> pas_refined aag s \<and> valid_queues s"])
+                               invs s \<and> pas_refined aag s \<and> valid_silc_label aag s \<and> cur_hyp_in_cur_domain s \<and> cur_fpu_in_cur_domain s \<and> valid_queues s"])
   apply (rule hoare_pre)
-     apply (rule scheduler_equiv_lift'[where P="invs"])
+     apply (rule scheduler_equiv_lift'[where P="invs and valid_silc_label aag"])
           apply (simp add: choose_thread_def)
-          apply (wp guarded_switch_to_lift silc_dom_lift | simp)+
+          apply (wp guarded_switch_to_lift | simp)+
     apply force
    apply (simp add: choose_thread_def)
    apply (wp guarded_switch_to_lift switch_to_idle_thread_unobservable switch_to_thread_unobservable
@@ -1310,13 +1432,15 @@ lemma choose_thread_reads_respects_scheduler_other_domain:
   done
 
 lemma choose_thread_reads_respects_scheduler:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "midstrength_reads_respects_scheduler aag l (invs and pas_refined aag and valid_queues)
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows "midstrength_reads_respects_scheduler aag l (invs and pas_refined aag and valid_silc_label aag and valid_queues and
+cur_hyp_in_cur_domain and cur_fpu_in_cur_domain)
            (choose_thread >>= (\<lambda>_. set_scheduler_action resume_cur_thread))"
   apply (rule equiv_valid_cases
                 [where P="\<lambda>s. pasDomainAbs aag (cur_domain s) \<inter> reads_scheduler aag l \<noteq> {}"])
     apply (rule equiv_valid_guard_imp)
-     apply (rule choose_thread_reads_respects_scheduler_cur_domain[OF domains_distinct])
+     apply (rule choose_thread_reads_respects_scheduler_cur_domain[OF wellformed])
     apply simp
    apply (rule equiv_valid_guard_imp)
     apply (rule midstrength_cur_domain_unobservable)
@@ -1327,9 +1451,15 @@ lemma choose_thread_reads_respects_scheduler:
   apply (simp add: scheduler_equiv_def domain_fields_equiv_def)
   done
 
+crunch next_domain
+  for typ_at[wp]: "\<lambda>s. P (typ_at T ptr s)"
+  (wp: dxo_wp_weak simp: Let_def)
+
 lemma next_domain_snippit:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "reads_respects_scheduler aag l (invs and pas_refined aag and valid_queues)
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
+  shows "reads_respects_scheduler aag l (invs and pas_refined aag and valid_silc_label aag and valid_queues
+ and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain and ct_in_cur_domain)
            (do dom_time \<leftarrow> gets domain_time;
                y \<leftarrow> when (dom_time = 0) (do y <- arch_prepare_next_domain;
                                             next_domain
@@ -1340,26 +1470,28 @@ lemma next_domain_snippit:
   apply (simp add: when_def)
   apply (rule bind_ev_pre)
      apply (rule bind_ev_general)
-       apply (rule choose_thread_reads_respects_scheduler[OF domains_distinct])
+       apply (rule choose_thread_reads_respects_scheduler[OF wellformed])
       apply (rule ev_weaken_pre_relation[THEN if_ev])
         apply (rule bind_ev_general)
           apply (rule next_domain_midstrength_equiv_scheduler)
-         apply (rule arch_prepare_next_domain_ev)
-        apply wp
+         apply (rule arch_prepare_next_domain_weak_scheduler_reads_respects)
+         apply wp+
        apply fastforce
       apply (rule ev_weaken_pre_relation)
        apply wp
       apply fastforce
-     apply (wp next_domain_valid_queues)+
+     apply (wpsimp wp: valid_silc_label_lift hoare_wp_simps
+                       next_domain_snippet_cur_hyp_in_cur_domain
+                       next_domain_snippet_cur_fpu_in_cur_domain)+
   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def)
   done
 
 lemma schedule_choose_new_thread_read_respects_scheduler:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "reads_respects_scheduler aag l (invs and pas_refined aag and valid_queues)
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  shows "reads_respects_scheduler aag l (invs and pas_refined aag and valid_silc_label aag and valid_queues and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain  and ct_in_cur_domain)
                                   schedule_choose_new_thread"
   unfolding schedule_choose_new_thread_def K_bind_def fun_app_def
-  by (rule next_domain_snippit[OF domains_distinct])
+  by (rule next_domain_snippit[OF wellformed])
 
 end
 
@@ -1525,20 +1657,23 @@ lemma dec_domain_time_reads_respects_scheduler[wp]:
   apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def globals_equiv_scheduler_def
                         scheduler_globals_frame_equiv_def silc_dom_equiv_def states_equiv_for_def
                         scheduler_affects_equiv_def equiv_for_def equiv_asids_def idle_equiv_def)
+  apply simp
   done
 
 end
 
+
 context Scheduler_IF_2 begin
 
 lemma reads_respects_scheduler_invisible_domain_switch:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows
-    "reads_respects_scheduler aag l (\<lambda>s. pas_refined aag s \<and> invs s \<and> valid_queues s
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]  shows
+    "reads_respects_scheduler aag l (\<lambda>s. pas_refined aag s \<and> valid_silc_label aag s \<and> invs s \<and> valid_queues s
                                        \<and> guarded_pas_domain aag s \<and> domain_time s = 0
-                                       \<and> scheduler_action s = choose_new_thread
+                                       \<and> scheduler_action s = choose_new_thread \<and> cur_hyp_in_cur_domain s \<and> cur_fpu_in_cur_domain s \<and> ct_in_cur_domain s
                                        \<and> \<not> reads_scheduler_cur_domain aag l s)
                               schedule"
+  supply valid_silc_label_lift[wp]
   apply (rule equiv_valid_guard_imp)
    apply (simp add: schedule_def)
    apply (simp add: equiv_valid_def2)
@@ -1553,7 +1688,7 @@ lemma reads_respects_scheduler_invisible_domain_switch:
               apply simp
               apply (rule equiv_valid_2_bind_pre)
                    apply (rule equiv_valid_2)
-                   apply (rule schedule_choose_new_thread_read_respects_scheduler[OF domains_distinct])
+                   apply (rule schedule_choose_new_thread_read_respects_scheduler[OF wellformed])
                   apply (rule_tac P="\<top>" and S="\<top>" and
                                   P'="pas_refined aag and
                                      (\<lambda>s. runnable rva
@@ -1602,10 +1737,11 @@ crunch schedule
      simp: crunch_simps)
 
 lemma choose_thread_unobservable:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
   shows
-    "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and scheduler_affects_equiv aag l st and
-      invs and valid_queues and pas_refined aag and scheduler_equiv aag st\<rbrace>
+    "\<lbrace>(\<lambda>s. \<not> reads_scheduler_cur_domain aag l s) and scheduler_affects_equiv aag l st and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain and
+      invs and valid_queues and pas_refined aag and valid_silc_label aag and scheduler_equiv aag st\<rbrace>
      choose_thread
      \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
   apply (simp add: choose_thread_def)
@@ -1627,10 +1763,11 @@ lemma tcb_sched_action_scheduler_equiv[wp]:
   by (rule scheduler_equiv_lift; wp)
 
 lemma schedule_choose_new_thread_schedule_affects_no_switch:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
   shows
-    "\<lbrace>\<lambda>s. invs s \<and> pas_refined aag s \<and> valid_queues s \<and> domain_time s \<noteq> 0
-                 \<and> \<not> reads_scheduler_cur_domain aag l s \<and> scheduler_equiv aag st s
+    "\<lbrace>\<lambda>s. invs s \<and> pas_refined aag s \<and> valid_silc_label aag s \<and> valid_queues s \<and> domain_time s \<noteq> 0
+                 \<and> \<not> reads_scheduler_cur_domain aag l s \<and> scheduler_equiv aag st s \<and> cur_hyp_in_cur_domain s \<and> cur_fpu_in_cur_domain s
                  \<and> scheduler_affects_equiv aag l st s \<and> cur_domain st = cur_domain s\<rbrace>
      schedule_choose_new_thread
      \<lbrace>\<lambda>_. scheduler_affects_equiv aag l st\<rbrace>"
@@ -1638,26 +1775,40 @@ lemma schedule_choose_new_thread_schedule_affects_no_switch:
   by (wpsimp wp: set_scheduler_action_unobservable choose_thread_unobservable
                  hoare_pre_cont[where f=next_domain])
 
+lemma silc_dom_equiv_updates'[simp]:
+  "\<And>f. silc_dom_equiv aag st (domain_index_update f s) = silc_dom_equiv aag st s"
+  "\<And>f. silc_dom_equiv aag st (domain_time_update f s) = silc_dom_equiv aag st s"
+  "\<And>f. silc_dom_equiv aag st (cur_domain_update f s) = silc_dom_equiv aag st s"
+  by (auto simp add: silc_dom_equiv_def equiv_for_def)
+
+crunch next_domain
+  for silc_dom_equiv[wp]: "silc_dom_equiv aag st"
+  (wp: dxo_wp_weak simp: Let_def)
+
+crunch schedule
+  for silc_dom_equiv[wp]: "silc_dom_equiv aag (st :: det_state)"
+  (wp: crunch_wps valid_silc_label_lift simp: crunch_simps)
+
 lemma reads_respects_scheduler_invisible_no_domain_switch:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
   shows
   "reads_respects_scheduler aag l
-     (\<lambda>s. pas_refined aag s \<and> invs s \<and> valid_sched s \<and> guarded_pas_domain aag s
+     (\<lambda>s. pas_refined aag s \<and> valid_silc_label aag s \<and> invs s \<and> valid_sched s \<and> guarded_pas_domain aag s \<and> cur_hyp_in_cur_domain s \<and> cur_fpu_in_cur_domain s
                             \<and> domain_time s \<noteq> 0 \<and> \<not> reads_scheduler_cur_domain aag l s)
      schedule"
-  supply if_split[split del]
+  supply if_split[split del] valid_silc_label_lift[wp]
   apply (rule reads_respects_scheduler_unobservable''[where P=Q and P'=Q and Q=Q for Q])
   apply (rule hoare_pre)
-     apply (rule scheduler_equiv_lift'[where P="invs and (\<lambda>s. domain_time s \<noteq> 0)"])
-          apply (wp schedule_no_domain_switch schedule_no_domain_fields
-                    silc_dom_lift | simp)+
+     apply (rule scheduler_equiv_lift'[where P="invs and valid_silc_label aag and (\<lambda>s. domain_time s \<noteq> 0)"])
+          apply (wp schedule_no_domain_switch schedule_no_domain_fields| simp)+
    apply (simp add: schedule_def)
    apply (wp guarded_switch_to_lift
              scheduler_equiv_lift
              schedule_choose_new_thread_schedule_affects_no_switch
              set_scheduler_action_unobservable
              tcb_sched_action_unobservable
-             switch_to_thread_unobservable silc_dom_lift
+             switch_to_thread_unobservable
              gts_wp
              hoare_vcg_all_lift
              hoare_vcg_disj_lift
@@ -1677,12 +1828,14 @@ lemma reads_respects_scheduler_invisible_no_domain_switch:
               | fastforce dest!: switch_to_cur_domain cur_thread_cur_domain
               | fastforce simp: st_tcb_at_def obj_at_def))+
 
+
 lemma read_respects_scheduler_switch_thread_case:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
   shows
     "reads_respects_scheduler aag l
        (invs and valid_queues and (\<lambda>s. scheduler_action s = switch_thread t)
-             and valid_sched_action and pas_refined aag)
+             and valid_sched_action and pas_refined aag and valid_silc_label aag and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain)
        (do tcb_sched_action tcb_sched_enqueue t;
            set_scheduler_action choose_new_thread;
            schedule_choose_new_thread
@@ -1692,20 +1845,21 @@ lemma read_respects_scheduler_switch_thread_case:
    apply simp
    apply (rule bind_ev)
      apply (rule bind_ev)
-       apply (rule next_domain_snippit[OF domains_distinct])
+       apply (rule next_domain_snippit[OF wellformed])
       apply wp[1]
      apply (simp add: pred_conj_def)
      apply (rule hoare_vcg_conj_lift)
-      apply (wp tcb_action_reads_respects_scheduler)+
+      apply (wp tcb_action_reads_respects_scheduler valid_silc_label_lift)+
   apply (clarsimp simp: valid_sched_action_def weak_valid_sched_action_def)
   done
 
 lemma read_respects_scheduler_switch_thread_case_app:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
   shows
   "reads_respects_scheduler aag l
      (invs and valid_queues and (\<lambda>s. scheduler_action s = switch_thread t)
-           and valid_sched_action and pas_refined aag)
+           and valid_sched_action and pas_refined aag and valid_silc_label aag and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain)
      (do tcb_sched_action tcb_sched_append t;
          set_scheduler_action choose_new_thread;
          schedule_choose_new_thread
@@ -1715,20 +1869,22 @@ lemma read_respects_scheduler_switch_thread_case_app:
    apply simp
    apply (rule bind_ev)
      apply (rule bind_ev)
-       apply (rule next_domain_snippit[OF domains_distinct])
+       apply (rule next_domain_snippit[OF wellformed])
       apply wp[1]
      apply (simp add: pred_conj_def)
      apply (rule hoare_vcg_conj_lift)
-      apply (wp tcb_action_reads_respects_scheduler)+
+      apply (wp tcb_action_reads_respects_scheduler valid_silc_label_lift)+
   apply (clarsimp simp: valid_sched_action_def weak_valid_sched_action_def)
   done
 
 lemma schedule_reads_respects_scheduler_cur_domain:
-  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
   shows
-  "reads_respects_scheduler aag l (invs and pas_refined aag and valid_sched
+  "reads_respects_scheduler aag l (invs and pas_refined aag and valid_silc_label aag and valid_sched and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain
                                         and guarded_pas_domain aag
                                         and (\<lambda>s. reads_scheduler_cur_domain aag l s)) schedule"
+  supply valid_silc_label_lift[wp]
   apply (simp add: schedule_def schedule_switch_thread_fastfail_def)
   apply (rule equiv_valid_guard_imp)
    apply (rule bind_ev)+
@@ -1738,17 +1894,17 @@ lemma schedule_reads_respects_scheduler_cur_domain:
           prefer 2
           (* choose new thread *)
           apply (rule bind_ev)
-            apply (rule schedule_choose_new_thread_read_respects_scheduler[OF domains_distinct])
+            apply (rule schedule_choose_new_thread_read_respects_scheduler[OF wellformed])
            apply ((wpsimp wp: when_ev gts_wp get_thread_state_reads_respects_scheduler)+)[2]
          (* switch thread *)
          apply (rule bind_ev)+
                      apply (rule if_ev)
-                      apply (rule read_respects_scheduler_switch_thread_case[OF domains_distinct])
+                      apply (rule read_respects_scheduler_switch_thread_case[OF wellformed])
                      apply (rule if_ev)
-                      apply (rule read_respects_scheduler_switch_thread_case_app[OF domains_distinct])
+                      apply (rule read_respects_scheduler_switch_thread_case_app[OF wellformed])
                      apply simp
                      apply (rule ev_weaken_pre_relation)
-                      apply (rule guarded_switch_to_thread_midstrength_reads_respects_scheduler[OF domains_distinct])
+                      apply (rule guarded_switch_to_thread_midstrength_reads_respects_scheduler[OF wellformed])
                      apply fastforce
                     apply (rule gets_highest_prio_ev_from_weak_sae)
                     apply fastforce
@@ -1781,10 +1937,9 @@ lemma schedule_reads_respects_scheduler_cur_domain:
   apply (frule st_tcb_at_tcb_at, drule (1) etcb_in_domains_of_state)
   apply (drule (1) bspec)
   apply simp
-  by (metis Int_emptyI assms pas_domains_distinct_inj)
+  by (metis Int_emptyI assms pas_domains_distinct_inj[OF domains_distinct])
 
 end
-
 
 lemma switch_to_cur_domain':
   "\<lbrakk> valid_sched_action s; scheduler_action s = switch_thread x; pas_refined aag s \<rbrakk>
@@ -1825,21 +1980,22 @@ definition tick_done where
   "tick_done s \<equiv> domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread"
 
 lemma schedule_reads_respects_scheduler:
-  assumes domains_distinct: "pas_domains_distinct aag"
+  assumes wellformed[wp]: "pas_wellformed_noninterference aag"
+  notes domains_distinct[wp] = pas_wellformed_noninterference_domains_distinct[OF wellformed]
   shows
-    "reads_respects_scheduler aag l (invs and pas_refined aag and valid_sched
+    "reads_respects_scheduler aag l (invs and pas_refined aag and valid_silc_label aag and valid_sched and cur_hyp_in_cur_domain and cur_fpu_in_cur_domain
                                           and guarded_pas_domain aag and tick_done) schedule"
   apply (rule_tac P="\<lambda>s. reads_scheduler_cur_domain aag l s"
                in equiv_valid_cases)
     apply (rule equiv_valid_guard_imp)
-     apply (rule schedule_reads_respects_scheduler_cur_domain[OF domains_distinct])
+     apply (rule schedule_reads_respects_scheduler_cur_domain[OF wellformed])
     apply simp
    apply (rule_tac P="\<lambda>s. domain_time s = 0" in equiv_valid_cases)
      apply (rule equiv_valid_guard_imp)
-      apply (rule reads_respects_scheduler_invisible_domain_switch[OF domains_distinct])
+      apply (rule reads_respects_scheduler_invisible_domain_switch[OF wellformed])
      apply (clarsimp simp: tick_done_def valid_sched_def)
     apply (rule equiv_valid_guard_imp)
-     apply (rule reads_respects_scheduler_invisible_no_domain_switch[OF domains_distinct])
+     apply (rule reads_respects_scheduler_invisible_no_domain_switch[OF wellformed])
     apply simp
    apply (clarsimp simp: scheduler_equiv_def domain_fields_equiv_def)+
   done
@@ -1914,13 +2070,8 @@ lemma thread_set_time_slice_reads_respect_scheduler[wp]:
   "reads_respects_scheduler aag l (invs and (\<lambda>s. t \<noteq> idle_thread s \<and> pasObjectAbs aag t \<noteq> SilcLabel)
                                         and guarded_pas_domain aag)
                             (thread_set (tcb_time_slice_update f) t)"
-  apply (rule reads_respects_scheduler_cases[where P'=\<top>])
-     prefer 3
-     apply (rule reads_respects_scheduler_unobservable'')
-       apply (wp | simp | elim conjE)+
-    apply (simp add: thread_set_def)
-    apply wp
-    apply (fastforce simp: scheduler_affects_equiv_def get_tcb_def states_equiv_for_def equiv_for_def)+
+  apply (wp thread_set_reads_respects_scheduler)
+  apply (clarsimp simp: valid_tcb_context_update_def)
   done
 
 lemma thread_set_time_slice_pas_refined[wp]:
@@ -2034,22 +2185,6 @@ lemma gets_ev':
   "equiv_valid_inv I A (P and K(\<forall>s t. P s \<longrightarrow> P t \<longrightarrow> I s t \<and> A s t \<longrightarrow> f s = f t)) (gets f)"
   by (clarsimp simp: equiv_valid_def2 equiv_valid_2_def gets_def get_def bind_def return_def)
 
-lemma irq_inactive_or_timer:
-  "\<lbrace>domain_sep_inv False st and Q IRQTimer and Q IRQInactive\<rbrace>
-   get_irq_state irq
-   \<lbrace>Q\<rbrace>"
-  apply (simp add:get_irq_state_def)
-  apply wp
-  apply (clarsimp simp add: domain_sep_inv_def)
-  apply (drule_tac x=irq in spec)
-  apply (drule_tac x=a in spec) (*makes yellow variables*)
-  apply (drule_tac x=b in spec)
-  apply (drule_tac x=aa in spec, drule_tac x=ba in spec)
-  apply clarsimp
-  apply (case_tac "interrupt_states st irq")
-     apply clarsimp+
-  done
-
 (*FIXME: MOVE corres-like statement for out of step equiv_valid. Move to scheduler_IF?*)
 lemma equiv_valid_2_bind_right:
   "\<lbrakk> \<And>rv. equiv_valid_2 D A A R T' (Q rv) g' (g rv);
@@ -2124,25 +2259,49 @@ lemma thread_set_scheduler_equiv[wp]:
        apply (wpsimp wp: thread_set_context_globals_equiv | simp)+
   done
 
+lemma set_thread_state_def2:
+  "set_thread_state ref ts \<equiv> do
+     thread_set (tcb_state_update (\<lambda>_. ts)) ref;
+     set_thread_state_act ref
+   od"
+  by (simp add: set_thread_state_def thread_set_def bind_assoc)
+
+
 lemma sts_reads_respects_scheduler:
   "reads_respects_scheduler aag l
      (K (pasObjectAbs aag rv \<in> reads_scheduler aag l) and reads_scheduler_cur_domain aag l
-                                                      and valid_idle and (\<lambda>s. rv \<noteq> idle_thread s))
+                                                      and valid_idle and valid_arch_state and (\<lambda>s. rv \<noteq> idle_thread s))
      (set_thread_state rv st)"
-  apply (simp add: set_thread_state_def)
+  apply (simp add: set_thread_state_def2)
   apply (simp add: set_thread_state_act_def)
-  apply (wp when_ev get_thread_state_reads_respects_scheduler gts_wp set_object_wp)
+  apply (wp when_ev get_thread_state_reads_respects_scheduler gts_wp set_object_wp thread_set_reads_respects_scheduler thread_set_wp)
   apply (clarsimp simp: get_tcb_scheduler_equiv valid_idle_def pred_tcb_at_def obj_at_def)
+  apply (clarsimp simp: valid_tcb_context_update_def)
+  done
+
+lemma as_user_def2:
+  "as_user t m = do
+             tcb \<leftarrow> gets_the (get_tcb t);
+             (a,uc) \<leftarrow> select_f (m (arch_tcb_context_get (tcb_arch tcb)));
+             thread_set (\<lambda>tcb. tcb\<lparr>tcb_arch := arch_tcb_context_set uc (tcb_arch tcb)\<rparr>) t;
+             return a
+           od"
+  apply (simp add: thread_set_def as_user_def)
+  apply (rule ext)
+  apply (rule bind_apply_cong [OF refl])+
+  apply (simp add: select_f_def in_monad gets_the_def gets_def)
+  apply (clarsimp simp add: get_def bind_def return_def assert_opt_def)
   done
 
 lemma as_user_reads_respects_scheduler:
   "reads_respects_scheduler aag l (K (pasObjectAbs aag rv \<in> reads_scheduler aag l) and
-                                   (\<lambda>s. rv \<noteq> idle_thread s) and K (det f))
+                                   (\<lambda>s. rv \<noteq> idle_thread s) and valid_arch_state and K (det f))
                             (as_user rv f)"
   apply (rule gen_asm_ev)
-  apply (simp add: as_user_def)
-  apply (wp select_f_ev | wpc | simp)+
+  apply (simp add: as_user_def2)
+  apply (wp select_f_ev thread_set_reads_respects_scheduler | wpc | simp)+
   apply (clarsimp simp: get_tcb_scheduler_equiv)
+  apply (clarsimp simp: valid_tcb_context_update_def)
   done
 
 end
@@ -2177,6 +2336,7 @@ lemma sts_silc_dom_equiv[wp]:
   apply (clarsimp simp: silc_dom_equiv_def equiv_for_def)
   done
 
+(*
 lemma as_user_silc_dom_equiv[wp]:
   "\<lbrace>K (pasObjectAbs aag x \<noteq> SilcLabel) and silc_dom_equiv aag st\<rbrace>
    as_user x f
@@ -2185,6 +2345,7 @@ lemma as_user_silc_dom_equiv[wp]:
   apply (wp dxo_wp_weak set_object_wp | wpc | simp)+
   apply (clarsimp simp: silc_dom_equiv_def equiv_for_def)
   done
+*)
 
 lemma set_scheduler_action_wp[wp]:
   "\<lbrace>\<lambda>s. P () (s\<lparr>scheduler_action := a\<rparr>)\<rbrace> set_scheduler_action a \<lbrace>P\<rbrace>"
@@ -2295,6 +2456,10 @@ lemma cur_thread_idle:
 
 context Scheduler_IF_2 begin
 
+lemma silc_inv_valid_silc_label[elim!]:
+  "silc_inv aag st s \<Longrightarrow> valid_silc_label aag s"
+  by (simp add: silc_inv_def valid_silc_label_def)
+
 lemma activate_thread_reads_respects_scheduler[wp]:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
   shows "reads_respects_scheduler aag l (invs and silc_inv aag st and guarded_pas_domain aag)
@@ -2314,7 +2479,7 @@ lemma activate_thread_reads_respects_scheduler[wp]:
                                 guarded_pas_domain aag s \<and> invs s"])
      apply ((wp scheduler_equiv_lift'[where P="invs and silc_inv aag st"]
                 globals_equiv_scheduler_inv'[where P="valid_arch_state and valid_idle"]
-                set_thread_state_globals_equiv gts_wp
+                set_thread_state_globals_equiv gts_wp valid_silc_label_lift
              | wpc
              | clarsimp simp: restart_not_idle silc_inv_not_cur_thread
              | force)+)[1]
@@ -2328,16 +2493,10 @@ lemma thread_set_reads_respect_scheduler[wp]:
                                         and (\<lambda>s. t = idle_thread s \<longrightarrow> tc = idle_context s)
                                         and guarded_pas_domain aag)
                             (thread_set (tcb_arch_update (arch_tcb_context_set tc)) t)"
-  apply (rule reads_respects_scheduler_cases[where P'=\<top>])
-     prefer 3
-     apply (rule reads_respects_scheduler_unobservable'')
-       apply (wp | simp | elim conjE)+
-    apply (simp add: thread_set_def)
-    apply wp
-    apply (fastforce simp: scheduler_affects_equiv_def get_tcb_def states_equiv_for_def
-                           equiv_for_def scheduler_equiv_def domain_fields_equiv_def equiv_asids_def
-                    split: option.splits kernel_object.splits)+
+  apply (wp thread_set_reads_respects_scheduler)
+  apply (clarsimp simp: valid_tcb_context_update_def)
   done
+
 
 lemma context_update_cur_thread_snippit_unobservable:
   "equiv_valid_2 (scheduler_equiv aag) (scheduler_affects_equiv aag l)

--- a/proof/infoflow/Syscall_IF.thy
+++ b/proof/infoflow/Syscall_IF.thy
@@ -61,23 +61,29 @@ locale Syscall_IF_1 =
   and arch_mask_irq_signal_globals_equiv[wp]:
     "arch_mask_irq_signal irq \<lbrace>globals_equiv st\<rbrace>"
   and handle_reserved_irq_globals_equiv[wp]:
-    "handle_reserved_irq irq \<lbrace>globals_equiv st\<rbrace>"
+     "\<lbrace>globals_equiv st and invs\<rbrace> handle_reserved_irq irq \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   and handle_spurious_irq_globals_equiv[wp]:
     "handle_spurious_irq \<lbrace>globals_equiv st\<rbrace>"
   and arch_prepare_set_domain_globals_equiv[wp]:
-    "arch_prepare_set_domain t new_dom \<lbrace>globals_equiv st\<rbrace>"
+    "\<lbrace>globals_equiv st and invs\<rbrace> arch_prepare_set_domain t new_dom \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   and arch_prepare_set_domain_valid_arch_state[wp]:
     "arch_prepare_set_domain t new_dom \<lbrace>\<lambda>s :: det_state. valid_arch_state s\<rbrace>"
   and handle_vm_fault_reads_respects:
-    "reads_respects aag l (K (is_subject aag thread)) (handle_vm_fault thread vmfault_type)"
+    "reads_respects aag l (pas_refined aag and valid_cur_hyp and
+                               schact_is_rct and ct_in_cur_domain
+                           and is_subject aag \<circ> cur_thread and K (is_subject aag thread))
+                          (handle_vm_fault thread vmfault_type)"
   and handle_hypervisor_fault_reads_respects:
-    "reads_respects aag l \<top> (handle_hypervisor_fault thread hypfault_type)"
+    "pas_domains_distinct aag \<Longrightarrow>
+     reads_respects aag l (invs and pas_refined aag and pas_cur_domain aag
+                                 and is_subject aag \<circ> cur_thread and K (is_subject aag thread))
+                          (handle_hypervisor_fault thread hypfault_type)"
   and handle_vm_fault_globals_equiv:
     "\<lbrace>globals_equiv st and valid_arch_state and (\<lambda>s. thread \<noteq> idle_thread s)\<rbrace>
      handle_vm_fault thread vmfault_type
      \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   and handle_hypervisor_fault_globals_equiv:
-    "handle_hypervisor_fault thread hypfault_type \<lbrace>globals_equiv st\<rbrace>"
+    "\<lbrace>globals_equiv st and invs\<rbrace> handle_hypervisor_fault thread hypfault_type \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   and arch_activate_idle_thread_globals_equiv[wp]:
     "arch_activate_idle_thread t \<lbrace>globals_equiv st\<rbrace>"
   and select_f_setNextPC_reads_respects[wp]:
@@ -792,12 +798,6 @@ lemma handle_recv_reads_respects_f_g:
    apply simp+
   done
 
-lemma dmo_return_reads_respects:
-  "reads_respects aag l \<top> (do_machine_op (return ()))"
-  apply (rule use_spec_ev)
-  apply (rule do_machine_op_spec_reads_respects; wp)
-  done
-
 lemma dmo_return_globals_equiv:
   "do_machine_op (return ()) \<lbrace>globals_equiv st\<rbrace>"
   by simp
@@ -886,8 +886,10 @@ lemma handle_interrupt_globals_equiv:
   done
 
 lemma handle_vm_fault_reads_respects_g:
-  "reads_respects_g aag l (K (is_subject aag t) and (valid_arch_state and (\<lambda>s. t \<noteq> idle_thread s)))
-                    (handle_vm_fault t vmfault_type)"
+  "reads_respects_g aag l (pas_refined aag and valid_cur_hyp and schact_is_rct and ct_in_cur_domain
+                                           and is_subject aag \<circ> cur_thread and K (is_subject aag t)
+                                           and (valid_arch_state and (\<lambda>s. t \<noteq> idle_thread s)))
+                          (handle_vm_fault t vmfault_type)"
   apply (rule reads_respects_g)
    apply (rule handle_vm_fault_reads_respects)
   apply (rule doesnt_touch_globalsI)
@@ -896,18 +898,22 @@ lemma handle_vm_fault_reads_respects_g:
   done
 
 lemma handle_hypervisor_fault_reads_respects_g:
-  "reads_respects_g aag l \<top> (handle_hypervisor_fault thread hyp)"
-  apply (rule reads_respects_g[where P="\<top>" and Q="\<top>", simplified])
-   apply (rule handle_hypervisor_fault_reads_respects)
-  apply (rule doesnt_touch_globalsI)
-  apply (wp handle_hypervisor_fault_globals_equiv)
+  assumes domains_distinct[wp]: "pas_domains_distinct aag"
+  shows "reads_respects_g aag l (invs and pas_refined aag and pas_cur_domain aag
+                                      and is_subject aag \<circ> cur_thread and K (is_subject aag thread))
+                                (handle_hypervisor_fault thread hyp)"
+  apply (rule equiv_valid_guard_imp)
+   apply (rule reads_respects_g[OF handle_hypervisor_fault_reads_respects])
+    apply wp
+   apply (rule doesnt_touch_globalsI)
+   apply (wp handle_hypervisor_fault_globals_equiv)
   apply simp
   done
 
 (* we explicitly exclude the case where ev is Interrupt since this is a scheduler action *)
 lemma handle_event_reads_respects_f_g:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
-  shows "reads_respects_f_g aag l (silc_inv aag st and only_timer_irq_inv irq st' and einvs
+  shows "reads_respects_f_g aag l (silc_inv aag st and only_timer_irq_inv irq st' and einvs and valid_cur_hyp
                                                    and schact_is_rct and is_subject aag \<circ> cur_thread
                                                    and domain_sep_inv (pasMaySendIrqs aag) st'
                                                    and (\<lambda>s. ev \<noteq> Interrupt \<and> (ct_active s))
@@ -953,16 +959,21 @@ lemma handle_event_reads_respects_f_g:
          | clarsimp simp: reads_equiv_f_g_conj requiv_g_cur_thread_eq schact_is_rct_simple
          | wpc | intro impI conjI allI)+
      apply (rule equiv_valid_guard_imp)
-      apply ((wp reads_respects_f_g'[OF handle_hypervisor_fault_reads_respects_g, where Q=\<top>]
+      apply ((wp reads_respects_f_g'[OF handle_hypervisor_fault_reads_respects_g]
                  handle_hypervisor_fault_silc_inv
               | simp)+)[1]
-     prefer 2
-     apply ((wp reads_respects_f_g'[OF handle_fault_reads_respects_g, where st=st] | simp)+)[1]
-    apply (simp add: validE_E_def)
-   apply (wp hv_invs handle_vm_fault_silc_inv)+
-  apply (simp add: invs_imps invs_mdb invs_valid_idle)+
+     apply simp
+    apply (wp hv_invs handle_vm_fault_silc_inv)+
   apply (fastforce simp: requiv_g_cur_thread_eq reads_equiv_f_g_conj ct_active_not_idle)
   done
+
+lemma getRestartPC_reads_respects:
+  "reads_respects aag l (K (aag_can_read_or_affect aag l t)) (as_user t getRestartPC)"
+  by (wpsimp wp: as_user_reads_respects simp: det_getRestartPC)
+
+lemma setNextPC_reads_respects:
+  "reads_respects aag l (K (aag_can_read_or_affect aag l t)) (as_user t (setNextPC pc))"
+  by (wpsimp wp: as_user_reads_respects simp: det_setNextPC)
 
 lemma activate_thread_reads_respects:
   assumes domains_distinct[wp]: "pas_domains_distinct aag"
@@ -971,9 +982,9 @@ lemma activate_thread_reads_respects:
            activate_thread"
   apply (simp add: activate_thread_def)
   apply (wpsimp wp: set_thread_state_runnable_reads_respects get_thread_state_rev)
-  by (wp set_object_reads_respects get_thread_state_rev
-      | simp add: as_user_def select_f_returns tcb_at_st_tcb_at[symmetric] cur_tcb_def
-      | rule hoare_drop_imps conjI requiv_cur_thread_eq requiv_get_tcb_eq'
+  by (wpsimp wp: set_object_reads_respects get_thread_state_rev
+                 getRestartPC_reads_respects setNextPC_reads_respects
+      | rule hoare_drop_imps conjI requiv_cur_thread_eq
       | clarsimp simp: st_tcb_at_def obj_at_def is_tcb_def)+
 
 lemma activate_thread_globals_equiv:

--- a/proof/infoflow/Tcb_IF.thy
+++ b/proof/infoflow/Tcb_IF.thy
@@ -22,7 +22,7 @@ lemma setup_reply_master_globals_equiv:
    setup_reply_master t
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding setup_reply_master_def
-  apply (wp set_cap_globals_equiv'' set_original_globals_equiv get_cap_wp)
+  apply (wp set_cap_globals_equiv set_original_globals_equiv get_cap_wp)
   apply clarsimp
   done
 
@@ -42,7 +42,7 @@ lemma cap_swap_for_delete_globals_equiv[wp]:
    cap_swap_for_delete a b
    \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   unfolding cap_swap_for_delete_def cap_swap_def set_original_def
-  by (wp modify_wp set_cdt_globals_equiv set_cap_globals_equiv'' dxo_wp_weak | simp)+
+  by (wp modify_wp set_cdt_globals_equiv set_cap_globals_equiv dxo_wp_weak | simp)+
 
 lemma rec_del_preservation2':
   assumes finalise_cap_P: "\<And>cap final. \<lbrace>R cap and P\<rbrace> finalise_cap cap final \<lbrace>\<lambda>_. P\<rbrace>"
@@ -191,7 +191,7 @@ locale Tcb_IF_1 =
   and arch_post_modify_registers_reads_respects_f[wp]:
     "reads_respects_f aag l \<top> (arch_post_modify_registers cur t)"
   and arch_get_sanitise_register_info_reads_respects_f[wp]:
-    "reads_respects_f aag l \<top> (arch_get_sanitise_register_info t)"
+    "reads_respects_f aag l (K (aag_can_read_or_affect aag l t)) (arch_get_sanitise_register_info t)"
 begin
 
 crunch cap_swap_for_delete
@@ -206,7 +206,7 @@ lemma rec_del_globals_equiv:
                     rec_del_preservation2[where Q="valid_arch_state"
                                             and R="\<lambda>cap s. invs s \<and> valid_cap cap s
                                                       \<and> (\<forall>p. cap = ThreadCap p \<longrightarrow> p \<noteq> idle_thread s)"])
-            apply (wp set_cap_globals_equiv'')
+            apply (wp set_cap_globals_equiv)
             apply simp
            apply (wp empty_slot_globals_equiv)+
           apply simp
@@ -295,9 +295,12 @@ locale Tcb_IF_2 = Tcb_IF_1 +
                               and K (authorised_tcb_inv aag ti \<and> authorised_tcb_inv_extra aag ti))
              (invoke_tcb ti)"
   and arch_post_set_flags_globals_equiv[wp]:
-    "arch_post_set_flags t flags \<lbrace>globals_equiv st\<rbrace>"
+    "\<lbrace>globals_equiv st and invs\<rbrace>
+     arch_post_set_flags t flags
+     \<lbrace>\<lambda>_. globals_equiv st\<rbrace>"
   and arch_post_set_flags_reads_respects_f:
-    "reads_respects_f aag l \<top> (arch_post_set_flags t flags)"
+    "pas_domains_distinct aag \<Longrightarrow>
+     reads_respects_f aag l (silc_inv aag st and valid_cur_fpu and K (is_subject aag t)) (arch_post_set_flags t flags)"
 begin
 
 crunch suspend, restart
@@ -325,9 +328,8 @@ lemma invoke_tcb_globals_equiv:
                           weak_if_wp')+
    apply (intro conjI impI; clarsimp simp: no_cap_to_idle_thread)+
   apply (simp del: invoke_tcb.simps tcb_inv_wf.simps)
-  apply (wp invoke_tcb_thread_preservation cap_delete_globals_equiv
-            cap_insert_globals_equiv'' thread_set_globals_equiv set_mcpriority_globals_equiv
-            set_priority_globals_equiv
+  apply (wp invoke_tcb_thread_preservation cap_delete_globals_equiv cap_insert_globals_equiv
+            thread_set_globals_equiv set_mcpriority_globals_equiv set_priority_globals_equiv
          | fastforce)+
   done
 
@@ -417,7 +419,7 @@ lemma set_mcpriority_reads_respects:
   assumes domains_distinct: "pas_domains_distinct aag"
   shows "reads_respects aag (l :: 'a subject_label) \<top> (set_mcpriority x y)"
   unfolding set_mcpriority_def
-  by (rule thread_set_reads_respects[OF domains_distinct])
+  by (rule thread_set_reads_respects)
 
 lemma checked_cap_insert_only_timer_irq_inv:
   "check_cap_at a b (check_cap_at c d (cap_insert a b e)) \<lbrace>only_timer_irq_inv irq (st :: det_state)\<rbrace>"
@@ -480,6 +482,10 @@ context Tcb_IF_2 begin
 lemma thread_set_tcb_flags_update_silc_inv[wp]:
   "thread_set (tcb_flags_update f) t \<lbrace>silc_inv aag st\<rbrace>"
   by (rule thread_set_silc_inv; simp add: tcb_cap_cases_def)
+
+crunch set_flags
+  for silc_inv[wp]: "silc_inv aag st"
+  (ignore: thread_set)
 
 lemma set_flags_reads_respects_f:
   assumes "pas_domains_distinct aag"

--- a/proof/infoflow/UserOp_IF.thy
+++ b/proof/infoflow/UserOp_IF.thy
@@ -116,6 +116,14 @@ locale UserOp_IF_1 =
           arch_globals_equiv ct it kh kh' as as' ms ms'"
     "\<And>f. arch_globals_equiv ct it kh kh' as as' ms (device_state_update f ms') =
           arch_globals_equiv ct it kh kh' as as' ms ms'"
+  and no_hyp_modify[wp,simp]:
+    "\<And>f. no_hyp (modify (\<lambda>ms :: machine_state. ms\<lparr>underlying_memory := f ms\<rparr>))"
+    "\<And>f. no_hyp (modify (\<lambda>ms :: machine_state. ms\<lparr>device_state := f ms\<rparr>))"
+    "\<And>f. no_hyp (modify (\<lambda>ms :: machine_state. ms\<lparr>machine_state_rest := f ms\<rparr>))"
+  and no_fpu_modify[wp,simp]:
+    "\<And>f. no_fpu (modify (\<lambda>ms :: machine_state. ms\<lparr>underlying_memory := f ms\<rparr>))"
+    "\<And>f. no_fpu (modify (\<lambda>ms :: machine_state. ms\<lparr>device_state := f ms\<rparr>))"
+    "\<And>f. no_fpu (modify (\<lambda>ms :: machine_state. ms\<lparr>machine_state_rest := f ms\<rparr>))"
 begin
 
 (* Assumptions:
@@ -132,13 +140,10 @@ lemma dmo_user_memory_update_reads_respects_g:
   apply (subgoal_tac "reads_respects aag l \<top> (do_machine_op (user_memory_update um))")
    apply (fastforce simp: equiv_valid_def2 equiv_valid_2_def in_monad do_machine_op_def
                           user_memory_update_def select_f_def idle_equiv_def)
-  apply (rule use_spec_ev)
   apply (simp add: user_memory_update_def)
-  apply (rule do_machine_op_spec_reads_respects)
-   apply (simp add: equiv_valid_def2)
-   apply (rule modify_ev2)
-   apply (fastforce intro: equiv_forI elim: equiv_forE split: option.splits)
-  apply (wp | simp)+
+  apply (wpsimp wp: do_machine_op_reads_respects modify_ev)
+      apply (fastforce intro: equiv_forI elim: equiv_forE split: option.splits)
+     apply wpsimp+
   done
 
 lemma dmo_device_state_update_reads_respects_g:
@@ -150,13 +155,10 @@ lemma dmo_device_state_update_reads_respects_g:
   apply (subgoal_tac "reads_respects aag l \<top> (do_machine_op (device_memory_update um))")
    apply (fastforce simp: equiv_valid_def2 equiv_valid_2_def in_monad do_machine_op_def
                           device_memory_update_def select_f_def idle_equiv_def)
-  apply (rule use_spec_ev)
   apply (simp add: device_memory_update_def)
-  apply (rule do_machine_op_spec_reads_respects)
-   apply (simp add: equiv_valid_def2)
-   apply (rule modify_ev2)
-   apply (fastforce intro: map_add_eq equiv_forI elim: equiv_forE split: option.splits)
-  apply (wp | simp)+
+  apply (wpsimp wp: do_machine_op_reads_respects modify_ev)
+      apply (fastforce intro: map_add_eq equiv_forI elim: equiv_forE split: option.splits)
+     apply wpsimp+
   done
 
 end

--- a/proof/infoflow/refine/AARCH64/ArchADT_IF_Refine.thy
+++ b/proof/infoflow/refine/AARCH64/ArchADT_IF_Refine.thy
@@ -8,7 +8,7 @@ theory ArchADT_IF_Refine
 imports ADT_IF_Refine
 begin
 
-context Arch begin global_naming RISCV64
+context Arch begin global_naming AARCH64
 
 named_theorems ADT_IF_Refine_assms
 
@@ -167,7 +167,7 @@ lemma do_user_op_if_corres[ADT_IF_Refine_assms]:
     apply (rule corres_split[where r'="(=)"])
        apply (clarsimp simp: select_def corres_underlying_def)
       apply clarsimp
-      apply (rule corres_split[OF corres_machine_op,where r'="(=)"])
+      apply (rule corres_split[OF corres_machine_op', where r'="(=)"])
          apply (rule corres_underlying_trivial)
          apply (clarsimp simp: user_memory_update_def)
          apply (rule no_fail_modify)
@@ -285,7 +285,7 @@ lemma getActiveIRQ_nf:
   done
 
 lemma dmo_getActiveIRQ_corres[ADT_IF_Refine_assms]:
-  "corres (=) \<top> \<top> (do_machine_op (getActiveIRQ in_kernel)) (doMachineOp (getActiveIRQ in_kernel'))"
+  "corres (=) \<top> \<top> (do_machine_op (getActiveIRQ in_kernel)) (doMachineOp (getActiveIRQ in_kernel))"
   apply (rule SubMonad_R.corres_machine_op)
   apply (rule corres_Id)
     apply (simp add: getActiveIRQ_def non_kernel_IRQs_def)
@@ -296,7 +296,7 @@ lemma dmo_getActiveIRQ_corres[ADT_IF_Refine_assms]:
 lemma dmo'_getActiveIRQ_wp[ADT_IF_Refine_assms]:
   "\<lbrace>\<lambda>s. P (irq_at (irq_state (ksMachineState s) + 1) (irq_masks (ksMachineState s)))
           (s\<lparr>ksMachineState := (ksMachineState s\<lparr>irq_state := irq_state (ksMachineState s) + 1\<rparr>)\<rparr>)\<rbrace>
-   doMachineOp (getActiveIRQ in_kernel)
+   doMachineOp (getActiveIRQ False)
    \<lbrace>P\<rbrace>"
   apply(simp add: doMachineOp_def getActiveIRQ_def non_kernel_IRQs_def)
   apply(wp modify_wp | wpc)+
@@ -356,30 +356,64 @@ lemma handleEvent_corres_arch_extras[ADT_IF_Refine_assms]:
        (handle_event event) (handleEvent event)"
   by (fastforce intro: corres_guard2_imp[OF handleEvent_corres])
 
-lemma getActiveIRQ_corres_True_False:
-  "corres_underlying Id False True (=) \<top> \<top> (getActiveIRQ True) (getActiveIRQ False)"
-  unfolding getActiveIRQ_def
-  by (corres simp: non_kernel_IRQs_def)
+lemma handle_event_valid_domain_time_IRQ:
+  "\<lbrace>\<lambda>s. 0 < domain_time s \<rbrace>
+   handle_event Interrupt
+   \<lbrace>\<lambda>_ s::det_state. domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread\<rbrace>, -"
+  by (wpsimp wp: maybe_handle_interrupt_valid_domain_time wp_del: handle_event_domain_time_valid)
 
-lemma maybeHandleInterrupt_corres_True_False[ADT_IF_Refine_assms]:
-  "corres dc einvs invs' (maybe_handle_interrupt True) (maybeHandleInterrupt False)"
-  unfolding maybe_handle_interrupt_def maybeHandleInterrupt_def
-  apply (corres corres: corres_machine_op getActiveIRQ_corres_True_False
-                        handleInterrupt_corres[@lift_corres_args]
-                simp:  irq_state_independent_def
-         | corres_cases_both)+
-     apply (wpsimp wp: hoare_drop_imps)
-    apply clarsimp
-    apply (strengthen contract_all_imp_strg[where P'=True, simplified])
-    apply (wpsimp wp: doMachineOp_getActiveIRQ_IRQ_active' hoare_vcg_all_lift)
-   apply clarsimp
-  apply (clarsimp simp: invs'_def valid_state'_def)
+lemma kernel_entry_if_corres[ADT_IF_Refine_assms]:
+  "corres (prod_lift (dc \<oplus> dc))
+     (einvs and no_domain_caps
+            and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running s)
+            and schact_is_rct
+            and (\<lambda>s. 0 < domain_time s) and valid_domain_list)
+     (invs' and (\<lambda>s. event \<noteq> Interrupt \<longrightarrow> ct_running' s)
+            and arch_extras
+            and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
+     (kernel_entry_if event tc) (kernelEntry_if event tc)"
+  supply local.getActiveIRQ_inv[wp del]
+  supply Machine_AI.AARCH64.getActiveIRQ_inv[wp del]
+  apply (simp add: kernel_entry_if_def kernelEntry_if_def)
+  apply (rule corres_guard_imp)
+    apply (rule corres_split[OF getCurThread_corres])
+      apply (rule corres_split)
+         apply simp
+         apply (rule threadset_corresT)
+              apply (erule arch_tcb_context_set_tcb_relation)
+             apply (clarsimp simp: tcb_cap_cases_def)
+            apply (rule allI[OF ball_tcb_cte_casesI]; clarsimp)
+           apply fastforce
+          apply fastforce
+         apply fastforce
+        apply (rule corres_split[OF handleEvent_corres_arch_extras])
+          apply (rule corres_stateAssert_assume_stronger[where Q=\<top> and
+                        P="\<lambda>s. valid_domain_list s \<and>
+                               (event \<noteq> Interrupt \<longrightarrow> 0 < domain_time s) \<and>
+                               (event = Interrupt \<longrightarrow> domain_time s = 0 \<longrightarrow>
+                                 scheduler_action s = choose_new_thread)"])
+           apply (clarsimp simp: prod_lift_def)
+          apply (clarsimp simp: state_relation_def)
+         apply (wp add: threadSet_invs_trivial thread_set_invs_trivial thread_set_ct_in_state
+                        threadSet_ct_running' thread_set_not_state_valid_sched
+                        hoare_vcg_const_imp_lift
+                        handle_interrupt_valid_domain_time handle_event_valid_domain_time_IRQ
+                        handle_event_noIRQ_domain_time_inv
+                        no_domain_caps_sep_inv_lift[OF thread_set_tcb_arch_update_domain_sep_inv]
+                   del: handle_event_domain_time_valid
+                | simp add: tcb_cap_cases_def schact_is_rct_def maybe_handle_interrupt_def
+                            arch_tcb_update_aux2
+                | wpc
+                | wps
+                | wp (once) hoare_drop_imp)+
+   apply (fastforce simp: invs_def cur_tcb_def valid_state_def)
+  apply force
   done
 
 end
 
 requalify_consts
-  RISCV64.doUserOp_if
+  AARCH64.doUserOp_if
 
 
 global_interpretation ADT_IF_Refine_1?: ADT_IF_Refine_1 doUserOp_if

--- a/proof/infoflow/refine/AARCH64/ArchADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/AARCH64/ArchADT_IF_Refine_C.thy
@@ -12,25 +12,6 @@ context kernel_m begin
 
 named_theorems ADT_IF_Refine_assms
 
-lemma handleInterrupt_ccorres[ADT_IF_Refine_assms]:
-  "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
-           (invs')
-           (UNIV)
-           []
-           (handleEvent Interrupt)
-           (handleInterruptEntry_C_body_if)"
-  apply (rule ccorres_guard_imp2)
-   apply (simp add: handleEvent_def minus_one_norm handleInterruptEntry_C_body_if_def)
-   apply (rule ccorres_add_return2)
-   apply (ctac (no_vcg) add: checkInterrupt_ccorres)
-    apply (rule_tac R="\<lambda>_. rv = Inr ()" in ccorres_return[where R'=UNIV])
-    apply (rule conseqPre, vcg)
-    apply (clarsimp simp: return_def)
-   apply (simp add: liftE_def)
-   apply wpsimp
-  apply clarsimp
-  done
-
 lemma handleInvocation_ccorres'[ADT_IF_Refine_assms]:
   "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
        (invs' and arch_extras and ct_active' and sch_act_simple)
@@ -182,6 +163,8 @@ lemma check_active_irq_corres_C[ADT_IF_Refine_assms]:
           apply (rule ccorres_rel_imp, rule ccorres_guard_imp)
              apply (rule getActiveIRQ_ccorres)
             apply simp+
+          apply (clarsimp split: option.splits)
+         apply simp+
        apply (rule no_fail_dmo')
        apply (rule no_fail_getActiveIRQ)
       apply (rule corres_trivial, clarsimp split: if_split option.splits)
@@ -224,10 +207,144 @@ lemma obs_cpspace_user_data_relation[ADT_IF_Refine_assms]:
   apply simp
   done
 
+
+definition handleHypervisorFault_C_body_if :: "64 word \<Rightarrow> (globals myvars, int, strictc_errortype) com"
+  where
+  "handleHypervisorFault_C_body_if hyp_fault_type ==
+      IF hyp_fault_type = 0x2000000 THEN
+        \<acute>ret__unsigned_long :== CALL getESR();;
+        \<acute>current_fault :== CALL seL4_Fault_UserException_new(\<acute>ret__unsigned_long,scast (0 :: 32 signed word));;
+        CALL handleFault(\<acute>ksCurThread)
+      ELSE
+        \<acute>current_fault :== CALL seL4_Fault_VCPUFault_new(hyp_fault_type);;
+        CALL handleFault(\<acute>ksCurThread)
+      FI;; \<acute>ret__unsigned_long :== scast EXCEPTION_NONE"
+
+definition hyp_fault_type_from_H :: "hyp_fault_type \<Rightarrow> machine_word" where
+  "hyp_fault_type_from_H fault \<equiv>
+    case fault of hyp_fault_type.ARMVCPUFault f \<Rightarrow> ucast f"
+
+lemma ucast_helper:
+  "\<lbrakk> UCAST('a::len \<rightarrow> 'b::len) a = b; LENGTH('a) \<le> LENGTH('b) \<rbrakk>
+     \<Longrightarrow> a = UCAST('b::len \<rightarrow> 'a::len) b"
+  by fastforce
+
+
+lemma handleHypervisorFault_C_body_ccorres[ADT_IF_Refine_assms]:
+  "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
+           (invs' and arch_extras and ct_running' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
+           (UNIV) []
+           (liftE (do thread <- getCurThread;
+                      handleHypervisorFault thread flt
+                   od))
+           (handleHypervisorFault_C_body_if (hyp_fault_type_from_H flt))"
+  apply (rule ccorres_guard_imp)
+   apply (simp add: liftE_def bind_assoc handleHypervisorFault_C_body_if_def)
+   apply (rule ccorres_pre_getCurThread)
+   apply (rule ccorres_split_nothrow_novcg)
+
+
+       apply (simp only: handleHypervisorFault_def handleHypervisorFault_C_body_if_def hyp_fault_type_from_H_def)
+       apply wpc
+       apply (simp only: hyp_fault_type.simps)
+
+       apply (rule_tac P="ARMVCPUFault x = ARMVCPUFault 0x2000000" in ccorres_cases)
+        apply clarsimp
+        apply (rule ccorres_cond_univ)
+        apply (rule ccorres_rhs_assoc)+
+        apply (ctac (no_vcg) add: getESR_ccorres)
+         apply (rule ccorres_symb_exec_r)
+         apply (rule_tac P="\<lambda>s. ksCurThread s = thread" in ccorres_cross_over_guard)
+
+           apply (rule_tac xf'=xfdc in ccorres_call)
+              apply (ctac (no_vcg) add: handleFault_ccorres)
+             apply simp
+            apply simp
+           apply simp
+          apply vcg
+         apply (clarsimp, rule conseqPre, vcg)
+         apply clarsimp
+        apply wp
+
+apply clarsimp
+       apply (prop_tac "x \<noteq> 0x2000000")
+        apply clarsimp
+       apply clarsimp
+       apply (prop_tac "UCAST(32 \<rightarrow> 64) x \<noteq> 0x2000000")
+        apply (erule swap)
+        apply clarsimp
+        apply (drule ucast_helper)
+         apply clarsimp
+        apply clarsimp
+       apply clarsimp
+
+       apply (rule ccorres_cond_empty)
+       apply (rule ccorres_symb_exec_r)
+         apply (rule_tac P="\<lambda>s. ksCurThread s = thread" in ccorres_cross_over_guard)
+         apply (rule_tac xf'=xfdc in ccorres_call)
+            apply (ctac (no_vcg) add: handleFault_ccorres)
+           apply simp
+          apply simp
+         apply simp
+          apply vcg
+       apply (rule conseqPre, vcg)
+         apply clarsimp
+      apply ceqv
+
+      apply clarsimp
+      apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
+      apply (rule allI, rule conseqPre, vcg)
+      apply (clarsimp simp: return_def)
+
+      apply wp
+     apply (simp add: guard_is_UNIV_def)
+   apply clarsimp
+   apply (auto simp: ct_in_state'_def isReply_def is_cap_fault_def
+                     cfault_rel_def seL4_Fault_UnknownSyscall_lift seL4_Fault_UserException_lift
+                     seL4_Fault_VCPUFault_lift
+               elim: pred_tcb'_weakenE st_tcb_ex_cap''
+               dest: st_tcb_at_idle_thread' rf_sr_ksCurThread split: if_splits)[1]
+  apply (rule ucast_and_mask_drop)
+  apply clarsimp
+  done
+
+declare handleSpuriousIRQ_ccorres[ADT_IF_Refine_assms]
+declare hvmf_invs_lift[ADT_IF_Refine_assms]
+
+lemma checkInterrupt_ccorres'[ADT_IF_Refine_assms]:
+  "ccorres dc xfdc (\<lambda>s. invs' s \<and> (\<not>inKernel \<longrightarrow> sch_act_not (ksCurThread s) s)) UNIV []
+           (maybeHandleInterrupt inKernel) (Call checkInterrupt_'proc)"
+  unfolding maybeHandleInterrupt_def
+  apply cinit'
+  apply (rule ccorres_guard_imp)
+    apply (simp add: liftE_def bind_assoc)
+    apply (ctac (no_vcg) add: getActiveIRQ_ccorres)
+         apply (rule_tac P="\<lambda>_. rv \<noteq> None" and R=\<top> in ccorres_cond_both)
+           apply (auto split: option.splits)[1]
+          apply (rule_tac P="rv \<noteq> None" in ccorres_gen_asm)
+          apply clarsimp
+          apply wpfix
+          apply (rule ccorres_call[where xf'=xfdc, OF handleInterrupt_ccorres]; simp)
+         apply (rule_tac P="rv = None" in ccorres_gen_asm)
+         apply clarsimp
+         apply wpfix
+         apply (ctac (no_vcg) add: handleSpuriousIRQ_ccorres)
+      apply wp
+     apply (simp add: guard_is_UNIV_def)
+    apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>irq. rv = Some irq \<longrightarrow> irq \<in> non_kernel_IRQs \<longrightarrow>
+                                                sch_act_not (ksCurThread s) s)"
+                    in hoare_post_imp)
+     apply (solves clarsimp)
+    apply (wpsimp wp: dmo_getActiveIRQ_inKernel_sch_act_not)
+    apply assumption
+   apply assumption
+  apply (clarsimp simp: invs'_def valid_state'_def)
+  done
+
 end
 
 
-sublocale kernel_m \<subseteq> ADT_IF_Refine_1?: ADT_IF_Refine_1 _ _ _ doUserOp_C_if
+sublocale kernel_m \<subseteq> ADT_IF_Refine_1?: ADT_IF_Refine_1 _ _ _ doUserOp_C_if handleHypervisorFault_C_body_if hyp_fault_type_from_H
 proof goal_cases
   interpret Arch .
   case 1 show ?case

--- a/proof/infoflow/refine/AARCH64/Example_Valid_StateH.thy
+++ b/proof/infoflow/refine/AARCH64/Example_Valid_StateH.thy
@@ -9,6 +9,53 @@ theory Example_Valid_StateH
 imports "InfoFlow.Example_Valid_State" ArchADT_IF_Refine
 begin
 
+(* FIXME AARCH64 IF: major cleanup *)
+
+context Arch begin arch_global_naming
+
+definition pg_index_bits :: nat where
+  "pg_index_bits \<equiv> pageBitsForSize (max_page_size) - pageBits"
+
+lemma pg_index_bits_def2:
+  "pg_index_bits \<equiv> if config_ARM_PA_SIZE_BITS_40 then 9 else 18"
+  apply (rule eq_reflection)
+  apply (simp add: pg_index_bits_def max_page_size_def bit_simps)
+  done
+
+lemma pg_index_bits_ge0[simp, intro!]: "0 < pg_index_bits"
+  by (simp add: pg_index_bits_def2)
+
+typedef pg_index_len = "{n :: nat. n < pg_index_bits}" by auto
+
+end
+
+instantiation AARCH64.pg_index_len :: len0
+begin
+  interpretation Arch .
+  definition len_of_pg_index_len: "len_of (x::pg_index_len itself) \<equiv> CARD(pg_index_len)"
+  instance ..
+end
+
+instantiation AARCH64.pg_index_len :: len
+begin
+  interpretation Arch .
+  instance
+  proof
+   show "0 < LENGTH(pg_index_len)"
+     by (simp add: len_of_pg_index_len type_definition.card[OF type_definition_pg_index_len])
+  qed
+end
+
+context Arch begin arch_global_naming
+
+type_synonym pg_index = "pg_index_len word"
+
+lemma length_pg_index_len[simp]:
+  "LENGTH(pg_index_len) = pg_index_bits"
+  by (simp add: len_of_pg_index_len type_definition.card[OF type_definition_pg_index_len])
+
+end
+
 context begin interpretation Arch .
 
 section \<open>Haskell state\<close>
@@ -36,16 +83,16 @@ definition Low_capsH :: "cnode_index \<Rightarrow> (capability \<times> mdbnode)
         (the_nat_to_bl_10 2)
           \<mapsto> (CNodeCap Low_cnode_ptr 10 2 10, MDB 0 Low_tcb_ptr False False),
         (the_nat_to_bl_10 3)
-          \<mapsto> (ArchObjectCap (PageTableCap Low_pd_ptr (Some (ucast Low_asid, 0))),
+          \<mapsto> (ArchObjectCap (PageTableCap Low_pd_ptr VSRootPT_T (Some (ucast Low_asid, 0))),
               MDB 0 (Low_tcb_ptr + 0x20) False False),
         (the_nat_to_bl_10 4)
           \<mapsto> (ArchObjectCap (ASIDPoolCap Low_pool_ptr (ucast Low_asid)), Null_mdb),
         (the_nat_to_bl_10 5)
-          \<mapsto> (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadWrite RISCVLargePage
+          \<mapsto> (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadWrite max_page_size
                                       False (Some (ucast Low_asid, 0))),
               MDB 0 (Silc_cnode_ptr + 0xA0) False False),
         (the_nat_to_bl_10 6)
-          \<mapsto> (ArchObjectCap (PageTableCap Low_pt_ptr (Some (ucast Low_asid, 0))), Null_mdb),
+          \<mapsto> (ArchObjectCap (PageTableCap Low_pt_ptr NormalPT_T (Some (ucast Low_asid, 0))), Null_mdb),
         (the_nat_to_bl_10 318)
           \<mapsto> (NotificationCap ntfn_ptr 0 True False, MDB (Silc_cnode_ptr + 318 * 0x20) 0 False False))"
 
@@ -69,16 +116,16 @@ definition High_capsH :: "cnode_index \<Rightarrow> (capability \<times> mdbnode
         (the_nat_to_bl_10 2)
           \<mapsto> (CNodeCap High_cnode_ptr 10 2 10, MDB 0 High_tcb_ptr False False),
         (the_nat_to_bl_10 3)
-          \<mapsto> (ArchObjectCap (PageTableCap High_pd_ptr (Some (ucast High_asid, 0))),
+          \<mapsto> (ArchObjectCap (PageTableCap High_pd_ptr VSRootPT_T (Some (ucast High_asid, 0))),
               MDB 0 (High_tcb_ptr + 0x20) False False),
         (the_nat_to_bl_10 4)
           \<mapsto> (ArchObjectCap (ASIDPoolCap High_pool_ptr (ucast High_asid)), Null_mdb),
         (the_nat_to_bl_10 5)
-          \<mapsto> (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadOnly RISCVLargePage
+          \<mapsto> (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadOnly max_page_size
                                       False (Some (ucast High_asid, 0))),
               MDB (Silc_cnode_ptr + 0xA0) 0 False False),
         (the_nat_to_bl_10 6)
-          \<mapsto> (ArchObjectCap (PageTableCap High_pt_ptr (Some (ucast High_asid, 0))),
+          \<mapsto> (ArchObjectCap (PageTableCap High_pt_ptr NormalPT_T (Some (ucast High_asid, 0))),
                   Null_mdb),
         (the_nat_to_bl_10 318)
           \<mapsto> (NotificationCap ntfn_ptr 0 False True, MDB 0 (Silc_cnode_ptr + 318 * 0x20) False False))"
@@ -101,7 +148,7 @@ definition Silc_capsH :: "cnode_index \<Rightarrow> (capability \<times> mdbnode
        ((the_nat_to_bl_10 2)
           \<mapsto> (CNodeCap Silc_cnode_ptr 10 2 10, Null_mdb),
         (the_nat_to_bl_10 5)
-          \<mapsto> (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadOnly RISCVLargePage
+          \<mapsto> (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadOnly max_page_size
                                       False (Some (ucast Silc_asid, 0))),
               MDB (Low_cnode_ptr + 0xA0) (High_cnode_ptr + 0xA0) False False),
         (the_nat_to_bl_10 318)
@@ -126,48 +173,32 @@ definition ntfnH :: notification where
 
 text \<open>Global page table\<close>
 
-definition global_pteH' :: "pt_index \<Rightarrow> pte" where
-  "global_pteH' idx \<equiv>
-     if idx = 0x100
-     then PagePTE ((ucast (idx && mask (ptTranslationBits - 1)) << ptTranslationBits * size max_pt_level))
-                  False False False VMKernelOnly
-     else if idx = elf_index
-     then PagePTE (ucast ((kernelELFPAddrBase && ~~mask toplevel_bits) >> pageBits)) False False False VMKernelOnly
-     else InvalidPTE"
-
-definition global_pteH where
-  "global_pteH \<equiv> (\<lambda>idx. if idx \<in> kernel_mapping_slots then global_pteH' idx else InvalidPTE)"
+abbreviation (input) pt_lift where
+  "pt_lift pt_t pt \<equiv> \<lambda>base offs.
+     if is_aligned offs 3 \<and> base \<le> offs \<and> offs \<le> base + 2 ^ (pt_bits pt_t) - 1
+     then Some (KOArch (KOPTE (pt (ucast (offs - base >> 3)))))
+     else None"
 
 definition global_ptH :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kernel_object option" where
-  "global_ptH \<equiv> \<lambda>base.
-     (map_option (\<lambda>x. KOArch (KOPTE (global_pteH (x :: pt_index))))) \<circ>
-     (\<lambda>offs. if is_aligned offs 3 \<and> base \<le> offs \<and> offs \<le> base + 2 ^ 12 - 1
-             then Some (ucast (offs - base >> 3)) else None)"
-
+  "global_ptH \<equiv> pt_lift VSRootPT_T (\<lambda>_. InvalidPTE)"
 
 text \<open>Low's page tables\<close>
 
 definition Low_pt'H :: "pt_index \<Rightarrow> pte" where
   "Low_pt'H \<equiv>
      (\<lambda>_. InvalidPTE)
-       (0 := PagePTE (shared_page_ptr_phys >> pt_bits) False False False VMReadWrite)"
+       (0 := PagePTE shared_page_ptr_phys False False True False VMReadWrite)"
 
 definition Low_ptH :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kernel_object option" where
-  "Low_ptH \<equiv>
-     \<lambda>base. (map_option (\<lambda>x. KOArch (KOPTE (Low_pt'H x)))) \<circ>
-            (\<lambda>offs. if is_aligned offs 3 \<and> base \<le> offs \<and> offs \<le> base + 2 ^ 12 - 1
-                    then Some (ucast (offs - base >> 3)) else None)"
+  "Low_ptH \<equiv> pt_lift NormalPT_T Low_pt'H"
 
-definition Low_pd'H :: "pt_index \<Rightarrow> pte" where
+definition Low_pd'H :: "vs_index \<Rightarrow> pte" where
   "Low_pd'H \<equiv>
-     global_pteH
-       (0 := PageTablePTE (addrFromPPtr Low_pt_ptr >> pt_bits) False)"
+     (\<lambda>_. InvalidPTE)
+       (0 := PageTablePTE (addrFromPPtr Low_pt_ptr >> pageBits))"
 
 definition Low_pdH :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kernel_object option" where
-  "Low_pdH \<equiv>
-     \<lambda>base. (map_option (\<lambda>x. KOArch (KOPTE (Low_pd'H x)))) \<circ>
-            (\<lambda>offs. if is_aligned offs 3 \<and> base \<le> offs \<and> offs \<le> base + 2 ^ 12 - 1
-                    then Some (ucast (offs - base >> 3)) else None)"
+  "Low_pdH \<equiv> pt_lift VSRootPT_T Low_pd'H"
 
 
 text \<open>High's page tables\<close>
@@ -175,24 +206,18 @@ text \<open>High's page tables\<close>
 definition High_pt'H :: "pt_index \<Rightarrow> pte" where
   "High_pt'H \<equiv>
      (\<lambda>_. InvalidPTE)
-       (0 := PagePTE (shared_page_ptr_phys >> pt_bits) False False False VMReadOnly)"
+       (0 := PagePTE shared_page_ptr_phys False False True False VMReadOnly)"
 
 definition High_ptH :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kernel_object option" where
-  "High_ptH \<equiv>
-     \<lambda>base. (map_option (\<lambda>x. KOArch (KOPTE (High_pt'H x)))) \<circ>
-            (\<lambda>offs. if is_aligned offs 3 \<and> base \<le> offs \<and> offs \<le> base + 2 ^ 12 - 1
-                    then Some (ucast (offs - base >> 3)) else None)"
+  "High_ptH \<equiv> pt_lift NormalPT_T High_pt'H"
 
-definition High_pd'H :: "pt_index \<Rightarrow> pte" where
+definition High_pd'H :: "vs_index \<Rightarrow> pte" where
   "High_pd'H \<equiv>
-     global_pteH
-       (0 := PageTablePTE (addrFromPPtr High_pt_ptr >> pt_bits) False)"
+     (\<lambda>_. InvalidPTE)
+       (0 := PageTablePTE (addrFromPPtr High_pt_ptr >> pageBits))"
 
 definition High_pdH :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kernel_object option" where
-  "High_pdH \<equiv>
-     \<lambda>base. (map_option (\<lambda>x. KOArch (KOPTE (High_pd'H x)))) \<circ>
-            (\<lambda>offs. if is_aligned offs 3 \<and> base \<le> offs \<and> offs \<le> base + 2 ^ 12 - 1
-                    then Some (ucast (offs - base >> 3)) else None)"
+  "High_pdH \<equiv> pt_lift VSRootPT_T High_pd'H"
 
 
 text \<open>Low's tcb\<close>
@@ -201,7 +226,7 @@ definition Low_tcbH :: tcb where
   "Low_tcbH \<equiv> Thread
      \<comment> \<open>tcbCTable            =\<close> (CTE (CNodeCap Low_cnode_ptr 10 2 10)
                                       (MDB (Low_cnode_ptr + 0x40) 0 False False))
-     \<comment> \<open>tcbVTable            =\<close> (CTE (ArchObjectCap (PageTableCap Low_pd_ptr (Some (ucast Low_asid, 0))))
+     \<comment> \<open>tcbVTable            =\<close> (CTE (ArchObjectCap (PageTableCap Low_pd_ptr VSRootPT_T (Some (ucast Low_asid, 0))))
                                       (MDB (Low_cnode_ptr + 0x60) 0 False False))
      \<comment> \<open>tcbReply             =\<close> (CTE (ReplyCap Low_tcb_ptr True True) (MDB 0 0 True True))
      \<comment> \<open>tcbCaller            =\<close> (CTE NullCap Null_mdb)
@@ -219,7 +244,7 @@ definition Low_tcbH :: tcb where
      \<comment> \<open>tcbSchedPrev         =\<close> None
      \<comment> \<open>tcbSchedNext         =\<close> None
      \<comment> \<open>tcbFlags             =\<close> 0
-     \<comment> \<open>tcbContext           =\<close> (ArchThread undefined)"
+     \<comment> \<open>tcbContext           =\<close> (ArchThread empty_context None)"
 
 
 text \<open>High's tcb\<close>
@@ -228,7 +253,7 @@ definition High_tcbH :: tcb where
   "High_tcbH \<equiv> Thread
      \<comment> \<open>tcbCTable            =\<close> (CTE (CNodeCap High_cnode_ptr 10 2 10)
                                       (MDB (High_cnode_ptr + 0x40) 0 False False))
-     \<comment> \<open>tcbVTable            =\<close> (CTE (ArchObjectCap (PageTableCap High_pd_ptr (Some (ucast High_asid, 0))))
+     \<comment> \<open>tcbVTable            =\<close> (CTE (ArchObjectCap (PageTableCap High_pd_ptr VSRootPT_T (Some (ucast High_asid, 0))))
                                       (MDB (High_cnode_ptr + 0x60) 0 False False))
      \<comment> \<open>tcbReply             =\<close> (CTE (ReplyCap High_tcb_ptr True True) (MDB 0 0 True True))
      \<comment> \<open>tcbCaller            =\<close> (CTE NullCap Null_mdb)
@@ -246,8 +271,7 @@ definition High_tcbH :: tcb where
      \<comment> \<open>tcbSchedPrev         =\<close> None
      \<comment> \<open>tcbSchedNext         =\<close> None
      \<comment> \<open>tcbFlags             =\<close> 0
-     \<comment> \<open>tcbContext           =\<close> (ArchThread undefined)"
-
+     \<comment> \<open>tcbContext           =\<close> (ArchThread empty_context None)"
 
 text \<open>idle's tcb\<close>
 
@@ -271,13 +295,13 @@ definition idle_tcbH :: tcb where
      \<comment> \<open>tcbSchedPrev         =\<close> None
      \<comment> \<open>tcbSchedNext         =\<close> None
      \<comment> \<open>tcbFlags             =\<close> 0
-     \<comment> \<open>tcbContext           =\<close> (ArchThread empty_context)"
+     \<comment> \<open>tcbContext           =\<close> (ArchThread empty_context None)"
 
 
 text \<open>Low's asid pool\<close>
 
-abbreviation Low_poolH' :: "obj_ref \<rightharpoonup> obj_ref" where
-  "Low_poolH' \<equiv> \<lambda>idx. if idx = ucast (asid_low_bits_of Low_asid) then Some Low_pd_ptr else None"
+abbreviation Low_poolH' :: "asid \<rightharpoonup> asidpool_entry" where
+  "Low_poolH' \<equiv> \<lambda>idx. if idx = ucast (asid_low_bits_of Low_asid) then Some (ASIDPoolVSpace None Low_pd_ptr) else None"
 
 definition Low_poolH :: arch_kernel_object where
   "Low_poolH \<equiv> KOASIDPool (ASIDPool Low_poolH')"
@@ -285,8 +309,8 @@ definition Low_poolH :: arch_kernel_object where
 
 text \<open>High's asid pool\<close>
 
-abbreviation High_poolH' :: "obj_ref \<rightharpoonup> obj_ref" where
-  "High_poolH' \<equiv> \<lambda>idx. if idx = ucast (asid_low_bits_of High_asid) then Some High_pd_ptr else None"
+abbreviation High_poolH' :: "asid \<rightharpoonup> asidpool_entry" where
+  "High_poolH' \<equiv> \<lambda>idx. if idx = ucast (asid_low_bits_of High_asid) then Some (ASIDPoolVSpace None High_pd_ptr) else None"
 
 definition High_poolH :: arch_kernel_object where
   "High_poolH \<equiv> KOASIDPool (ASIDPool High_poolH')"
@@ -296,7 +320,7 @@ text \<open>Shared page\<close>
 
 definition shared_pageH :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> kernel_object option" where
   "shared_pageH \<equiv> \<lambda>base.
-     (\<lambda>offs. if is_aligned offs 12 \<and> base \<le> offs \<and> offs \<le> base + 2 ^ 21 - 1
+     (\<lambda>offs. if is_aligned offs 12 \<and> base \<le> offs \<and> offs \<le> base + mask (pageBitsForSize max_page_size)
              then Some KOUserData else None)"
 
 
@@ -326,67 +350,78 @@ definition kh0H :: "(obj_ref \<rightharpoonup> kernel_object)" where
            option_update_range [High_tcb_ptr \<mapsto> KOTCB High_tcbH] \<circ>
            option_update_range [idle_tcb_ptr \<mapsto> KOTCB idle_tcbH] \<circ>
            option_update_range (shared_pageH shared_page_ptr_virt) \<circ>
-           option_update_range (global_ptH riscv_global_pt_ptr)
+           option_update_range (global_ptH arm_global_pt_ptr)
            ) Map.empty"
 
-
 lemma s0_ptrs_aligned:
-  "is_aligned riscv_global_pt_ptr 12"
-  "is_aligned High_pd_ptr 12"
-  "is_aligned Low_pd_ptr 12"
+  "is_aligned arm_global_pt_ptr (pt_bits VSRootPT_T)"
+  "is_aligned High_pd_ptr (pt_bits VSRootPT_T)"
+  "is_aligned Low_pd_ptr (pt_bits VSRootPT_T)"
+  "is_aligned arm_global_pt_ptr 13"
+  "is_aligned High_pd_ptr 13"
+  "is_aligned Low_pd_ptr 13"
   "is_aligned High_pt_ptr 12"
   "is_aligned Low_pt_ptr 12"
   "is_aligned Silc_cnode_ptr 15"
   "is_aligned High_cnode_ptr 15"
   "is_aligned Low_cnode_ptr 15"
-  "is_aligned High_tcb_ptr 10"
-  "is_aligned Low_tcb_ptr 10"
-  "is_aligned idle_tcb_ptr 10"
+  "is_aligned High_tcb_ptr 11"
+  "is_aligned Low_tcb_ptr 11"
+  "is_aligned idle_tcb_ptr 11"
   "is_aligned ntfn_ptr 5"
-  "is_aligned shared_page_ptr_virt 21"
+  "is_aligned shared_page_ptr_virt 30"
   "is_aligned irq_cnode_ptr 10"
   "is_aligned Low_pool_ptr 12"
   "is_aligned High_pool_ptr 12"
-  by (simp add: is_aligned_def s0_ptr_defs)+
+  by (simp add: is_aligned_def s0_ptr_defs bit_simps)+
 
 
 text \<open>Page offset lemmas\<close>
 
+declare pg_index_bits_def2[bit_simps]
+
 lemma page_offs_min':
-  "is_aligned ptr 21 \<Longrightarrow> (ptr :: obj_ref) \<le> ptr + (ucast (x :: pt_index) << 12)"
+  "is_aligned ptr 30 \<Longrightarrow> (ptr :: obj_ref) \<le> ptr + (ucast (x :: pg_index) << 12)"
+  unfolding bit_simps
   apply (erule is_aligned_no_wrap')
-  apply (word_bitwise, auto)
+  apply (auto split: if_splits)
+  apply (rule ucast_less_shiftl_helper')
+   apply (auto simp: bit_simps)[2]
   done
 
 lemma page_offs_min:
-  "shared_page_ptr_virt \<le> shared_page_ptr_virt + (ucast (x:: pt_index) << 12)"
+  "shared_page_ptr_virt \<le> shared_page_ptr_virt + (ucast (x:: pg_index) << 12)"
   by (simp_all add: page_offs_min' s0_ptrs_aligned)
 
+lemma pageBitsForSize_max_page_size[bit_simps]:
+  "pageBitsForSize max_page_size = (if config_ARM_PA_SIZE_BITS_40 then 21 else 30)"
+  by (auto simp: max_page_size_def bit_simps)
+
 lemma page_offs_max':
-  "is_aligned ptr 21 \<Longrightarrow> (ptr :: obj_ref) + (ucast (x :: pt_index) << 12) \<le> ptr + 0x1FFFFF"
+  "is_aligned ptr 30 \<Longrightarrow> (ptr :: obj_ref) + (ucast (x :: pg_index) << 12) \<le> ptr + mask (pageBitsForSize max_page_size)"
   apply (rule word_plus_mono_right)
    apply (simp add: shiftl_t2n mult.commute)
    apply (rule div_to_mult_word_lt)
-   apply simp
    apply (rule plus_one_helper)
-   apply simp
    apply (cut_tac ucast_less[where x=x])
-    apply simp
-   apply (fastforce elim: dual_order.strict_trans[rotated])
+    apply (auto simp add: bit_simps mask_def split: if_splits)[2]
+  apply (drule_tac y="pageBitsForSize max_page_size" in is_aligned_weaken)
+   apply (simp add: bit_simps)
   apply (drule is_aligned_no_overflow)
-  apply (simp add: add.commute)
+  apply (simp add: mask_2pm1 p_assoc_help)
   done
 
 lemma page_offs_max:
-  "shared_page_ptr_virt + (ucast (x :: pt_index) << 12) \<le> shared_page_ptr_virt + 0x1FFFFF"
+  "shared_page_ptr_virt + (ucast (x :: pg_index) << 12) \<le> shared_page_ptr_virt + mask (pageBitsForSize max_page_size)"
   by (simp_all add: page_offs_max' s0_ptrs_aligned)
 
+
 definition page_offs_range where
-  "page_offs_range (ptr :: obj_ref) \<equiv> {x. ptr \<le> x \<and> x \<le> ptr + 2 ^ 21 - 1}
+  "page_offs_range (ptr :: obj_ref) \<equiv> {x. ptr \<le> x \<and> x \<le> ptr + mask (pageBitsForSize max_page_size)}
                                     \<inter> {x. is_aligned x 12}"
 
 lemma page_offs_in_range':
-  "is_aligned ptr 21 \<Longrightarrow> ptr + (ucast (x :: pt_index) << 12) \<in> page_offs_range ptr"
+  "is_aligned ptr 30 \<Longrightarrow> ptr + (ucast (x :: pg_index) << 12) \<in> page_offs_range ptr"
   apply (clarsimp simp: page_offs_min' page_offs_max' page_offs_range_def add.commute)
   apply (rule is_aligned_add[OF _ is_aligned_shift])
   apply (erule is_aligned_weaken)
@@ -394,13 +429,13 @@ lemma page_offs_in_range':
   done
 
 lemma page_offs_in_range:
-  "shared_page_ptr_virt + (ucast (x :: pt_index) << 12) \<in> page_offs_range shared_page_ptr_virt"
+  "shared_page_ptr_virt + (ucast (x :: pg_index) << 12) \<in> page_offs_range shared_page_ptr_virt"
   by (simp_all add: page_offs_in_range' s0_ptrs_aligned)
 
 lemma page_offs_range_correct':
-  "\<lbrakk> x \<in> page_offs_range ptr; is_aligned ptr 21 \<rbrakk>
-     \<Longrightarrow> \<exists>y. x = ptr + (ucast (y :: pt_index) << 12)"
-  apply (clarsimp simp: page_offs_range_def s0_ptr_defs)
+  "\<lbrakk> x \<in> page_offs_range ptr; is_aligned ptr 30 \<rbrakk>
+     \<Longrightarrow> \<exists>y. x = ptr + (ucast (y :: pg_index) << 12)"
+  apply (clarsimp simp: page_offs_range_def s0_ptr_defs bit_simps)
   apply (rule_tac x="ucast ((x - ptr) >> 12)" in exI)
   apply (clarsimp simp: ucast_ucast_mask)
   apply (subst aligned_shiftr_mask_shiftl)
@@ -409,8 +444,30 @@ lemma page_offs_range_correct':
     apply (erule is_aligned_weaken)
     apply simp
    apply simp
-  apply simp
-  apply (rule_tac n=21 in mask_eqI)
+  apply (simp add: bit_simps split: if_splits)
+   apply (drule is_aligned_weaken[where y=21], solves simp)
+   apply (rule_tac n=21 in mask_eqI)
+    apply (subst mask_add_aligned)
+     apply (simp add: is_aligned_def)
+    apply (simp add: mask_twice)
+    apply (subst diff_conv_add_uminus)
+    apply (subst add.commute[symmetric])
+    apply (subst mask_add_aligned)
+     apply (simp add: is_aligned_minus)
+    apply simp
+   apply (subst diff_conv_add_uminus)
+   apply (subst add_mask_lower_bits)
+     apply (simp add: is_aligned_def)
+    apply clarsimp
+   apply (cut_tac x=x and y="ptr + mask 21" and n=21 in neg_mask_mono_le)
+    apply (simp add: add_ac)
+   apply (drule_tac n=21 in aligned_le_sharp)
+    apply (simp add: is_aligned_def)
+   apply (subst(asm) mask_out_add_aligned[symmetric])
+    apply (erule is_aligned_weaken)
+    apply simp
+   apply (simp add: mask_def)
+  apply (rule_tac n=30 in mask_eqI)
    apply (subst mask_add_aligned)
     apply (simp add: is_aligned_def)
    apply (simp add: mask_twice)
@@ -423,11 +480,10 @@ lemma page_offs_range_correct':
   apply (subst add_mask_lower_bits)
     apply (simp add: is_aligned_def)
    apply clarsimp
-  apply (cut_tac x=x and y="ptr + 0x1FFFFF" and n=21 in neg_mask_mono_le)
-   apply (simp add: add.commute)
-  apply (drule_tac n=21 in aligned_le_sharp)
+  apply (cut_tac x=x and y="ptr + mask 30" and n=30 in neg_mask_mono_le)
+   apply (simp add: add_ac)
+  apply (drule_tac n=30 in aligned_le_sharp)
    apply (simp add: is_aligned_def)
-  apply (simp add: add.commute)
   apply (subst(asm) mask_out_add_aligned[symmetric])
    apply (erule is_aligned_weaken)
    apply simp
@@ -436,7 +492,7 @@ lemma page_offs_range_correct':
 
 lemma page_offs_range_correct:
   "x \<in> page_offs_range shared_page_ptr_virt
-   \<Longrightarrow> \<exists>y. x = shared_page_ptr_virt + (ucast (y :: pt_index) << 12)"
+   \<Longrightarrow> \<exists>y. x = shared_page_ptr_virt + (ucast (y :: pg_index) << 12)"
   by (simp_all add: page_offs_range_correct' s0_ptrs_aligned)
 
 
@@ -444,66 +500,122 @@ text \<open>Page table offset lemmas\<close>
 
 lemma pt_offs_min':
   "is_aligned ptr 12 \<Longrightarrow> (ptr :: obj_ref) \<le> ptr + (ucast (x :: pt_index) << 3)"
+  unfolding bit_simps
   apply (erule is_aligned_no_wrap')
-  apply (word_bitwise, auto)
+  apply (rule ucast_less_shiftl_helper')
+   apply (auto simp: bit_simps)
+  done
+
+lemma vs_offs_min':
+  "is_aligned ptr 13 \<Longrightarrow> (ptr :: obj_ref) \<le> ptr + (ucast (x :: vs_index) << 3)"
+  unfolding bit_simps
+  apply (erule is_aligned_no_wrap')
+  apply (auto split: if_splits)
+  apply (rule ucast_less_shiftl_helper')
+   apply (auto simp: bit_simps)[2]
   done
 
 lemma pt_offs_min:
-  "Low_pd_ptr  \<le> Low_pd_ptr  + (ucast (x :: pt_index) << 3)"
-  "High_pd_ptr \<le> High_pd_ptr + (ucast (x :: pt_index) << 3)"
-  "Low_pt_ptr  \<le> Low_pt_ptr  + (ucast (x :: pt_index) << 3)"
-  "High_pt_ptr \<le> High_pt_ptr + (ucast (x :: pt_index) << 3)"
-  "riscv_global_pt_ptr \<le> riscv_global_pt_ptr + (ucast (x :: pt_index) << 3)"
-  by (simp_all add: pt_offs_min' s0_ptrs_aligned)
+  "Low_pd_ptr  \<le> Low_pd_ptr  + (ucast (x :: vs_index) << 3)"
+  "High_pd_ptr \<le> High_pd_ptr + (ucast (x :: vs_index) << 3)"
+  "Low_pt_ptr  \<le> Low_pt_ptr  + (ucast (y :: pt_index) << 3)"
+  "High_pt_ptr \<le> High_pt_ptr + (ucast (y :: pt_index) << 3)"
+  "arm_global_pt_ptr \<le> arm_global_pt_ptr + (ucast (x :: vs_index) << 3)"
+  by (auto intro: pt_offs_min' vs_offs_min' s0_ptrs_aligned)
 
 lemma pt_offs_max':
-  "is_aligned ptr 12 \<Longrightarrow> (ptr :: obj_ref) + (ucast (x :: pt_index) << 3) \<le> ptr + 0xFFF"
+  assumes "is_aligned ptr 12"
+  shows "(ptr :: obj_ref) + (ucast (x :: pt_index) << 3) \<le> ptr + 0xFFF"
   apply (rule word_plus_mono_right)
    apply (simp add: shiftl_t2n mult.commute)
    apply (rule div_to_mult_word_lt)
-   apply simp
+   apply (simp add: bit_simps mask_def)
    apply (rule plus_one_helper)
    apply simp
    apply (cut_tac ucast_less[where x=x])
     apply simp
    apply (fastforce elim: dual_order.strict_trans[rotated])
-  apply (drule is_aligned_no_overflow)
-  apply (simp add: add.commute)
+  apply (insert is_aligned_no_overflow[OF assms])
+  apply (auto simp add: add.commute bit_simps mask_def split: if_splits)
+  done
+
+lemma vs_offs_max':
+  assumes "is_aligned ptr (pt_bits VSRootPT_T)"
+  shows "(ptr :: obj_ref) + (ucast (x :: vs_index) << 3) \<le> ptr + mask (pt_bits VSRootPT_T)"
+  apply (rule word_plus_mono_right)
+   apply (simp add: shiftl_t2n mult.commute)
+   apply (rule div_to_mult_word_lt)
+   apply (auto simp add: bit_simps mask_def)[1]
+    apply (rule plus_one_helper)
+    apply simp
+    apply (cut_tac ucast_less[where x=x])
+     apply (simp add: bit_simps split: if_splits)
+    apply (simp add: bit_simps)
+   apply (rule plus_one_helper)
+   apply simp
+   apply (cut_tac ucast_less[where x=x])
+    apply (simp add: bit_simps split: if_splits)
+   apply (simp add: bit_simps)
+  apply (insert is_aligned_no_overflow[OF assms])
+  apply (auto simp add: add.commute bit_simps mask_def split: if_splits)
   done
 
 lemma pt_offs_max:
-  "Low_pd_ptr  + (ucast (x :: pt_index) << 3) \<le> Low_pd_ptr  + 0xFFF"
-  "High_pd_ptr + (ucast (x :: pt_index) << 3) \<le> High_pd_ptr + 0xFFF"
-  "Low_pt_ptr  + (ucast (x :: pt_index) << 3) \<le> Low_pt_ptr  + 0xFFF"
-  "High_pt_ptr + (ucast (x :: pt_index) << 3) \<le> High_pt_ptr + 0xFFF"
-  "riscv_global_pt_ptr + (ucast (x :: pt_index) << 3) \<le> riscv_global_pt_ptr + 0xFFF"
-  by (simp_all add: pt_offs_max' s0_ptrs_aligned)
+  "Low_pd_ptr  + (ucast (x :: vs_index) << 3) \<le> Low_pd_ptr  + mask (pt_bits VSRootPT_T)"
+  "High_pd_ptr + (ucast (x :: vs_index) << 3) \<le> High_pd_ptr + mask (pt_bits VSRootPT_T)"
+  "Low_pt_ptr  + (ucast (y :: pt_index) << 3) \<le> Low_pt_ptr  + 0xFFF"
+  "High_pt_ptr + (ucast (y :: pt_index) << 3) \<le> High_pt_ptr + 0xFFF"
+  "arm_global_pt_ptr + (ucast (x :: vs_index) << 3) \<le> arm_global_pt_ptr + mask (pt_bits VSRootPT_T)"
+  by (rule pt_offs_max' vs_offs_max', rule s0_ptrs_aligned)+
 
 definition pt_offs_range where
-  "pt_offs_range (ptr :: obj_ref) \<equiv> {x. ptr \<le> x \<and> x \<le> ptr + 2 ^ 12 - 1}
+  "pt_offs_range (pt_t :: pt_type) (ptr :: obj_ref) \<equiv> {x. ptr \<le> x \<and> x \<le> ptr + 2 ^ (pt_bits pt_t) - 1}
                                   \<inter> {x. is_aligned x 3}"
 
 lemma pt_offs_in_range':
   "is_aligned ptr 12
-   \<Longrightarrow> ptr + (ucast (x :: pt_index) << 3) \<in> pt_offs_range ptr"
-  apply (clarsimp simp: pt_offs_min' pt_offs_max' pt_offs_range_def add.commute)
+   \<Longrightarrow> ptr + (ucast (x :: pt_index) << 3) \<in> pt_offs_range NormalPT_T ptr"
+  apply (clarsimp simp: pt_offs_min' pt_offs_range_def add.commute)
+  apply (rule conjI)
+   apply (rule order.trans)
+    apply (erule pt_offs_max')
+   apply (simp add: bit_simps add_ac)
   apply (rule is_aligned_add[OF _ is_aligned_shift])
   apply (erule is_aligned_weaken)
-  apply simp
+  apply (simp add: bit_simps)
+  done
+
+lemma vs_offs_in_range':
+  "is_aligned ptr 13
+   \<Longrightarrow> ptr + (ucast (x :: vs_index) << 3) \<in> pt_offs_range VSRootPT_T ptr"
+  apply (clarsimp simp: pt_offs_range_def vs_offs_min')
+  apply (rule conjI)
+   apply (rule order.trans)
+    apply (rule vs_offs_max')
+    apply (erule is_aligned_weaken)
+    apply (simp add: bit_simps)
+   apply (simp add: bit_simps add_ac mask_def)
+  apply (rule is_aligned_add[OF _ is_aligned_shift])
+  apply (erule is_aligned_weaken)
+  apply (simp add: bit_simps)
   done
 
 lemma pt_offs_in_range:
-  "Low_pd_ptr + (ucast (x :: pt_index) << 3) \<in> pt_offs_range Low_pd_ptr"
-  "High_pd_ptr + (ucast (x :: pt_index) << 3) \<in> pt_offs_range High_pd_ptr"
-  "Low_pt_ptr + (ucast (x :: pt_index) << 3) \<in> pt_offs_range Low_pt_ptr"
-  "High_pt_ptr + (ucast (x :: pt_index) << 3) \<in> pt_offs_range High_pt_ptr"
-  "riscv_global_pt_ptr + (ucast (x :: pt_index) << 3) \<in> pt_offs_range riscv_global_pt_ptr"
-  by (simp_all add: pt_offs_in_range' s0_ptrs_aligned)
+  "Low_pd_ptr + (ucast (x :: vs_index) << 3) \<in> pt_offs_range VSRootPT_T Low_pd_ptr"
+  "High_pd_ptr + (ucast (x :: vs_index) << 3) \<in> pt_offs_range VSRootPT_T High_pd_ptr"
+  "Low_pt_ptr + (ucast (y :: pt_index) << 3) \<in> pt_offs_range NormalPT_T Low_pt_ptr"
+  "High_pt_ptr + (ucast (y :: pt_index) << 3) \<in> pt_offs_range NormalPT_T High_pt_ptr"
+  "arm_global_pt_ptr + (ucast (x :: vs_index) << 3) \<in> pt_offs_range VSRootPT_T arm_global_pt_ptr"
+  by (simp_all add: pt_offs_in_range' vs_offs_in_range' s0_ptrs_aligned)
+
+lemma is_aligned_pt_bitsD:
+  "is_aligned ptr (pt_bits pt_t) \<Longrightarrow> is_aligned ptr 12"
+  by (erule is_aligned_weaken, simp add: bit_simps)
 
 lemma pt_offs_range_correct':
-  "\<lbrakk> x \<in> pt_offs_range ptr; is_aligned ptr 12 \<rbrakk>
+  "\<lbrakk> x \<in> pt_offs_range NormalPT_T ptr; is_aligned ptr 12 \<rbrakk>
      \<Longrightarrow> \<exists>y. x = ptr + (ucast (y :: pt_index) << 3)"
-  apply (clarsimp simp: pt_offs_range_def s0_ptr_defs)
+  apply (clarsimp simp: pt_offs_range_def s0_ptr_defs bit_simps)
   apply (rule_tac x="ucast ((x - ptr) >> 3)" in exI)
   apply (clarsimp simp: ucast_ucast_mask)
   apply (subst aligned_shiftr_mask_shiftl)
@@ -527,10 +639,67 @@ lemma pt_offs_range_correct':
     apply (simp add: is_aligned_def)
    apply clarsimp
   apply (cut_tac x=x and y="ptr + 0xFFF" and n=12 in neg_mask_mono_le)
-   apply (simp add: add.commute)
+   apply (simp add: add_ac)
   apply (drule_tac n=12 in aligned_le_sharp)
    apply (simp add: is_aligned_def)
-  apply (simp add: add.commute)
+  apply (subst(asm) mask_out_add_aligned[symmetric])
+   apply (erule is_aligned_weaken)
+   apply simp
+  apply (simp add: mask_def)
+  done
+
+lemma vs_offs_range_correct':
+  "\<lbrakk> x \<in> pt_offs_range VSRootPT_T ptr; is_aligned ptr 13 \<rbrakk>
+     \<Longrightarrow> \<exists>y. x = ptr + (ucast (y :: vs_index) << 3)"
+  apply (clarsimp simp: pt_offs_range_def s0_ptr_defs)
+  apply (rule_tac x="ucast ((x - ptr) >> 3)" in exI)
+  apply (clarsimp simp: ucast_ucast_mask)
+  apply (subst aligned_shiftr_mask_shiftl)
+   apply (rule aligned_sub_aligned)
+     apply assumption
+    apply (erule is_aligned_weaken)
+    apply simp
+   apply simp
+  apply (simp add: bit_simps split: if_splits)
+   apply (rule_tac n=13 in mask_eqI)
+    apply (subst mask_add_aligned)
+     apply (simp add: is_aligned_def)
+    apply (simp add: mask_twice)
+    apply (subst diff_conv_add_uminus)
+    apply (subst add.commute[symmetric])
+    apply (subst mask_add_aligned)
+     apply (simp add: is_aligned_minus)
+    apply simp
+   apply (subst diff_conv_add_uminus)
+   apply (subst add_mask_lower_bits)
+     apply (simp add: is_aligned_def)
+    apply clarsimp
+   apply (cut_tac x=x and y="ptr + 0x1FFF" and n=13 in neg_mask_mono_le)
+    apply (simp add: add_ac)
+   apply (drule_tac n=13 in aligned_le_sharp)
+    apply (simp add: is_aligned_def)
+   apply (subst(asm) mask_out_add_aligned[symmetric])
+    apply (erule is_aligned_weaken)
+    apply simp
+   apply (simp add: mask_def)
+  apply (drule is_aligned_weaken[where y=12], solves simp)
+  apply (rule_tac n=12 in mask_eqI)
+   apply (subst mask_add_aligned)
+    apply (simp add: is_aligned_def)
+   apply (simp add: mask_twice)
+   apply (subst diff_conv_add_uminus)
+   apply (subst add.commute[symmetric])
+   apply (subst mask_add_aligned)
+    apply (simp add: is_aligned_minus)
+   apply simp
+  apply (subst diff_conv_add_uminus)
+  apply (subst add_mask_lower_bits)
+    apply (simp add: is_aligned_def)
+   apply clarsimp
+  apply (cut_tac x=x and y="ptr + 0xFFF" and n=12 in neg_mask_mono_le)
+   apply (simp add: add_ac)
+  apply (drule_tac n=12 in aligned_le_sharp)
+   apply (simp add: is_aligned_def)
   apply (subst(asm) mask_out_add_aligned[symmetric])
    apply (erule is_aligned_weaken)
    apply simp
@@ -538,12 +707,12 @@ lemma pt_offs_range_correct':
   done
 
 lemma pt_offs_range_correct:
-  "x \<in> pt_offs_range Low_pd_ptr  \<Longrightarrow> \<exists>y. x = Low_pd_ptr  + (ucast (y :: pt_index) << 3)"
-  "x \<in> pt_offs_range High_pd_ptr \<Longrightarrow> \<exists>y. x = High_pd_ptr + (ucast (y :: pt_index) << 3)"
-  "x \<in> pt_offs_range Low_pt_ptr  \<Longrightarrow> \<exists>y. x = Low_pt_ptr  + (ucast (y :: pt_index) << 3)"
-  "x \<in> pt_offs_range High_pt_ptr \<Longrightarrow> \<exists>y. x = High_pt_ptr + (ucast (y :: pt_index) << 3)"
-  "x \<in> pt_offs_range riscv_global_pt_ptr \<Longrightarrow> \<exists>y. x = riscv_global_pt_ptr + (ucast (y :: pt_index) << 3)"
-  by (simp_all add: pt_offs_range_correct' s0_ptrs_aligned)
+  "x \<in> pt_offs_range VSRootPT_T Low_pd_ptr  \<Longrightarrow> \<exists>y. x = Low_pd_ptr  + (ucast (y :: vs_index) << 3)"
+  "x \<in> pt_offs_range VSRootPT_T High_pd_ptr \<Longrightarrow> \<exists>y. x = High_pd_ptr + (ucast (y :: vs_index) << 3)"
+  "x \<in> pt_offs_range NormalPT_T Low_pt_ptr  \<Longrightarrow> \<exists>y. x = Low_pt_ptr  + (ucast (y :: pt_index) << 3)"
+  "x \<in> pt_offs_range NormalPT_T High_pt_ptr \<Longrightarrow> \<exists>y. x = High_pt_ptr + (ucast (y :: pt_index) << 3)"
+  "x \<in> pt_offs_range VSRootPT_T arm_global_pt_ptr \<Longrightarrow> \<exists>y. x = arm_global_pt_ptr + (ucast (y :: vs_index) << 3)"
+  by (simp_all add: pt_offs_range_correct' vs_offs_range_correct' s0_ptrs_aligned)
 
 
 text \<open>CNode offset lemmas\<close>
@@ -698,7 +867,7 @@ lemma cnode_offs_range_correct:
 text \<open>TCB offset lemmas\<close>
 
 lemma tcb_offs_min':
-  "is_aligned ptr 10 \<Longrightarrow> (ptr :: obj_ref) \<le> ptr + ucast (x :: 10 word)"
+  "is_aligned ptr 11 \<Longrightarrow> (ptr :: obj_ref) \<le> ptr + ucast (x :: 11 word)"
   apply (erule is_aligned_no_wrap')
   apply (cut_tac x=x and 'a=64 in ucast_less)
    apply simp
@@ -706,48 +875,48 @@ lemma tcb_offs_min':
   done
 
 lemma tcb_offs_min:
-  "Low_tcb_ptr  \<le> Low_tcb_ptr + ucast  (x :: 10 word)"
-  "High_tcb_ptr \<le> High_tcb_ptr + ucast (x :: 10 word)"
-  "idle_tcb_ptr \<le> idle_tcb_ptr + ucast (x :: 10 word)"
+  "Low_tcb_ptr  \<le> Low_tcb_ptr + ucast  (x :: 11 word)"
+  "High_tcb_ptr \<le> High_tcb_ptr + ucast (x :: 11 word)"
+  "idle_tcb_ptr \<le> idle_tcb_ptr + ucast (x :: 11 word)"
   by (simp_all add: tcb_offs_min' s0_ptrs_aligned)
 
 lemma tcb_offs_max':
-  "is_aligned ptr 10 \<Longrightarrow> (ptr :: obj_ref) + ucast (x :: 10 word) \<le> ptr + 0x3ff"
+  "is_aligned ptr 11 \<Longrightarrow> (ptr :: obj_ref) + ucast (x :: 11 word) \<le> ptr + 0x7FF"
   apply (rule word_plus_mono_right)
    apply (rule plus_one_helper)
    apply (cut_tac ucast_less[where x=x and 'a=64])
     apply simp
-   apply simp
+    apply (simp add: mask_def)
   apply (drule is_aligned_no_overflow)
   apply (simp add: add.commute)
   done
 
 lemma tcb_offs_max:
-  "Low_tcb_ptr  + ucast (x :: 10 word) \<le> Low_tcb_ptr  + 0x3ff"
-  "High_tcb_ptr + ucast (x :: 10 word) \<le> High_tcb_ptr + 0x3ff"
-  "idle_tcb_ptr + ucast (x :: 10 word) \<le> idle_tcb_ptr + 0x3ff"
+  "Low_tcb_ptr  + ucast (x :: 11 word) \<le> Low_tcb_ptr  + 0x7FF"
+  "High_tcb_ptr + ucast (x :: 11 word) \<le> High_tcb_ptr + 0x7FF"
+  "idle_tcb_ptr + ucast (x :: 11 word) \<le> idle_tcb_ptr + 0x7FF"
   by (simp_all add: tcb_offs_max' s0_ptrs_aligned)
 
 definition tcb_offs_range where
-  "tcb_offs_range (ptr :: obj_ref) \<equiv> {x. ptr \<le> x \<and> x \<le> ptr + 2 ^ 10 - 1}"
+  "tcb_offs_range (ptr :: obj_ref) \<equiv> {x. ptr \<le> x \<and> x \<le> ptr + 0x7FF}"
 
 lemma tcb_offs_in_range':
-  "is_aligned ptr 10 \<Longrightarrow> ptr + ucast (x :: 10 word) \<in> tcb_offs_range ptr"
+  "is_aligned ptr 11 \<Longrightarrow> ptr + ucast (x :: 11 word) \<in> tcb_offs_range ptr"
   by (clarsimp simp: tcb_offs_min' tcb_offs_max' tcb_offs_range_def add.commute)
 
 lemma tcb_offs_in_range:
-  "Low_tcb_ptr  + ucast (x :: 10 word) \<in> tcb_offs_range Low_tcb_ptr"
-  "High_tcb_ptr + ucast (x :: 10 word) \<in> tcb_offs_range High_tcb_ptr"
-  "idle_tcb_ptr + ucast (x :: 10 word) \<in> tcb_offs_range idle_tcb_ptr"
+  "Low_tcb_ptr  + ucast (x :: 11 word) \<in> tcb_offs_range Low_tcb_ptr"
+  "High_tcb_ptr + ucast (x :: 11 word) \<in> tcb_offs_range High_tcb_ptr"
+  "idle_tcb_ptr + ucast (x :: 11 word) \<in> tcb_offs_range idle_tcb_ptr"
   by (simp_all add: tcb_offs_in_range' s0_ptrs_aligned)
 
 lemma tcb_offs_range_correct':
-  "\<lbrakk> x \<in> tcb_offs_range ptr; is_aligned ptr 10 \<rbrakk>
-     \<Longrightarrow> \<exists>y. x = ptr + ucast (y :: 10 word)"
+  "\<lbrakk> x \<in> tcb_offs_range ptr; is_aligned ptr 11 \<rbrakk>
+     \<Longrightarrow> \<exists>y. x = ptr + ucast (y :: 11 word)"
   apply (clarsimp simp: tcb_offs_range_def s0_ptr_defs)
   apply (rule_tac x="ucast (x - ptr)" in exI)
   apply (clarsimp simp: ucast_ucast_mask)
-  apply (rule_tac n=10 in mask_eqI)
+  apply (rule_tac n=11 in mask_eqI)
    apply (subst mask_add_aligned)
     apply (simp add: is_aligned_def)
    apply (simp add: mask_twice)
@@ -760,11 +929,10 @@ lemma tcb_offs_range_correct':
   apply (subst add_mask_lower_bits)
     apply (simp add: is_aligned_def)
    apply clarsimp
-  apply (cut_tac x=x and y="ptr + 0x3FF" and n=10 in neg_mask_mono_le)
-   apply (simp add: add.commute)
-  apply (drule_tac n=10 in aligned_le_sharp)
+  apply (cut_tac x=x and y="ptr + 0x7FF" and n=11 in neg_mask_mono_le)
+   apply (simp add: mask_def)
+  apply (drule_tac n=11 in aligned_le_sharp)
    apply (simp add: is_aligned_def)
-  apply (simp add: add.commute)
   apply (subst(asm) mask_out_add_aligned[symmetric])
    apply (erule is_aligned_weaken)
    apply simp
@@ -772,9 +940,9 @@ lemma tcb_offs_range_correct':
   done
 
 lemma tcb_offs_range_correct:
-  "x \<in> tcb_offs_range Low_tcb_ptr  \<Longrightarrow> \<exists>y. x = Low_tcb_ptr + ucast (y:: 10 word)"
-  "x \<in> tcb_offs_range High_tcb_ptr \<Longrightarrow> \<exists>y. x = High_tcb_ptr + ucast (y:: 10 word)"
-  "x \<in> tcb_offs_range idle_tcb_ptr \<Longrightarrow> \<exists>y. x = idle_tcb_ptr + ucast (y:: 10 word)"
+  "x \<in> tcb_offs_range Low_tcb_ptr  \<Longrightarrow> \<exists>y. x = Low_tcb_ptr + ucast (y:: 11 word)"
+  "x \<in> tcb_offs_range High_tcb_ptr \<Longrightarrow> \<exists>y. x = High_tcb_ptr + ucast (y:: 11 word)"
+  "x \<in> tcb_offs_range idle_tcb_ptr \<Longrightarrow> \<exists>y. x = idle_tcb_ptr + ucast (y:: 11 word)"
   by (simp_all add: tcb_offs_range_correct' s0_ptrs_aligned)
 
 lemma caps_dom_length_10:
@@ -797,7 +965,7 @@ lemmas kh0H_obj_def =
   global_ptH_def shared_pageH_def High_poolH_def Low_poolH_def
 
 lemmas kh0H_all_obj_def =
-  Low_pd'H_def High_pd'H_def Low_pt'H_def High_pt'H_def global_pteH_def global_pteH'_def
+  Low_pd'H_def High_pd'H_def Low_pt'H_def High_pt'H_def
   Low_cte'_def Low_capsH_def High_cte'_def High_capsH_def
   Silc_cte'_def Silc_capsH_def empty_cte_def kh0H_obj_def
 
@@ -805,13 +973,25 @@ lemma not_in_range_None:
   "x \<notin> cnode_offs_range Low_cnode_ptr \<Longrightarrow> Low_cte Low_cnode_ptr x = None"
   "x \<notin> cnode_offs_range High_cnode_ptr \<Longrightarrow> High_cte High_cnode_ptr x = None"
   "x \<notin> cnode_offs_range Silc_cnode_ptr \<Longrightarrow> Silc_cte Silc_cnode_ptr x = None"
-  "x \<notin> pt_offs_range Low_pd_ptr \<Longrightarrow> Low_pdH Low_pd_ptr x = None"
-  "x \<notin> pt_offs_range High_pd_ptr \<Longrightarrow> High_pdH High_pd_ptr x = None"
-  "x \<notin> pt_offs_range riscv_global_pt_ptr \<Longrightarrow> global_ptH riscv_global_pt_ptr x = None"
-  "x \<notin> pt_offs_range Low_pt_ptr \<Longrightarrow> Low_ptH Low_pt_ptr x = None"
-  "x \<notin> pt_offs_range High_pt_ptr \<Longrightarrow> High_ptH High_pt_ptr x = None"
+  "x \<notin> pt_offs_range VSRootPT_T Low_pd_ptr \<Longrightarrow> Low_pdH Low_pd_ptr x = None"
+  "x \<notin> pt_offs_range VSRootPT_T High_pd_ptr \<Longrightarrow> High_pdH High_pd_ptr x = None"
+  "x \<notin> pt_offs_range VSRootPT_T arm_global_pt_ptr \<Longrightarrow> global_ptH arm_global_pt_ptr x = None"
+  "x \<notin> pt_offs_range NormalPT_T Low_pt_ptr \<Longrightarrow> Low_ptH Low_pt_ptr x = None"
+  "x \<notin> pt_offs_range NormalPT_T High_pt_ptr \<Longrightarrow> High_ptH High_pt_ptr x = None"
   "x \<notin> page_offs_range shared_page_ptr_virt \<Longrightarrow> shared_pageH shared_page_ptr_virt x = None"
   by (auto simp: page_offs_range_def cnode_offs_range_def pt_offs_range_def s0_ptr_defs kh0H_obj_def)
+
+lemma in_range_not_None:
+  "x \<in> cnode_offs_range Low_cnode_ptr \<Longrightarrow> Low_cte Low_cnode_ptr x \<noteq> None"
+  "x \<in> cnode_offs_range High_cnode_ptr \<Longrightarrow> High_cte High_cnode_ptr x \<noteq> None"
+  "x \<in> cnode_offs_range Silc_cnode_ptr \<Longrightarrow> Silc_cte Silc_cnode_ptr x \<noteq> None"
+  "x \<in> pt_offs_range VSRootPT_T Low_pd_ptr \<Longrightarrow> Low_pdH Low_pd_ptr x \<noteq> None"
+  "x \<in> pt_offs_range VSRootPT_T High_pd_ptr \<Longrightarrow> High_pdH High_pd_ptr x \<noteq> None"
+  "x \<in> pt_offs_range VSRootPT_T arm_global_pt_ptr \<Longrightarrow> global_ptH arm_global_pt_ptr x \<noteq> None"
+  "x \<in> pt_offs_range NormalPT_T Low_pt_ptr \<Longrightarrow> Low_ptH Low_pt_ptr x \<noteq> None"
+  "x \<in> pt_offs_range NormalPT_T High_pt_ptr \<Longrightarrow> High_ptH High_pt_ptr x \<noteq> None"
+  "x \<in> page_offs_range shared_page_ptr_virt \<Longrightarrow> shared_pageH shared_page_ptr_virt x \<noteq> None"
+  by (auto simp: page_offs_range_def cnode_offs_range_def pt_offs_range_def s0_ptr_defs kh0H_all_obj_def)
 
 lemma kh0H_dom_distinct:
   "idle_tcb_ptr \<notin> cnode_offs_range Silc_cnode_ptr"
@@ -835,41 +1015,41 @@ lemma kh0H_dom_distinct:
   "Low_pool_ptr \<notin> cnode_offs_range High_cnode_ptr"
   "irq_cnode_ptr \<notin> cnode_offs_range High_cnode_ptr"
   "ntfn_ptr \<notin> cnode_offs_range High_cnode_ptr"
-  "idle_tcb_ptr \<notin> pt_offs_range Low_pd_ptr"
-  "High_tcb_ptr \<notin> pt_offs_range Low_pd_ptr"
-  "Low_tcb_ptr \<notin> pt_offs_range Low_pd_ptr"
-  "High_pool_ptr \<notin> pt_offs_range Low_pd_ptr"
-  "Low_pool_ptr \<notin> pt_offs_range Low_pd_ptr"
-  "irq_cnode_ptr \<notin> pt_offs_range Low_pd_ptr"
-  "ntfn_ptr \<notin> pt_offs_range Low_pd_ptr"
-  "idle_tcb_ptr \<notin> pt_offs_range High_pd_ptr"
-  "High_tcb_ptr \<notin> pt_offs_range High_pd_ptr"
-  "Low_tcb_ptr \<notin> pt_offs_range High_pd_ptr"
-  "High_pool_ptr \<notin> pt_offs_range High_pd_ptr"
-  "Low_pool_ptr \<notin> pt_offs_range High_pd_ptr"
-  "irq_cnode_ptr \<notin> pt_offs_range High_pd_ptr"
-  "ntfn_ptr \<notin> pt_offs_range High_pd_ptr"
-  "idle_tcb_ptr \<notin> pt_offs_range riscv_global_pt_ptr"
-  "High_tcb_ptr \<notin> pt_offs_range riscv_global_pt_ptr"
-  "Low_tcb_ptr \<notin> pt_offs_range riscv_global_pt_ptr"
-  "High_pool_ptr \<notin> pt_offs_range riscv_global_pt_ptr"
-  "Low_pool_ptr \<notin> pt_offs_range riscv_global_pt_ptr"
-  "irq_cnode_ptr \<notin> pt_offs_range riscv_global_pt_ptr"
-  "ntfn_ptr \<notin> pt_offs_range riscv_global_pt_ptr"
-  "idle_tcb_ptr \<notin> pt_offs_range Low_pt_ptr"
-  "High_tcb_ptr \<notin> pt_offs_range Low_pt_ptr"
-  "Low_tcb_ptr \<notin> pt_offs_range Low_pt_ptr"
-  "High_pool_ptr \<notin> pt_offs_range Low_pt_ptr"
-  "Low_pool_ptr \<notin> pt_offs_range Low_pt_ptr"
-  "irq_cnode_ptr \<notin> pt_offs_range Low_pt_ptr"
-  "ntfn_ptr \<notin> pt_offs_range Low_pt_ptr"
-  "idle_tcb_ptr \<notin> pt_offs_range High_pt_ptr"
-  "High_tcb_ptr \<notin> pt_offs_range High_pt_ptr"
-  "Low_tcb_ptr \<notin> pt_offs_range High_pt_ptr"
-  "High_pool_ptr \<notin> pt_offs_range High_pt_ptr"
-  "Low_pool_ptr \<notin> pt_offs_range High_pt_ptr"
-  "irq_cnode_ptr \<notin> pt_offs_range High_pt_ptr"
-  "ntfn_ptr \<notin> pt_offs_range High_pt_ptr"
+  "idle_tcb_ptr \<notin> pt_offs_range VSRootPT_T Low_pd_ptr"
+  "High_tcb_ptr \<notin> pt_offs_range VSRootPT_T Low_pd_ptr"
+  "Low_tcb_ptr \<notin> pt_offs_range VSRootPT_T Low_pd_ptr"
+  "High_pool_ptr \<notin> pt_offs_range VSRootPT_T Low_pd_ptr"
+  "Low_pool_ptr \<notin> pt_offs_range VSRootPT_T Low_pd_ptr"
+  "irq_cnode_ptr \<notin> pt_offs_range VSRootPT_T Low_pd_ptr"
+  "ntfn_ptr \<notin> pt_offs_range VSRootPT_T Low_pd_ptr"
+  "idle_tcb_ptr \<notin> pt_offs_range VSRootPT_T High_pd_ptr"
+  "High_tcb_ptr \<notin> pt_offs_range VSRootPT_T High_pd_ptr"
+  "Low_tcb_ptr \<notin> pt_offs_range VSRootPT_T High_pd_ptr"
+  "High_pool_ptr \<notin> pt_offs_range VSRootPT_T High_pd_ptr"
+  "Low_pool_ptr \<notin> pt_offs_range VSRootPT_T High_pd_ptr"
+  "irq_cnode_ptr \<notin> pt_offs_range VSRootPT_T High_pd_ptr"
+  "ntfn_ptr \<notin> pt_offs_range VSRootPT_T High_pd_ptr"
+  "idle_tcb_ptr \<notin> pt_offs_range VSRootPT_T arm_global_pt_ptr"
+  "High_tcb_ptr \<notin> pt_offs_range VSRootPT_T arm_global_pt_ptr"
+  "Low_tcb_ptr \<notin> pt_offs_range VSRootPT_T arm_global_pt_ptr"
+  "High_pool_ptr \<notin> pt_offs_range VSRootPT_T arm_global_pt_ptr"
+  "Low_pool_ptr \<notin> pt_offs_range VSRootPT_T arm_global_pt_ptr"
+  "irq_cnode_ptr \<notin> pt_offs_range VSRootPT_T arm_global_pt_ptr"
+  "ntfn_ptr \<notin> pt_offs_range VSRootPT_T arm_global_pt_ptr"
+  "idle_tcb_ptr \<notin> pt_offs_range NormalPT_T Low_pt_ptr"
+  "High_tcb_ptr \<notin> pt_offs_range NormalPT_T Low_pt_ptr"
+  "Low_tcb_ptr \<notin> pt_offs_range NormalPT_T Low_pt_ptr"
+  "High_pool_ptr \<notin> pt_offs_range NormalPT_T Low_pt_ptr"
+  "Low_pool_ptr \<notin> pt_offs_range NormalPT_T Low_pt_ptr"
+  "irq_cnode_ptr \<notin> pt_offs_range NormalPT_T Low_pt_ptr"
+  "ntfn_ptr \<notin> pt_offs_range NormalPT_T Low_pt_ptr"
+  "idle_tcb_ptr \<notin> pt_offs_range NormalPT_T High_pt_ptr"
+  "High_tcb_ptr \<notin> pt_offs_range NormalPT_T High_pt_ptr"
+  "Low_tcb_ptr \<notin> pt_offs_range NormalPT_T High_pt_ptr"
+  "High_pool_ptr \<notin> pt_offs_range NormalPT_T High_pt_ptr"
+  "Low_pool_ptr \<notin> pt_offs_range NormalPT_T High_pt_ptr"
+  "irq_cnode_ptr \<notin> pt_offs_range NormalPT_T High_pt_ptr"
+  "ntfn_ptr \<notin> pt_offs_range NormalPT_T High_pt_ptr"
   "idle_tcb_ptr \<notin> tcb_offs_range Low_tcb_ptr"
   "High_tcb_ptr \<notin> tcb_offs_range Low_tcb_ptr"
   "High_pool_ptr \<notin> tcb_offs_range Low_tcb_ptr"
@@ -895,82 +1075,100 @@ lemma kh0H_dom_distinct:
   "Low_pool_ptr \<notin> page_offs_range shared_page_ptr_virt"
   "irq_cnode_ptr \<notin> page_offs_range shared_page_ptr_virt"
   "ntfn_ptr \<notin> page_offs_range shared_page_ptr_virt"
+  "idle_tcb_ptr \<notin> cnode_offs_range init_irq_node_ptr"
+  "High_tcb_ptr \<notin> cnode_offs_range init_irq_node_ptr"
+  "Low_tcb_ptr \<notin> cnode_offs_range init_irq_node_ptr"
+  "High_pool_ptr \<notin> cnode_offs_range init_irq_node_ptr"
+  "Low_pool_ptr \<notin> cnode_offs_range init_irq_node_ptr"
+  "irq_cnode_ptr \<notin> cnode_offs_range init_irq_node_ptr"
+  "ntfn_ptr \<notin> cnode_offs_range init_irq_node_ptr"
   by (auto simp: tcb_offs_range_def pt_offs_range_def page_offs_range_def
-                 cnode_offs_range_def kh0H_obj_def s0_ptr_defs)
+                 cnode_offs_range_def kh0H_obj_def s0_ptr_defs bit_simps)
 
 lemma kh0H_dom_sets_distinct:
   "irq_node_offs_range \<inter> cnode_offs_range Silc_cnode_ptr = {}"
   "irq_node_offs_range \<inter> cnode_offs_range High_cnode_ptr = {}"
   "irq_node_offs_range \<inter> cnode_offs_range Low_cnode_ptr = {}"
-  "irq_node_offs_range \<inter> pt_offs_range riscv_global_pt_ptr = {}"
-  "irq_node_offs_range \<inter> pt_offs_range High_pd_ptr = {}"
-  "irq_node_offs_range \<inter> pt_offs_range Low_pd_ptr = {}"
-  "irq_node_offs_range \<inter> pt_offs_range High_pt_ptr = {}"
-  "irq_node_offs_range \<inter> pt_offs_range Low_pt_ptr = {}"
+  "irq_node_offs_range \<inter> pt_offs_range VSRootPT_T arm_global_pt_ptr = {}"
+  "irq_node_offs_range \<inter> pt_offs_range VSRootPT_T High_pd_ptr = {}"
+  "irq_node_offs_range \<inter> pt_offs_range VSRootPT_T Low_pd_ptr = {}"
+  "irq_node_offs_range \<inter> pt_offs_range NormalPT_T High_pt_ptr = {}"
+  "irq_node_offs_range \<inter> pt_offs_range NormalPT_T Low_pt_ptr = {}"
   "irq_node_offs_range \<inter> tcb_offs_range High_tcb_ptr = {}"
   "irq_node_offs_range \<inter> tcb_offs_range Low_tcb_ptr = {}"
   "irq_node_offs_range \<inter> tcb_offs_range idle_tcb_ptr = {}"
   "irq_node_offs_range \<inter> page_offs_range shared_page_ptr_virt = {}"
   "cnode_offs_range Silc_cnode_ptr \<inter> cnode_offs_range High_cnode_ptr = {}"
   "cnode_offs_range Silc_cnode_ptr \<inter> cnode_offs_range Low_cnode_ptr = {}"
-  "cnode_offs_range Silc_cnode_ptr \<inter> pt_offs_range riscv_global_pt_ptr = {}"
-  "cnode_offs_range Silc_cnode_ptr \<inter> pt_offs_range High_pd_ptr = {}"
-  "cnode_offs_range Silc_cnode_ptr \<inter> pt_offs_range Low_pd_ptr = {}"
-  "cnode_offs_range Silc_cnode_ptr \<inter> pt_offs_range High_pt_ptr = {}"
-  "cnode_offs_range Silc_cnode_ptr \<inter> pt_offs_range Low_pt_ptr = {}"
+  "cnode_offs_range Silc_cnode_ptr \<inter> pt_offs_range VSRootPT_T arm_global_pt_ptr = {}"
+  "cnode_offs_range Silc_cnode_ptr \<inter> pt_offs_range VSRootPT_T High_pd_ptr = {}"
+  "cnode_offs_range Silc_cnode_ptr \<inter> pt_offs_range VSRootPT_T Low_pd_ptr = {}"
+  "cnode_offs_range Silc_cnode_ptr \<inter> pt_offs_range NormalPT_T High_pt_ptr = {}"
+  "cnode_offs_range Silc_cnode_ptr \<inter> pt_offs_range NormalPT_T Low_pt_ptr = {}"
   "cnode_offs_range Silc_cnode_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
   "cnode_offs_range Silc_cnode_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
   "cnode_offs_range Silc_cnode_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
   "cnode_offs_range Silc_cnode_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
   "cnode_offs_range High_cnode_ptr \<inter> cnode_offs_range Low_cnode_ptr = {}"
-  "cnode_offs_range High_cnode_ptr \<inter> pt_offs_range riscv_global_pt_ptr = {}"
-  "cnode_offs_range High_cnode_ptr \<inter> pt_offs_range High_pd_ptr = {}"
-  "cnode_offs_range High_cnode_ptr \<inter> pt_offs_range Low_pd_ptr = {}"
-  "cnode_offs_range High_cnode_ptr \<inter> pt_offs_range High_pt_ptr = {}"
-  "cnode_offs_range High_cnode_ptr \<inter> pt_offs_range Low_pt_ptr = {}"
+  "cnode_offs_range High_cnode_ptr \<inter> pt_offs_range VSRootPT_T arm_global_pt_ptr = {}"
+  "cnode_offs_range High_cnode_ptr \<inter> pt_offs_range VSRootPT_T High_pd_ptr = {}"
+  "cnode_offs_range High_cnode_ptr \<inter> pt_offs_range VSRootPT_T Low_pd_ptr = {}"
+  "cnode_offs_range High_cnode_ptr \<inter> pt_offs_range NormalPT_T High_pt_ptr = {}"
+  "cnode_offs_range High_cnode_ptr \<inter> pt_offs_range NormalPT_T Low_pt_ptr = {}"
   "cnode_offs_range High_cnode_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
   "cnode_offs_range High_cnode_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
   "cnode_offs_range High_cnode_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
   "cnode_offs_range High_cnode_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
-  "cnode_offs_range Low_cnode_ptr \<inter> pt_offs_range riscv_global_pt_ptr = {}"
-  "cnode_offs_range Low_cnode_ptr \<inter> pt_offs_range High_pd_ptr = {}"
-  "cnode_offs_range Low_cnode_ptr \<inter> pt_offs_range Low_pd_ptr = {}"
-  "cnode_offs_range Low_cnode_ptr \<inter> pt_offs_range High_pt_ptr = {}"
-  "cnode_offs_range Low_cnode_ptr \<inter> pt_offs_range Low_pt_ptr = {}"
+  "cnode_offs_range Low_cnode_ptr \<inter> pt_offs_range VSRootPT_T arm_global_pt_ptr = {}"
+  "cnode_offs_range Low_cnode_ptr \<inter> pt_offs_range VSRootPT_T High_pd_ptr = {}"
+  "cnode_offs_range Low_cnode_ptr \<inter> pt_offs_range VSRootPT_T Low_pd_ptr = {}"
+  "cnode_offs_range Low_cnode_ptr \<inter> pt_offs_range NormalPT_T High_pt_ptr = {}"
+  "cnode_offs_range Low_cnode_ptr \<inter> pt_offs_range NormalPT_T Low_pt_ptr = {}"
   "cnode_offs_range Low_cnode_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
   "cnode_offs_range Low_cnode_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
   "cnode_offs_range Low_cnode_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
   "cnode_offs_range Low_cnode_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
-  "pt_offs_range riscv_global_pt_ptr \<inter> pt_offs_range High_pd_ptr = {}"
-  "pt_offs_range riscv_global_pt_ptr \<inter> pt_offs_range Low_pd_ptr = {}"
-  "pt_offs_range riscv_global_pt_ptr \<inter> pt_offs_range High_pt_ptr = {}"
-  "pt_offs_range riscv_global_pt_ptr \<inter> pt_offs_range Low_pt_ptr = {}"
-  "pt_offs_range riscv_global_pt_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
-  "pt_offs_range riscv_global_pt_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
-  "pt_offs_range riscv_global_pt_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
-  "pt_offs_range riscv_global_pt_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
-  "pt_offs_range High_pd_ptr \<inter> pt_offs_range Low_pd_ptr = {}"
-  "pt_offs_range High_pd_ptr \<inter> pt_offs_range High_pt_ptr = {}"
-  "pt_offs_range High_pd_ptr \<inter> pt_offs_range Low_pt_ptr = {}"
-  "pt_offs_range High_pd_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
-  "pt_offs_range High_pd_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
-  "pt_offs_range High_pd_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
-  "pt_offs_range High_pd_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
-  "pt_offs_range Low_pd_ptr \<inter> pt_offs_range High_pt_ptr = {}"
-  "pt_offs_range Low_pd_ptr \<inter> pt_offs_range Low_pt_ptr = {}"
-  "pt_offs_range Low_pd_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
-  "pt_offs_range Low_pd_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
-  "pt_offs_range Low_pd_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
-  "pt_offs_range Low_pd_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
-  "pt_offs_range High_pt_ptr \<inter> pt_offs_range Low_pt_ptr = {}"
-  "pt_offs_range High_pt_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
-  "pt_offs_range High_pt_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
-  "pt_offs_range High_pt_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
-  "pt_offs_range High_pt_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
-  "pt_offs_range Low_pt_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
-  "pt_offs_range Low_pt_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
-  "pt_offs_range Low_pt_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
-  "pt_offs_range Low_pt_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
+  "cnode_offs_range init_irq_node_ptr \<inter> cnode_offs_range High_cnode_ptr = {}"
+  "cnode_offs_range init_irq_node_ptr \<inter> cnode_offs_range Low_cnode_ptr = {}"
+  "cnode_offs_range init_irq_node_ptr \<inter> pt_offs_range VSRootPT_T arm_global_pt_ptr = {}"
+  "cnode_offs_range init_irq_node_ptr \<inter> pt_offs_range VSRootPT_T High_pd_ptr = {}"
+  "cnode_offs_range init_irq_node_ptr \<inter> pt_offs_range VSRootPT_T Low_pd_ptr = {}"
+  "cnode_offs_range init_irq_node_ptr \<inter> pt_offs_range NormalPT_T High_pt_ptr = {}"
+  "cnode_offs_range init_irq_node_ptr \<inter> pt_offs_range NormalPT_T Low_pt_ptr = {}"
+  "cnode_offs_range init_irq_node_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
+  "cnode_offs_range init_irq_node_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
+  "cnode_offs_range init_irq_node_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
+  "cnode_offs_range init_irq_node_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
+  "pt_offs_range VSRootPT_T arm_global_pt_ptr \<inter> pt_offs_range VSRootPT_T High_pd_ptr = {}"
+  "pt_offs_range VSRootPT_T arm_global_pt_ptr \<inter> pt_offs_range VSRootPT_T Low_pd_ptr = {}"
+  "pt_offs_range VSRootPT_T arm_global_pt_ptr \<inter> pt_offs_range NormalPT_T High_pt_ptr = {}"
+  "pt_offs_range VSRootPT_T arm_global_pt_ptr \<inter> pt_offs_range NormalPT_T Low_pt_ptr = {}"
+  "pt_offs_range VSRootPT_T arm_global_pt_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
+  "pt_offs_range VSRootPT_T arm_global_pt_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
+  "pt_offs_range VSRootPT_T arm_global_pt_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
+  "pt_offs_range VSRootPT_T arm_global_pt_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
+  "pt_offs_range VSRootPT_T High_pd_ptr \<inter> pt_offs_range VSRootPT_T Low_pd_ptr = {}"
+  "pt_offs_range VSRootPT_T High_pd_ptr \<inter> pt_offs_range NormalPT_T High_pt_ptr = {}"
+  "pt_offs_range VSRootPT_T High_pd_ptr \<inter> pt_offs_range NormalPT_T Low_pt_ptr = {}"
+  "pt_offs_range VSRootPT_T High_pd_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
+  "pt_offs_range VSRootPT_T High_pd_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
+  "pt_offs_range VSRootPT_T High_pd_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
+  "pt_offs_range VSRootPT_T High_pd_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
+  "pt_offs_range VSRootPT_T Low_pd_ptr \<inter> pt_offs_range NormalPT_T High_pt_ptr = {}"
+  "pt_offs_range VSRootPT_T Low_pd_ptr \<inter> pt_offs_range NormalPT_T Low_pt_ptr = {}"
+  "pt_offs_range VSRootPT_T Low_pd_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
+  "pt_offs_range VSRootPT_T Low_pd_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
+  "pt_offs_range VSRootPT_T Low_pd_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
+  "pt_offs_range VSRootPT_T Low_pd_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
+  "pt_offs_range NormalPT_T High_pt_ptr \<inter> pt_offs_range NormalPT_T Low_pt_ptr = {}"
+  "pt_offs_range NormalPT_T High_pt_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
+  "pt_offs_range NormalPT_T High_pt_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
+  "pt_offs_range NormalPT_T High_pt_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
+  "pt_offs_range NormalPT_T High_pt_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
+  "pt_offs_range NormalPT_T Low_pt_ptr \<inter> tcb_offs_range High_tcb_ptr = {}"
+  "pt_offs_range NormalPT_T Low_pt_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
+  "pt_offs_range NormalPT_T Low_pt_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
+  "pt_offs_range NormalPT_T Low_pt_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
   "tcb_offs_range High_tcb_ptr \<inter> tcb_offs_range Low_tcb_ptr = {}"
   "tcb_offs_range High_tcb_ptr \<inter> tcb_offs_range idle_tcb_ptr = {}"
   "tcb_offs_range High_tcb_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
@@ -978,8 +1176,8 @@ lemma kh0H_dom_sets_distinct:
   "tcb_offs_range Low_tcb_ptr \<inter> page_offs_range shared_page_ptr_virt = {}"
   "page_offs_range shared_page_ptr_virt \<inter> tcb_offs_range idle_tcb_ptr = {}"
   by (rule disjointI, clarsimp simp: tcb_offs_range_def pt_offs_range_def page_offs_range_def
-                                     irq_node_offs_range_def cnode_offs_range_def s0_ptr_defs
-                    , drule (1) order_trans le_less_trans, fastforce)+
+                                     irq_node_offs_range_def cnode_offs_range_def s0_ptr_defs bit_simps
+                    , drule (1) order_trans le_less_trans, fastforce split: if_splits)+
 
 lemmas offs_in_range =
   pt_offs_in_range page_offs_in_range tcb_offs_in_range cnode_offs_in_range irq_node_offs_in_range
@@ -990,6 +1188,8 @@ lemmas offs_range_correct =
 
 lemma kh0H_dom_distinct':
   fixes y :: pt_index
+  and v :: vs_index
+  and z :: "pg_index"
   shows
   "length x = 10 \<Longrightarrow> Silc_cnode_ptr + of_bl x * 0x20 \<noteq> idle_tcb_ptr"
   "length x = 10 \<Longrightarrow> Silc_cnode_ptr + of_bl x * 0x20 \<noteq> High_tcb_ptr"
@@ -1012,20 +1212,20 @@ lemma kh0H_dom_distinct':
   "length x = 10 \<Longrightarrow> High_cnode_ptr + of_bl x * 0x20 \<noteq> Low_pool_ptr"
   "length x = 10 \<Longrightarrow> High_cnode_ptr + of_bl x * 0x20 \<noteq> irq_cnode_ptr"
   "length x = 10 \<Longrightarrow> High_cnode_ptr + of_bl x * 0x20 \<noteq> ntfn_ptr"
-  "Low_pd_ptr + (ucast y << 3) \<noteq> idle_tcb_ptr"
-  "Low_pd_ptr + (ucast y << 3) \<noteq> High_tcb_ptr"
-  "Low_pd_ptr + (ucast y << 3) \<noteq> Low_tcb_ptr"
-  "Low_pd_ptr + (ucast y << 3) \<noteq> High_pool_ptr"
-  "Low_pd_ptr + (ucast y << 3) \<noteq> Low_pool_ptr"
-  "Low_pd_ptr + (ucast y << 3) \<noteq> irq_cnode_ptr"
-  "Low_pd_ptr + (ucast y << 3) \<noteq> ntfn_ptr"
-  "High_pd_ptr + (ucast y << 3) \<noteq> idle_tcb_ptr"
-  "High_pd_ptr + (ucast y << 3) \<noteq> High_tcb_ptr"
-  "High_pd_ptr + (ucast y << 3) \<noteq> Low_tcb_ptr"
-  "High_pd_ptr + (ucast y << 3) \<noteq> High_pool_ptr"
-  "High_pd_ptr + (ucast y << 3) \<noteq> Low_pool_ptr"
-  "High_pd_ptr + (ucast y << 3) \<noteq> irq_cnode_ptr"
-  "High_pd_ptr + (ucast y << 3) \<noteq> ntfn_ptr"
+  "Low_pd_ptr + (ucast v << 3) \<noteq> idle_tcb_ptr"
+  "Low_pd_ptr + (ucast v << 3) \<noteq> High_tcb_ptr"
+  "Low_pd_ptr + (ucast v << 3) \<noteq> Low_tcb_ptr"
+  "Low_pd_ptr + (ucast v << 3) \<noteq> High_pool_ptr"
+  "Low_pd_ptr + (ucast v << 3) \<noteq> Low_pool_ptr"
+  "Low_pd_ptr + (ucast v << 3) \<noteq> irq_cnode_ptr"
+  "Low_pd_ptr + (ucast v << 3) \<noteq> ntfn_ptr"
+  "High_pd_ptr + (ucast v << 3) \<noteq> idle_tcb_ptr"
+  "High_pd_ptr + (ucast v << 3) \<noteq> High_tcb_ptr"
+  "High_pd_ptr + (ucast v << 3) \<noteq> Low_tcb_ptr"
+  "High_pd_ptr + (ucast v << 3) \<noteq> High_pool_ptr"
+  "High_pd_ptr + (ucast v << 3) \<noteq> Low_pool_ptr"
+  "High_pd_ptr + (ucast v << 3) \<noteq> irq_cnode_ptr"
+  "High_pd_ptr + (ucast v << 3) \<noteq> ntfn_ptr"
   "Low_pt_ptr + (ucast y << 3) \<noteq> idle_tcb_ptr"
   "Low_pt_ptr + (ucast y << 3) \<noteq> High_tcb_ptr"
   "Low_pt_ptr + (ucast y << 3) \<noteq> Low_tcb_ptr"
@@ -1040,27 +1240,27 @@ lemma kh0H_dom_distinct':
   "High_pt_ptr + (ucast y << 3) \<noteq> Low_pool_ptr"
   "High_pt_ptr + (ucast y << 3) \<noteq> irq_cnode_ptr"
   "High_pt_ptr + (ucast y << 3) \<noteq> ntfn_ptr"
-  "riscv_global_pt_ptr + (ucast y << 3) \<noteq> idle_tcb_ptr"
-  "riscv_global_pt_ptr + (ucast y << 3) \<noteq> High_tcb_ptr"
-  "riscv_global_pt_ptr + (ucast y << 3) \<noteq> Low_tcb_ptr"
-  "riscv_global_pt_ptr + (ucast y << 3) \<noteq> High_pool_ptr"
-  "riscv_global_pt_ptr + (ucast y << 3) \<noteq> Low_pool_ptr"
-  "riscv_global_pt_ptr + (ucast y << 3) \<noteq> irq_cnode_ptr"
-  "riscv_global_pt_ptr + (ucast y << 3) \<noteq> ntfn_ptr"
-  "shared_page_ptr_virt + (ucast y << 12) \<noteq> idle_tcb_ptr"
-  "shared_page_ptr_virt + (ucast y << 12) \<noteq> High_tcb_ptr"
-  "shared_page_ptr_virt + (ucast y << 12) \<noteq> Low_tcb_ptr"
-  "shared_page_ptr_virt + (ucast y << 12) \<noteq> High_pool_ptr"
-  "shared_page_ptr_virt + (ucast y << 12) \<noteq> Low_pool_ptr"
-  "shared_page_ptr_virt + (ucast y << 12) \<noteq> irq_cnode_ptr"
-  "shared_page_ptr_virt + (ucast y << 12) \<noteq> ntfn_ptr"
+  "arm_global_pt_ptr + (ucast v << 3) \<noteq> idle_tcb_ptr"
+  "arm_global_pt_ptr + (ucast v << 3) \<noteq> High_tcb_ptr"
+  "arm_global_pt_ptr + (ucast v << 3) \<noteq> Low_tcb_ptr"
+  "arm_global_pt_ptr + (ucast v << 3) \<noteq> High_pool_ptr"
+  "arm_global_pt_ptr + (ucast v << 3) \<noteq> Low_pool_ptr"
+  "arm_global_pt_ptr + (ucast v << 3) \<noteq> irq_cnode_ptr"
+  "arm_global_pt_ptr + (ucast v << 3) \<noteq> ntfn_ptr"
+  "shared_page_ptr_virt + (ucast z << 12) \<noteq> idle_tcb_ptr"
+  "shared_page_ptr_virt + (ucast z << 12) \<noteq> High_tcb_ptr"
+  "shared_page_ptr_virt + (ucast z << 12) \<noteq> Low_tcb_ptr"
+  "shared_page_ptr_virt + (ucast z << 12) \<noteq> High_pool_ptr"
+  "shared_page_ptr_virt + (ucast z << 12) \<noteq> Low_pool_ptr"
+  "shared_page_ptr_virt + (ucast z << 12) \<noteq> irq_cnode_ptr"
+  "shared_page_ptr_virt + (ucast z << 12) \<noteq> ntfn_ptr"
   apply (drule offs_in_range, fastforce simp: kh0H_dom_distinct)+
-  apply (cut_tac x=y in offs_in_range(1), fastforce simp: kh0H_dom_distinct)+
-  apply (cut_tac x=y in offs_in_range(2), fastforce simp: kh0H_dom_distinct)+
-  apply (cut_tac x=y in offs_in_range(3), fastforce simp: kh0H_dom_distinct)+
-  apply (cut_tac x=y in offs_in_range(4), fastforce simp: kh0H_dom_distinct)+
-  apply (cut_tac x=y in offs_in_range(5), fastforce simp: kh0H_dom_distinct)+
-  apply (cut_tac x=y in offs_in_range(6), fastforce simp: kh0H_dom_distinct)+
+  apply (cut_tac x=v in offs_in_range(1), fastforce simp: kh0H_dom_distinct)+
+  apply (cut_tac x=v in offs_in_range(2), fastforce simp: kh0H_dom_distinct)+
+  apply (cut_tac y=y in offs_in_range(3), fastforce simp: kh0H_dom_distinct)+
+  apply (cut_tac y=y in offs_in_range(4), fastforce simp: kh0H_dom_distinct)+
+  apply (cut_tac x=v in offs_in_range(5), fastforce simp: kh0H_dom_distinct)+
+  apply (cut_tac x=z in offs_in_range(6), fastforce simp: kh0H_dom_distinct)+
   done
 
 lemma not_disjointI:
@@ -1068,15 +1268,17 @@ lemma not_disjointI:
   by fastforce
 
 lemma shared_pageH_KOUserData[simp]:
-  "shared_pageH shared_page_ptr_virt (shared_page_ptr_virt + (UCAST(9 \<rightarrow> 64) y << 12)) = Some KOUserData"
+  "shared_pageH shared_page_ptr_virt (shared_page_ptr_virt + (UCAST(pg_index_len \<rightarrow> 64) y << 12)) = Some KOUserData"
   apply (clarsimp simp: shared_pageH_def page_offs_min page_offs_max add.commute)
-  apply (cut_tac shared_page_ptr_is_aligned)
-  apply (clarsimp simp: is_aligned_mask mask_def s0_ptr_defs bit_simps)
-  apply word_bitwise
+  apply (rule is_aligned_add)
+   apply (rule is_aligned_weaken, rule s0_ptrs_aligned, simp)
+  apply (clarsimp simp: is_aligned_mask)
   done
 
 lemma kh0H_simps[simp]:
   fixes y :: pt_index
+  and v :: vs_index
+  and z :: "pg_index"
   shows
   "kh0H (init_irq_node_ptr + (ucast (irq :: irq) << 5)) = Some (KOCTE (CTE NullCap Null_mdb))"
   "kh0H ntfn_ptr      = Some (KONotification ntfnH)"
@@ -1089,16 +1291,16 @@ lemma kh0H_simps[simp]:
   "length x = 10 \<Longrightarrow> kh0H (Low_cnode_ptr  + of_bl x * 0x20) = Low_cte  Low_cnode_ptr  (Low_cnode_ptr  + of_bl x * 0x20)"
   "length x = 10 \<Longrightarrow> kh0H (High_cnode_ptr + of_bl x * 0x20) = High_cte High_cnode_ptr (High_cnode_ptr + of_bl x * 0x20)"
   "length x = 10 \<Longrightarrow> kh0H (Silc_cnode_ptr + of_bl x * 0x20) = Silc_cte Silc_cnode_ptr (Silc_cnode_ptr + of_bl x * 0x20)"
-  "kh0H (Low_pd_ptr  + (ucast y << 3)) = Low_pdH  Low_pd_ptr  (Low_pd_ptr  + (ucast y << 3))"
-  "kh0H (High_pd_ptr + (ucast y << 3)) = High_pdH High_pd_ptr (High_pd_ptr + (ucast y << 3))"
+  "kh0H (Low_pd_ptr  + (ucast v << 3)) = Low_pdH  Low_pd_ptr  (Low_pd_ptr  + (ucast v << 3))"
+  "kh0H (High_pd_ptr + (ucast v << 3)) = High_pdH High_pd_ptr (High_pd_ptr + (ucast v << 3))"
   "kh0H (Low_pt_ptr  + (ucast y << 3)) = Low_ptH  Low_pt_ptr  (Low_pt_ptr  + (ucast y << 3))"
   "kh0H (High_pt_ptr + (ucast y << 3)) = High_ptH High_pt_ptr (High_pt_ptr + (ucast y << 3))"
-  "kh0H (riscv_global_pt_ptr + (ucast y << 3)) = global_ptH riscv_global_pt_ptr (riscv_global_pt_ptr + (ucast y << 3))"
-  "kh0H (shared_page_ptr_virt + (ucast y << 12)) = Some KOUserData"
+  "kh0H (arm_global_pt_ptr + (ucast v << 3)) = global_ptH arm_global_pt_ptr (arm_global_pt_ptr + (ucast v << 3))"
+  "kh0H (shared_page_ptr_virt + (ucast z << 12)) = Some KOUserData"
   supply option.case_cong[cong]
   apply (fastforce simp: kh0H_def option_update_range_def)
   by ((clarsimp simp: kh0H_def kh0H_dom_distinct kh0H_dom_distinct'
-                       option_update_range_def not_in_range_None offs_in_range
+                      option_update_range_def not_in_range_None offs_in_range
        | simp add: offs_in_range kh0H_dom_sets_distinct[THEN orthD1] not_in_range_None
        | simp add: offs_in_range kh0H_dom_sets_distinct[THEN orthD2] not_in_range_None
        | rule conjI | clarsimp split: option.splits)+,
@@ -1115,11 +1317,11 @@ lemma kh0H_dom:
               cnode_offs_range Silc_cnode_ptr \<union>
               cnode_offs_range High_cnode_ptr \<union>
               cnode_offs_range Low_cnode_ptr \<union>
-              pt_offs_range riscv_global_pt_ptr \<union>
-              pt_offs_range High_pd_ptr \<union>
-              pt_offs_range Low_pd_ptr \<union>
-              pt_offs_range High_pt_ptr \<union>
-              pt_offs_range Low_pt_ptr"
+              pt_offs_range VSRootPT_T arm_global_pt_ptr \<union>
+              pt_offs_range VSRootPT_T High_pd_ptr \<union>
+              pt_offs_range VSRootPT_T Low_pd_ptr \<union>
+              pt_offs_range NormalPT_T High_pt_ptr \<union>
+              pt_offs_range NormalPT_T Low_pt_ptr"
   apply (rule equalityI)
    apply (simp add: kh0H_def dom_def)
    apply (clarsimp simp: offs_in_range option_update_range_def not_in_range_None split: if_split_asm)
@@ -1127,12 +1329,9 @@ lemma kh0H_dom:
   apply (rule conjI)
    apply (force simp: kh0H_def kh0H_dom_distinct option_update_range_def not_in_range_None
                 dest: irq_node_offs_range_correct split: option.splits)
-  by (rule conjI
-      | clarsimp simp: kh0H_def kh0H_dom_distinct option_update_range_def not_in_range_None
-                split: option.splits
-        , frule offs_range_correct
-        , clarsimp simp: kh0H_all_obj_def cnode_offs_range_def page_offs_range_def pt_offs_range_def
-                  split: if_split_asm)+
+  apply (intro conjI)
+  by (auto simp: kh0H_def kh0H_dom_distinct option_update_range_def not_in_range_None in_range_not_None
+          split: option.splits)
 
 lemmas kh0H_SomeD' = set_mp[OF equalityD1[OF kh0H_dom[simplified dom_def]], OF CollectI, simplified, OF exI]
 
@@ -1142,13 +1341,13 @@ lemma kh0H_SomeD:
        x = Low_tcb_ptr \<and> y = KOTCB Low_tcbH \<or>
        x = High_tcb_ptr \<and> y = KOTCB High_tcbH \<or>
        x = idle_tcb_ptr \<and> y = KOTCB idle_tcbH \<or>
-       x \<in> pt_offs_range riscv_global_pt_ptr \<and> global_ptH riscv_global_pt_ptr x \<noteq> None
-                                             \<and> y = the (global_ptH riscv_global_pt_ptr x) \<or>
+       x \<in> pt_offs_range VSRootPT_T arm_global_pt_ptr \<and> global_ptH arm_global_pt_ptr x \<noteq> None
+                                             \<and> y = the (global_ptH arm_global_pt_ptr x) \<or>
        x \<in> irq_node_offs_range \<and> y = KOCTE (CTE NullCap Null_mdb) \<or>
-       x \<in> pt_offs_range Low_pt_ptr \<and> Low_ptH Low_pt_ptr x \<noteq> None \<and> y = the (Low_ptH Low_pt_ptr x) \<or>
-       x \<in> pt_offs_range High_pt_ptr \<and> High_ptH High_pt_ptr x \<noteq> None \<and> y = the (High_ptH High_pt_ptr x) \<or>
-       x \<in> pt_offs_range Low_pd_ptr \<and> Low_pdH Low_pd_ptr x \<noteq> None \<and> y = the (Low_pdH Low_pd_ptr x) \<or>
-       x \<in> pt_offs_range High_pd_ptr \<and> High_pdH High_pd_ptr x \<noteq> None \<and> y = the (High_pdH High_pd_ptr x) \<or>
+       x \<in> pt_offs_range NormalPT_T Low_pt_ptr \<and> Low_ptH Low_pt_ptr x \<noteq> None \<and> y = the (Low_ptH Low_pt_ptr x) \<or>
+       x \<in> pt_offs_range NormalPT_T High_pt_ptr \<and> High_ptH High_pt_ptr x \<noteq> None \<and> y = the (High_ptH High_pt_ptr x) \<or>
+       x \<in> pt_offs_range VSRootPT_T Low_pd_ptr \<and> Low_pdH Low_pd_ptr x \<noteq> None \<and> y = the (Low_pdH Low_pd_ptr x) \<or>
+       x \<in> pt_offs_range VSRootPT_T High_pd_ptr \<and> High_pdH High_pd_ptr x \<noteq> None \<and> y = the (High_pdH High_pd_ptr x) \<or>
        x = Low_pool_ptr \<and> y = KOArch Low_poolH \<or>
        x = High_pool_ptr \<and> y = KOArch High_poolH \<or>
        x \<in> cnode_offs_range Low_cnode_ptr \<and> Low_cte Low_cnode_ptr x \<noteq> None \<and> y = the (Low_cte Low_cnode_ptr x) \<or>
@@ -1158,20 +1357,29 @@ lemma kh0H_SomeD:
        x \<in> page_offs_range shared_page_ptr_virt \<and> y = KOUserData"
   apply (frule kh0H_SomeD')
   apply (elim disjE)
-  by ((clarsimp | drule offs_range_correct)+)
-
+  by (clarsimp | drule offs_range_correct)+
 
 definition arch_state0H :: Arch.kernel_state where
-  "arch_state0H \<equiv>
-     RISCVKernelState [ucast (asid_high_bits_of Low_asid) \<mapsto> Low_pool_ptr,
-                       ucast (asid_high_bits_of High_asid) \<mapsto> High_pool_ptr]
-                      (\<lambda>level. if level = maxPTLevel then [riscv_global_pt_ptr] else [])
-                      init_vspace_uses"
+  "arch_state0H \<equiv> ARMKernelState
+             \<comment> \<open>armKSASIDTable    =\<close> [ucast (asid_high_bits_of Low_asid) \<mapsto> Low_pool_ptr,
+                                       ucast (asid_high_bits_of High_asid) \<mapsto> High_pool_ptr]
+             \<comment> \<open>armKSKernelVSpace =\<close>  Example_Valid_State.init_vspace_uses
+             \<comment> \<open>armKSVMIDTable  =\<close> Map.empty
+             \<comment> \<open>armKSNextVMID     =\<close> 0
+             \<comment> \<open>armKSGlobalUserVSpace     =\<close> arm_global_pt_ptr
+             \<comment> \<open>armHSCurVCPU      =\<close> None
+             \<comment> \<open>armKSGICVCPUNumListRegs      =\<close> (max_armKSGICVCPUNumListRegs - 1)
+             \<comment> \<open>gsPTTypes     =\<close> [Low_pt_ptr \<mapsto> NormalPT_T,
+                                   High_pt_ptr \<mapsto> NormalPT_T,
+                                   Low_pd_ptr \<mapsto> VSRootPT_T,
+                                   High_pd_ptr \<mapsto> VSRootPT_T,
+                                   arm_global_pt_ptr \<mapsto> VSRootPT_T]
+             \<comment> \<open>armKSGlobalPTs    =\<close> None"
 
 definition s0H_internal :: "kernel_state" where
   "s0H_internal \<equiv> \<lparr>
      ksPSpace = kh0H,
-     gsUserPages = [shared_page_ptr_virt \<mapsto> RISCVLargePage],
+     gsUserPages = [shared_page_ptr_virt \<mapsto> max_page_size],
      gsCNodes = (\<lambda>x. if \<exists>irq :: irq. init_irq_node_ptr + (ucast irq << 5) = x
                      then Some 0 else None)
                 (Low_cnode_ptr  \<mapsto> 10,
@@ -1181,10 +1389,11 @@ definition s0H_internal :: "kernel_state" where
      gsUntypedZeroRanges = ran (map_comp untypedZeroRange (option_map cteCap o map_to_ctes kh0H)),
      gsMaxObjectSize = card (UNIV :: obj_ref set),
      ksDomScheduleIdx = 0,
-     ksDomSchedule = [(0, 10), (1, 10)],
+     ksDomScheduleStart = 0,
+     ksDomSchedule = [(0, 10), (1, 10), (0, 0)],
      ksCurDomain = 0,
      ksDomainTime = 5,
-     ksReadyQueues = const (TcbQueue None None),
+     ksReadyQueues = const emptyQueue,
      ksReadyQueuesL1Bitmap = const 0,
      ksReadyQueuesL2Bitmap = const 0,
      ksCurThread = Low_tcb_ptr,
@@ -1194,7 +1403,6 @@ definition s0H_internal :: "kernel_state" where
      ksWorkUnitsCompleted = undefined,
      ksArchState = arch_state0H,
      ksMachineState = machine_state0\<rparr>"
-
 
 definition Low_cte_cte :: "obj_ref \<Rightarrow> obj_ref \<Rightarrow> cte option" where
   "Low_cte_cte \<equiv> \<lambda>base offs. if is_aligned offs 5 \<and> base \<le> offs \<and> offs \<le> base + 2 ^ 15 - 1
@@ -1234,11 +1442,23 @@ lemma not_in_range_cte_None:
   "x \<notin> cnode_offs_range Low_cnode_ptr \<Longrightarrow> Low_cte_cte Low_cnode_ptr x = None"
   "x \<notin> cnode_offs_range High_cnode_ptr \<Longrightarrow> High_cte_cte High_cnode_ptr x = None"
   "x \<notin> cnode_offs_range Silc_cnode_ptr \<Longrightarrow> Silc_cte_cte Silc_cnode_ptr x = None"
+  "x \<notin> cnode_offs_range init_irq_node_ptr \<Longrightarrow> \<forall>irq. x \<noteq> init_irq_node_ptr + (UCAST(9 \<rightarrow> 64) irq << 5)"
   "x \<notin> tcb_offs_range Low_tcb_ptr \<Longrightarrow> Low_tcb_cte x = None"
   "x \<notin> tcb_offs_range High_tcb_ptr \<Longrightarrow> High_tcb_cte x = None"
   "x \<notin> tcb_offs_range idle_tcb_ptr \<Longrightarrow> idle_tcb_cte x = None"
-  by (fastforce simp: cnode_offs_range_def page_offs_range_def tcb_offs_range_def s0_ptr_defs Low_cte_cte_def
-                      High_cte_cte_def Silc_cte_cte_def Low_tcb_cte_def High_tcb_cte_def idle_tcb_cte_def)+
+        apply (clarsimp simp: cnode_offs_range_def page_offs_range_def tcb_offs_range_def s0_ptr_defs Low_cte_cte_def
+                              High_cte_cte_def Silc_cte_cte_def Low_tcb_cte_def High_tcb_cte_def idle_tcb_cte_def mask_def)+
+     apply safe
+       apply word_bitwise
+      apply word_bitwise
+     apply (erule swap)
+     apply clarsimp
+     apply (rule is_aligned_add)
+      apply (clarsimp simp: is_aligned_def)
+     apply (rule is_aligned_shift)
+    apply (auto simp: cnode_offs_range_def page_offs_range_def tcb_offs_range_def s0_ptr_defs Low_cte_cte_def
+                      High_cte_cte_def Silc_cte_cte_def Low_tcb_cte_def High_tcb_cte_def idle_tcb_cte_def mask_def)
+  done
 
 lemma mask_neg_le:
   "x && ~~ mask n \<le> x"
@@ -1247,9 +1467,9 @@ lemma mask_neg_le:
   done
 
 lemma mask_in_tcb_offs_range:
-  "x && ~~ mask 10 = ptr \<Longrightarrow> x \<in> tcb_offs_range ptr"
-  apply (clarsimp simp: tcb_offs_range_def mask_neg_le objBitsKO_def)
-  apply (cut_tac and_neg_mask_plus_mask_mono[where p=x and n=10])
+  "x && ~~ mask 11 = ptr \<Longrightarrow> x \<in> tcb_offs_range ptr"
+  apply (clarsimp simp: tcb_offs_range_def word_and_le2 objBitsKO_def)
+  apply (cut_tac and_neg_mask_plus_mask_mono[where p=x and n=11])
   apply (simp add: add.commute mask_def)
   done
 
@@ -1266,7 +1486,7 @@ lemma opt_None_not_dom:
   by (simp add: dom_def)
 
 lemma tcb_offs_range_mask_eq:
-  "\<lbrakk> x \<in> tcb_offs_range ptr; is_aligned ptr 10 \<rbrakk> \<Longrightarrow> x && ~~ mask 10 = ptr"
+  "\<lbrakk> x \<in> tcb_offs_range ptr; is_aligned ptr 11 \<rbrakk> \<Longrightarrow> x && ~~ mask 11 = ptr"
   apply (drule(1) tcb_offs_range_correct')
   apply (clarsimp simp: objBitsKO_def)
   apply (drule_tac d="ucast y" in is_aligned_add_helper)
@@ -1277,27 +1497,29 @@ lemma tcb_offs_range_mask_eq:
   done
 
 lemma not_in_tcb_offs:
-  "\<forall>tcb. kh0H (x && ~~ mask 10) \<noteq> Some (KOTCB tcb)
+  "\<forall>tcb. kh0H (x && ~~ mask 11) \<noteq> Some (KOTCB tcb)
    \<Longrightarrow> x \<notin> tcb_offs_range Low_tcb_ptr"
-  "\<forall>tcb. kh0H (x && ~~ mask 10) \<noteq> Some (KOTCB tcb)
+  "\<forall>tcb. kh0H (x && ~~ mask 11) \<noteq> Some (KOTCB tcb)
    \<Longrightarrow> x \<notin> tcb_offs_range High_tcb_ptr"
-  "\<forall>tcb. kh0H (x && ~~ mask 10) \<noteq> Some (KOTCB tcb)
+  "\<forall>tcb. kh0H (x && ~~ mask 11) \<noteq> Some (KOTCB tcb)
    \<Longrightarrow> x \<notin> tcb_offs_range idle_tcb_ptr"
   by (fastforce simp: s0_ptrs_aligned dest: tcb_offs_range_mask_eq)+
 
 lemma range_tcb_not_kh0H_dom:
-  "{(x && ~~ mask 10) + 1..(x && ~~ mask 10) + 2 ^ 10 - 1} \<inter> dom kh0H \<noteq> {} \<Longrightarrow> (x && ~~ mask 10) \<noteq> High_tcb_ptr"
-  "{(x && ~~ mask 10) + 1..(x && ~~ mask 10) + 2 ^ 10 - 1} \<inter> dom kh0H \<noteq> {} \<Longrightarrow> (x && ~~ mask 10) \<noteq> Low_tcb_ptr"
-  "{(x && ~~ mask 10) + 1..(x && ~~ mask 10) + 2 ^ 10 - 1} \<inter> dom kh0H \<noteq> {} \<Longrightarrow> (x && ~~ mask 10) \<noteq> idle_tcb_ptr"
+  "{(x && ~~ mask 11) + 1..(x && ~~ mask 11) + 2 ^ 11 - 1} \<inter> dom kh0H \<noteq> {} \<Longrightarrow> (x && ~~ mask 11) \<noteq> High_tcb_ptr"
+  "{(x && ~~ mask 11) + 1..(x && ~~ mask 11) + 2 ^ 11 - 1} \<inter> dom kh0H \<noteq> {} \<Longrightarrow> (x && ~~ mask 11) \<noteq> Low_tcb_ptr"
+  "{(x && ~~ mask 11) + 1..(x && ~~ mask 11) + 2 ^ 11 - 1} \<inter> dom kh0H \<noteq> {} \<Longrightarrow> (x && ~~ mask 11) \<noteq> idle_tcb_ptr"
     apply clarsimp
     apply (drule int_not_emptyD)
     apply (clarsimp simp: kh0H_dom)
     apply (subgoal_tac "xa \<in> tcb_offs_range High_tcb_ptr")
      prefer 2
      apply (clarsimp simp: tcb_offs_range_def objBitsKO_def)
-     apply (rule_tac y="High_tcb_ptr + 1" in order_trans)
+     apply (rule conjI)
+      apply (erule dual_order.trans)
       apply (simp add: s0_ptr_defs)
-     apply simp
+     apply (erule order.trans)
+     apply (simp add: s0_ptr_defs mask_def)
     apply (clarsimp simp: kh0H_dom_distinct[THEN set_mem_neq])
     apply ((clarsimp simp: kh0H_dom_sets_distinct[THEN orthD2] |
             clarsimp simp: kh0H_dom_sets_distinct[THEN orthD1])+)[1]
@@ -1308,9 +1530,11 @@ lemma range_tcb_not_kh0H_dom:
    apply (subgoal_tac "xa \<in> tcb_offs_range Low_tcb_ptr")
     prefer 2
     apply (clarsimp simp: tcb_offs_range_def objBitsKO_def)
-    apply (rule_tac y="Low_tcb_ptr + 1" in order_trans)
+    apply (rule conjI)
+     apply (erule dual_order.trans)
      apply (simp add: s0_ptr_defs)
-    apply simp
+    apply (erule order.trans)
+    apply (simp add: s0_ptr_defs mask_def)
    apply (clarsimp simp: kh0H_dom_distinct[THEN set_mem_neq])
    apply ((clarsimp simp: kh0H_dom_sets_distinct[THEN orthD2] |
            clarsimp simp: kh0H_dom_sets_distinct[THEN orthD1])+)[1]
@@ -1321,9 +1545,11 @@ lemma range_tcb_not_kh0H_dom:
   apply (subgoal_tac "xa \<in> tcb_offs_range idle_tcb_ptr")
    prefer 2
    apply (clarsimp simp: tcb_offs_range_def objBitsKO_def)
-   apply (rule_tac y="idle_tcb_ptr + 1" in order_trans)
+   apply (rule conjI)
+    apply (erule dual_order.trans)
     apply (simp add: s0_ptr_defs)
-   apply simp
+   apply (erule order.trans)
+   apply (simp add: s0_ptr_defs mask_def)
   apply (clarsimp simp: kh0H_dom_distinct[THEN set_mem_neq])
   apply ((clarsimp simp: kh0H_dom_sets_distinct[THEN orthD2] |
           clarsimp simp: kh0H_dom_sets_distinct[THEN orthD1])+)[1]
@@ -1337,6 +1563,14 @@ lemma kh0H_dom_tcb:
   apply (simp add: kh0H_dom)
   apply (elim disjE)
   by (auto dest: offs_range_correct simp: kh0H_all_obj_def s0_ptrs_aligned split: if_split_asm)
+
+lemma vs_index_bits_less_word_len[simp]:
+  "vs_index_bits < 64"
+  by (auto simp: bit_simps)
+
+lemma vs_index_bits_pt_bits:
+  "vs_index_bits + 3 = pt_bits VSRootPT_T"
+  by (simp add: bit_simps)
 
 lemma map_to_ctes_kh0H:
   "map_to_ctes kh0H =
@@ -1370,8 +1604,8 @@ lemma map_to_ctes_kh0H:
       apply (clarsimp split: option.splits)
       apply (rule conjI)
        apply (fastforce simp: tcb_cte_cases_def Low_tcb_cte_def dest: neg_mask_decompose)
-      subgoal by (fastforce simp: Low_tcb_cte_def tcb_cte_cases_def
-                           split: if_split_asm dest: neg_mask_decompose)
+  subgoal by (fastforce simp: Low_tcb_cte_def tcb_cte_cases_def
+                       split: if_split_asm dest: neg_mask_decompose)
      apply (clarsimp simp: option_update_range_def)
      apply (frule mask_in_tcb_offs_range)
      apply (clarsimp simp: kh0H_dom_distinct[THEN set_mem_neq])
@@ -1382,8 +1616,8 @@ lemma map_to_ctes_kh0H:
      apply (clarsimp split: option.splits)
      apply (rule conjI)
       apply (fastforce simp: tcb_cte_cases_def High_tcb_cte_def dest: neg_mask_decompose)
-     subgoal by (fastforce simp: High_tcb_cte_def tcb_cte_cases_def
-                          split: if_split_asm dest: neg_mask_decompose)
+  subgoal by (fastforce simp: High_tcb_cte_def tcb_cte_cases_def
+                       split: if_split_asm dest: neg_mask_decompose)
     apply (clarsimp simp: option_update_range_def)
     apply (frule mask_in_tcb_offs_range)
     apply (clarsimp simp: kh0H_dom_distinct[THEN set_mem_neq])
@@ -1394,8 +1628,8 @@ lemma map_to_ctes_kh0H:
     apply (clarsimp split: option.splits)
     apply (rule conjI)
      apply (fastforce simp: tcb_cte_cases_def idle_tcb_cte_def dest: neg_mask_decompose)
-    subgoal by (fastforce simp: idle_tcb_cte_def tcb_cte_cases_def
-                         split: if_split_asm dest: neg_mask_decompose)
+  subgoal by (fastforce simp: idle_tcb_cte_def tcb_cte_cases_def
+                       split: if_split_asm dest: neg_mask_decompose)
    apply (drule_tac m="kh0H" in opt_None_not_dom)
    apply (rule conjI)
     apply (clarsimp simp: kh0H_dom option_update_range_def)
@@ -1430,18 +1664,20 @@ lemma map_to_ctes_kh0H:
                defer 2
                apply ((clarsimp simp: map_to_ctes_def Let_def split del: if_split,
                        subst if_split_eq1, rule conjI, rule impI, drule pt_offs_range_correct,
-                       clarsimp simp: kh0H_obj_def kh0H_dom_distinct option_update_range_def not_in_range_cte_None,
+                       clarsimp simp: kh0H_obj_def kh0H_dom_distinct option_update_range_def not_in_range_cte_None split: if_split_asm,
                        rule impI, subst if_split_eq1, rule conjI, rule impI, rule FalseE,
-                       drule pt_offs_range_correct, clarsimp, cut_tac x=ya and 'a=64 in ucast_less,
-                       simp, drule shiftl_less_t2n'[where n=3], simp, simp,
-                       drule plus_one_helper[where n="0xFFF", simplified], drule kh0H_dom_tcb,
+                       drule pt_offs_range_correct, clarsimp, cut_tac x=ya and 'a=64 in ucast_less, simp add: bit_simps,
+                       drule shiftl_less_t2n'[where n=3], simp add: bit_simps, simp,
+                       drule plus_one_helper[where n="2 ^ (vs_index_bits + 3) - 1", simplified]
+                             plus_one_helper[where n="0xFFF", simplified],
+                       drule kh0H_dom_tcb,
                        (elim disjE, (clarsimp simp: s0_ptr_defs objBitsKO_def,
                                      erule notE[rotated],
                                      rule_tac a="x::obj_ref" for x in dual_order.strict_implies_not_eq,
                                      rule less_le_trans[rotated, OF aligned_le_sharp],
-                                     erule word_plus_mono_right2[rotated],
-                                     simp, simp add: is_aligned_def, simp)+)[1],
-                       rule impI,
+                                     rule word_plus_mono_right2[rotated], simp add: order_less_imp_le,
+                                     simp add: bit_simps, simp add: is_aligned_def, simp)+)[1],
+                        rule impI,
                        clarsimp simp: option_update_range_def kh0H_dom_distinct[THEN set_mem_neq] not_in_range_cte_None,
                        ((clarsimp simp: kh0H_dom_sets_distinct[THEN orthD1] not_in_range_cte_None irq_node_offs_in_range |
                          clarsimp simp: kh0H_dom_sets_distinct[THEN orthD2] not_in_range_cte_None)+)[1])+)[5]
@@ -1465,7 +1701,8 @@ lemma map_to_ctes_kh0H:
                frule_tac 'a=64 in of_bl_length_le, simp, simp, drule int_not_emptyD,
                clarsimp simp: kh0H_dom s0_ptr_defs cnode_offs_range_def page_offs_range_def
                               pt_offs_range_def irq_node_offs_range_def,
-               (elim disjE, (clarsimp simp: s0_ptr_defs,
+               (elim disjE, ((subst (asm) pt_bits_def, simp add: bit_simps split: if_splits; unat_arith)
+                           | clarsimp simp: s0_ptr_defs,
                              drule_tac b="x + y * 0x20" and n=5 for x y in aligned_le_sharp,
                              fastforce simp: is_aligned_def, clarsimp simp: add.commute,
                              subst (asm) mask_out_add_aligned[symmetric],
@@ -1475,12 +1712,12 @@ lemma map_to_ctes_kh0H:
                              erule word_plus_mono_right2[rotated],
                              fastforce, fastforce, fastforce simp: add.commute | unat_arith)+)[1])+)[3]
     apply (clarsimp simp: map_to_ctes_def Let_def kh0H_obj_def split del: if_split,
-           subst if_split_eq1, rule conjI, rule impI,
-           clarsimp simp: option_update_range_def kh0H_dom_distinct not_in_range_cte_None, rule impI,
-           clarsimp simp: kh0H_dom objBitsKO_def s0_ptr_defs is_aligned_def page_offs_range_def
-                          cnode_offs_range_def pt_offs_range_def irq_node_offs_range_def,
-           rule FalseE, drule int_not_emptyD, clarsimp,
-           (elim disjE, (clarsimp | drule(1) order_trans le_less_trans, fastforce)+)[1])
+        subst if_split_eq1, rule conjI, rule impI,
+        clarsimp simp: option_update_range_def kh0H_dom_distinct not_in_range_cte_None, rule impI,
+        clarsimp simp: kh0H_dom objBitsKO_def s0_ptr_defs is_aligned_def page_offs_range_def
+                       cnode_offs_range_def pt_offs_range_def irq_node_offs_range_def,
+        rule FalseE, drule int_not_emptyD, clarsimp,
+        (elim disjE, (clarsimp simp: bit_simps split: if_splits | drule(1) order_trans le_less_trans, fastforce)+)[1])
    apply (clarsimp simp: map_to_ctes_def Let_def kh0H_obj_def split del: if_split)
    apply (subst if_split_eq1)
    apply (rule conjI, clarsimp)
@@ -1515,13 +1752,14 @@ lemma map_to_ctes_kh0H:
   apply (drule shiftl_less_t2n'[where n=5])
    apply simp
   apply simp
-  apply (drule plus_one_helper[where n="0x7FF", simplified])
+  apply (drule plus_one_helper[where n="0x3FFF", simplified])
   apply (elim disjE)
          apply (unat_arith+)[7]
   apply (drule int_not_emptyD)
   apply clarsimp
   apply (elim disjE,
-         ((clarsimp,
+         (((subst (asm) pt_bits_def, simp add: bit_simps split: if_splits; unat_arith) |
+          clarsimp,
           drule(1) aligned_le_sharp,
           clarsimp simp: add.commute,
           subst(asm) mask_out_add_aligned[symmetric],
@@ -1542,8 +1780,9 @@ lemma option_update_range_map_comp:
   by (simp add: fun_eq_iff option_update_range_def map_comp_def map_add_def split: option.split)
 
 lemma tcb_offs_in_rangeI:
-  "\<lbrakk> ptr \<le> ptr + x; ptr + x \<le> ptr + 2 ^ 10 - 1 \<rbrakk> \<Longrightarrow> ptr + x \<in> tcb_offs_range ptr"
-  by (simp add: tcb_offs_range_def)
+  "\<lbrakk> ptr \<le> ptr + x; ptr + x \<le> ptr + 2 ^ 11 - 1 \<rbrakk> \<Longrightarrow> ptr + x \<in> tcb_offs_range ptr"
+  apply (simp add: tcb_offs_range_def)
+  by (simp add: Groups.add_ac(2))
 
 lemma map_to_ctes_kh0H_simps[simp]:
   "map_to_ctes kh0H (init_irq_node_ptr + (ucast (irq :: irq) << 5)) = Some (CTE NullCap Null_mdb)"
@@ -1891,13 +2130,13 @@ lemma map_to_ctes_kh0H_SomeD:
        x = idle_tcb_ptr + 0x60 \<and> y = (CTE NullCap Null_mdb) \<or>
        x = idle_tcb_ptr + 0x80 \<and> y = (CTE NullCap Null_mdb) \<or>
        x = Low_tcb_ptr \<and> y = (CTE (CNodeCap Low_cnode_ptr 10 2 10) (MDB (Low_cnode_ptr + 0x40) 0 False False)) \<or>
-       x = Low_tcb_ptr + 0x20 \<and> y = (CTE (ArchObjectCap (PageTableCap Low_pd_ptr (Some (ucast Low_asid,0))))
+       x = Low_tcb_ptr + 0x20 \<and> y = (CTE (ArchObjectCap (PageTableCap Low_pd_ptr VSRootPT_T (Some (ucast Low_asid,0))))
                                          (MDB (Low_cnode_ptr + 0x60) 0 False False)) \<or>
        x = Low_tcb_ptr + 0x40 \<and> y = (CTE (ReplyCap Low_tcb_ptr True True) (MDB 0 0 True True)) \<or>
        x = Low_tcb_ptr + 0x60 \<and> y = (CTE NullCap Null_mdb) \<or>
        x = Low_tcb_ptr + 0x80 \<and> y = (CTE NullCap Null_mdb) \<or>
        x = High_tcb_ptr \<and> y = (CTE (CNodeCap High_cnode_ptr 10 2 10) (MDB (High_cnode_ptr + 0x40) 0 False False)) \<or>
-       x = High_tcb_ptr + 0x20 \<and> y = (CTE (ArchObjectCap (PageTableCap High_pd_ptr (Some (ucast High_asid, 0))))
+       x = High_tcb_ptr + 0x20 \<and> y = (CTE (ArchObjectCap (PageTableCap High_pd_ptr VSRootPT_T (Some (ucast High_asid, 0))))
                                           (MDB (High_cnode_ptr + 0x60) 0 False False)) \<or>
        x = High_tcb_ptr + 0x40 \<and> y = (CTE (ReplyCap High_tcb_ptr True True) (MDB 0 0 True True)) \<or>
        x = High_tcb_ptr + 0x60 \<and> y = (CTE NullCap Null_mdb) \<or>
@@ -1956,7 +2195,7 @@ lemma pspace_distinct'_split:
   done
 
 lemma irq_node_offs_range_def2:
-  "irq_node_offs_range = {x. init_irq_node_ptr \<le> x \<and> x \<le> init_irq_node_ptr + 0x7E0} \<inter>
+  "irq_node_offs_range = {x. init_irq_node_ptr \<le> x \<and> x \<le> init_irq_node_ptr + 0x3FFF} \<inter>
                          {x. is_aligned x 5}"
   apply (safe, simp_all add: irq_node_offs_range_def add.commute)
   by (auto dest: word_less_sub_1 simp: s0_ptr_defs elim: dual_order.strict_trans2[rotated])
@@ -2002,7 +2241,7 @@ lemma s0H_pspace_distinct':
                                , drule dual_order.trans, assumption
                                , clarsimp simp: s0_ptr_defs objBitsKO_def
                | solves \<open>clarsimp simp: s0_ptr_defs objBitsKO_def\<close>)+)
-  \<comment> \<open>riscv_global_pt_ptr\<close>
+  \<comment> \<open>arm_global_pt_ptr\<close>
   apply (erule_tac P="_ \<and> _ \<and> y = _" in disjE)
    apply (elim disjE; clarsimp)
                    apply ((clarsimp simp: irq_node_offs_range_def2 pt_offs_range_def objBitsKO_def,
@@ -2013,109 +2252,140 @@ lemma s0H_pspace_distinct':
              apply (clarsimp simp: pt_offs_range_def objBitsKO_def archObjSize_def kh0H_obj_def bit_simps
                             split: if_split_asm;
                     (drule (1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def))
-             apply (thin_tac "_ \<le> _",
-                    clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
-                                   irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
-                    drule_tac a=x and b="_ + _" in aligned_le_sharp, assumption,
-                    drule dual_order.trans[rotated],
-                    erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
-                    (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
-                    simp add: s0_ptr_defs mask_def)+
+              apply ((thin_tac "_ \<le> _",
+                      clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
+                                     irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
+                      drule_tac a=x in aligned_le_sharp, assumption,
+                      solves \<open>drule dual_order.trans[rotated],
+                      erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
+                      (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
+                      simp add: s0_ptr_defs mask_def split: if_splits\<close>)+)[12]
   \<comment> \<open>irq_node_offs_range\<close>
   apply (erule_tac P="_ \<and> y = _" in disjE)
    apply (elim disjE; clarsimp)
-                   apply ((clarsimp simp: irq_node_offs_range_def2 pt_offs_range_def objBitsKO_def,
-                           drule dual_order.trans, assumption,
-                           (thin_tac "ya \<le> _", thin_tac "_ \<le> ya",
-                            drule_tac b=ya and a="_ + _" in dual_order.trans, assumption)?,
-                           simp add: s0_ptr_defs)+)[5]
+                   apply (clarsimp simp: irq_node_offs_range_def2 pt_offs_range_def objBitsKO_def,
+                          drule dual_order.trans, assumption,
+                          drule dual_order.trans[where c="init_irq_node_ptr"], assumption,
+                          solves \<open>clarsimp simp: s0_ptr_defs bit_simps split: if_splits\<close>)+
               apply (clarsimp simp: irq_node_offs_range_def objBitsKO_def archObjSize_def kh0H_obj_def
                              split: if_split_asm;
                      (drule(1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def))
-             apply (thin_tac "_ \<le> _",
-                    clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
-                                   irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
-                    drule_tac a=x and b="_ + _" in aligned_le_sharp, assumption,
-                    drule dual_order.trans[rotated],
-                    erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
-                    (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
-                    simp add: s0_ptr_defs mask_def)+
+             apply (clarsimp simp: irq_node_offs_range_def2 cnode_offs_range_def pt_offs_range_def objBitsKO_def,
+                    drule dual_order.trans, assumption,
+                    drule dual_order.trans[where c="init_irq_node_ptr"], assumption,
+                    solves \<open>clarsimp simp: s0_ptr_defs bit_simps split: if_splits\<close>)+
+       apply (thin_tac "_ \<le> _",
+              clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
+                             irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
+              drule_tac a=x and b="_ + _" in aligned_le_sharp, assumption,
+              drule dual_order.trans[rotated],
+              erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
+              (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
+              simp add: s0_ptr_defs mask_def)+
   \<comment> \<open>Low_pt_ptr\<close>
   apply (erule_tac P="_ \<and> _ \<and> y = _" in disjE)
    apply (elim disjE; clarsimp)
-                   apply ((clarsimp simp: irq_node_offs_range_def2 pt_offs_range_def objBitsKO_def,
-                           drule dual_order.trans, assumption,
-                           (thin_tac "ya \<le> _", thin_tac "_ \<le> ya",
-                            drule_tac b=ya and a="_ + _" in dual_order.trans, assumption)?,
-                           simp add: s0_ptr_defs)+)[6]
+                   apply (clarsimp simp: irq_node_offs_range_def2 cnode_offs_range_def pt_offs_range_def objBitsKO_def,
+                          drule dual_order.trans, assumption,
+                          drule dual_order.trans[where c="Low_pt_ptr"], assumption,
+                          solves \<open>clarsimp simp: s0_ptr_defs bit_simps split: if_splits\<close>)+
+              apply ((thin_tac "_ \<le> _",
+                      clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
+                                     irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def split: if_split_asm,
+                      drule_tac a=x and b="_ + _" in aligned_le_sharp, assumption,
+                      solves \<open>drule dual_order.trans[rotated],
+                      erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
+                      (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
+                      simp add: s0_ptr_defs mask_def\<close>)+)[1]
              apply (clarsimp simp: pt_offs_range_def objBitsKO_def archObjSize_def kh0H_obj_def bit_simps
                             split: if_split_asm;
                     (drule (1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def))
-             apply (thin_tac "_ \<le> _",
-                    clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
-                                   irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
-                    drule_tac a=x and b="_ + _" in aligned_le_sharp, assumption,
-                    drule dual_order.trans[rotated],
-                    erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
-                    (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
-                    simp add: s0_ptr_defs mask_def)+
+            apply (thin_tac "_ \<le> _",
+                   clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
+                                  irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
+                   drule_tac a=x and b="_ + _" in aligned_le_sharp, assumption,
+                   drule dual_order.trans[rotated],
+                   erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
+                   (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
+                   simp add: s0_ptr_defs mask_def)+
   \<comment> \<open>High_pt_ptr\<close>
   apply (erule_tac P="_ \<and> _ \<and> y = _" in disjE)
    apply (elim disjE; clarsimp)
-                   apply ((clarsimp simp: irq_node_offs_range_def2 pt_offs_range_def objBitsKO_def,
-                           drule dual_order.trans, assumption,
-                           (thin_tac "ya \<le> _", thin_tac "_ \<le> ya",
-                            drule_tac b=ya and a="_ + _" in dual_order.trans, assumption)?,
-                           simp add: s0_ptr_defs)+)[7]
+                   apply (clarsimp simp: irq_node_offs_range_def2 cnode_offs_range_def pt_offs_range_def objBitsKO_def,
+                          drule dual_order.trans, assumption,
+                          drule dual_order.trans[where c="High_pt_ptr"], assumption,
+                          solves \<open>clarsimp simp: s0_ptr_defs bit_simps split: if_splits\<close>)+
+              apply ((thin_tac "_ \<le> _",
+                      clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
+                                     irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def split: if_split_asm,
+                      drule_tac a=x and b="_ + _" in aligned_le_sharp, assumption,
+                      solves \<open>drule dual_order.trans[rotated],
+                      erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
+                      (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
+                      simp add: s0_ptr_defs mask_def\<close>)+)
              apply (clarsimp simp: pt_offs_range_def objBitsKO_def archObjSize_def kh0H_obj_def bit_simps
                             split: if_split_asm;
-                    (drule (1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def))
-             apply (thin_tac "_ \<le> _",
-                    clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
-                                   irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
-                    drule_tac a=x and b="_ + _" in aligned_le_sharp, assumption,
-                    drule dual_order.trans[rotated],
-                    erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
-                    (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
-                    simp add: s0_ptr_defs mask_def)+
+                    (drule (1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def))+
+         apply (thin_tac "_ \<le> _",
+                clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
+                               irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
+                drule_tac a=x and b="_ + _" in aligned_le_sharp, assumption,
+                drule dual_order.trans[rotated],
+                erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
+                (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
+                simp add: s0_ptr_defs mask_def)+
   \<comment> \<open>Low_pd_ptr\<close>
   apply (erule_tac P="_ \<and> _ \<and> y = _" in disjE)
    apply (elim disjE; clarsimp)
-                   apply ((clarsimp simp: irq_node_offs_range_def2 pt_offs_range_def objBitsKO_def,
-                           drule dual_order.trans, assumption,
-                           (thin_tac "ya \<le> _", thin_tac "_ \<le> ya",
-                            drule_tac b=ya and a="_ + _" in dual_order.trans, assumption)?,
-                           simp add: s0_ptr_defs)+)[8]
-             apply (clarsimp simp: pt_offs_range_def objBitsKO_def archObjSize_def kh0H_obj_def bit_simps
-                            split: if_split_asm;
-                    (drule (1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def))
-             apply (thin_tac "_ \<le> _",
-                    clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
-                                   irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
-                    drule_tac a=x and b="_ + _" in aligned_le_sharp, assumption,
-                    drule dual_order.trans[rotated],
-                    erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
-                    (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
-                    simp add: s0_ptr_defs mask_def)+
+                   apply (clarsimp simp: irq_node_offs_range_def2 cnode_offs_range_def pt_offs_range_def objBitsKO_def,
+                          drule dual_order.trans, assumption,
+                          drule dual_order.trans[where c="Low_pd_ptr"], assumption,
+                          solves \<open>clarsimp simp: s0_ptr_defs bit_simps split: if_splits\<close>)+
+              apply (thin_tac "_ \<le> _",
+                     clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
+                                    irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
+                     drule_tac a=x in aligned_le_sharp, assumption,
+                     drule dual_order.trans[rotated],
+                     erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
+                     (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
+                     solves \<open>simp add: s0_ptr_defs mask_def bit_simps split: if_splits\<close>)
+             apply (solves \<open>clarsimp simp: pt_offs_range_def objBitsKO_def archObjSize_def kh0H_obj_def bit_simps
+                                    split: if_split_asm;
+                    (drule (1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def)\<close>)+
+         apply ((thin_tac "_ \<le> _",
+                 clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
+                                irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
+                 drule_tac a=x in aligned_le_sharp, assumption,
+                 solves \<open>drule dual_order.trans[rotated],
+                 erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
+                 (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
+                 simp add: s0_ptr_defs mask_def bit_simps split: if_splits\<close>)+)[7]
   \<comment> \<open>High_pd_ptr\<close>
   apply (erule_tac P="_ \<and> _ \<and> y = _" in disjE)
    apply (elim disjE; clarsimp)
-                   apply ((clarsimp simp: irq_node_offs_range_def2 pt_offs_range_def objBitsKO_def,
-                           drule dual_order.trans, assumption,
-                           (thin_tac "ya \<le> _", thin_tac "_ \<le> ya",
-                            drule_tac b=ya and a="_ + _" in dual_order.trans, assumption)?,
-                           simp add: s0_ptr_defs)+)[9]
-             apply (clarsimp simp: pt_offs_range_def objBitsKO_def archObjSize_def kh0H_obj_def bit_simps
-                            split: if_split_asm;
-                    (drule (1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def))
-             apply (thin_tac "_ \<le> _",
-                    clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
-                                   irq_node_offs_range_def cnode_offs_range_def page_offs_range_def,
-                    drule_tac a=x and b="_ + _" in aligned_le_sharp, assumption,
-                    drule dual_order.trans[rotated],
-                    erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
-                    (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
-                    simp add: s0_ptr_defs mask_def)+
+                   apply (clarsimp simp: irq_node_offs_range_def2 cnode_offs_range_def pt_offs_range_def objBitsKO_def,
+                          drule dual_order.trans, assumption,
+                          drule dual_order.trans[where c="High_pd_ptr"], assumption,
+                          solves \<open>clarsimp simp: s0_ptr_defs bit_simps split: if_splits\<close>)+
+              apply (thin_tac "_ \<le> _",
+                     clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
+                                    irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
+                     drule_tac a=x in aligned_le_sharp, assumption,
+                     drule dual_order.trans[rotated],
+                     erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
+                     (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
+                     solves \<open>simp add: s0_ptr_defs mask_def bit_simps split: if_splits\<close>)
+             apply (solves \<open>clarsimp simp: pt_offs_range_def objBitsKO_def archObjSize_def kh0H_obj_def bit_simps
+                                    split: if_split_asm;
+                            (drule (1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def)\<close>)+
+         apply ((thin_tac "_ \<le> _",
+                 clarsimp simp: kh0H_obj_def objBitsKO_def archObjSize_def bit_simps pt_offs_range_def
+                                irq_node_offs_range_def2 cnode_offs_range_def page_offs_range_def,
+                 drule_tac a=x in aligned_le_sharp, assumption,
+                 solves \<open>drule dual_order.trans[rotated],
+                 erule word_plus_mono_left, simp add: s0_ptr_defs mask_def,
+                 (drule_tac b=ya and a="(_ && ~~ mask _) + _" in dual_order.trans, assumption)?,
+                 simp add: s0_ptr_defs mask_def bit_simps split: if_splits\<close>)+)[7]
   \<comment> \<open>Low_pool_ptr\<close>
   apply (erule_tac P="_ \<and> y = _" in disjE)
    subgoal for x y ya yb
@@ -2124,7 +2394,7 @@ lemma s0H_pspace_distinct':
                         page_offs_range_def objBitsKO_def archObjSize_def kh0H_obj_def,
          (thin_tac "ya \<le> _", drule dual_order.trans, assumption |
           thin_tac "_ \<le> ya", drule dual_order.trans, assumption)?,
-         solves \<open>clarsimp simp: s0_ptr_defs bit_simps\<close>)+))
+         solves \<open>clarsimp simp: s0_ptr_defs bit_simps split: if_splits\<close>)+))
   \<comment> \<open>High_pool_ptr\<close>
   apply (erule_tac P="_ \<and> y = _" in disjE)
    subgoal for x y ya yb
@@ -2133,16 +2403,13 @@ lemma s0H_pspace_distinct':
                         page_offs_range_def objBitsKO_def archObjSize_def kh0H_obj_def,
          (thin_tac "ya \<le> _", drule dual_order.trans, assumption |
           thin_tac "_ \<le> ya", drule dual_order.trans, assumption)?,
-         solves \<open>clarsimp simp: s0_ptr_defs bit_simps\<close>)+))
+         solves \<open>clarsimp simp: s0_ptr_defs bit_simps split: if_splits\<close>)+))
   \<comment> \<open>Low_cnode_ptr\<close>
   apply (erule_tac P="_ \<and> _ \<and> y = _" in disjE)
   apply (elim disjE; clarsimp)
-                  apply ((clarsimp simp: cnode_offs_range_def irq_node_offs_range_def2
-                                         pt_offs_range_def objBitsKO_def,
-                          drule dual_order.trans, assumption,
-                          (thin_tac "ya \<le> _", thin_tac "_ \<le> ya",
-                           drule_tac b=ya and a="_ + _" in dual_order.trans, assumption)?,
-                          simp add: s0_ptr_defs)+)[12]
+     apply (clarsimp simp: cnode_offs_range_def irq_node_offs_range_def2 pt_offs_range_def,
+             drule order.trans, assumption, drule order.trans, assumption,
+              solves \<open>simp add: s0_ptr_defs bit_simps split: if_splits\<close>)+
       apply (clarsimp simp: objBitsKO_def kh0H_obj_def Low_cte'_def Low_capsH_def cnode_offs_range_def
                      split: if_split_asm;
              (drule (1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def))
@@ -2157,12 +2424,9 @@ lemma s0H_pspace_distinct':
   \<comment> \<open>High_cnode_ptr\<close>
   apply (erule_tac P="_ \<and> _ \<and> y = _" in disjE)
   apply (elim disjE; clarsimp)
-                  apply ((clarsimp simp: cnode_offs_range_def irq_node_offs_range_def2
-                                         pt_offs_range_def objBitsKO_def,
-                          drule dual_order.trans, assumption,
-                          (thin_tac "ya \<le> _", thin_tac "_ \<le> ya",
-                           drule_tac b=ya and a="_ + _" in dual_order.trans, assumption)?,
-                          simp add: s0_ptr_defs)+)[13]
+                       apply (clarsimp simp: cnode_offs_range_def irq_node_offs_range_def2 pt_offs_range_def,
+             drule order.trans, assumption, drule order.trans, assumption,
+              solves \<open>simp add: s0_ptr_defs bit_simps split: if_splits\<close>)+
       apply (clarsimp simp: objBitsKO_def kh0H_obj_def High_cte'_def High_capsH_def cnode_offs_range_def
                      split: if_split_asm;
              (drule (1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def))
@@ -2177,12 +2441,9 @@ lemma s0H_pspace_distinct':
   \<comment> \<open>Silc_cnode_ptr\<close>
   apply (erule_tac P="_ \<and> _ \<and> y = _" in disjE)
   apply (elim disjE; clarsimp)
-                  apply ((clarsimp simp: cnode_offs_range_def irq_node_offs_range_def2
-                                         pt_offs_range_def objBitsKO_def,
-                          drule dual_order.trans, assumption,
-                          (thin_tac "ya \<le> _", thin_tac "_ \<le> ya",
-                           drule_tac b=ya and a="_ + _" in dual_order.trans, assumption)?,
-                          simp add: s0_ptr_defs)+)[14]
+                       apply (clarsimp simp: cnode_offs_range_def irq_node_offs_range_def2 pt_offs_range_def,
+             drule order.trans, assumption, drule order.trans, assumption,
+              solves \<open>simp add: s0_ptr_defs bit_simps split: if_splits\<close>)+
       apply (clarsimp simp: objBitsKO_def kh0H_obj_def Silc_cte'_def Silc_capsH_def cnode_offs_range_def
                      split: if_split_asm;
              (drule (1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def))
@@ -2202,15 +2463,13 @@ lemma s0H_pspace_distinct':
                         page_offs_range_def objBitsKO_def archObjSize_def kh0H_obj_def,
          (thin_tac "ya \<le> _", drule dual_order.trans, assumption |
           thin_tac "_ \<le> ya", drule dual_order.trans, assumption)?,
-         solves \<open>clarsimp simp: s0_ptr_defs bit_simps\<close>)+))
+         solves \<open>clarsimp simp: s0_ptr_defs bit_simps split: if_splits\<close>)+))
   \<comment> \<open>shared_page_ptr\<close>
   apply (elim disjE; clarsimp)
-                 apply ((clarsimp simp: cnode_offs_range_def irq_node_offs_range_def2
+     apply (clarsimp simp: cnode_offs_range_def irq_node_offs_range_def2
                                         page_offs_range_def pt_offs_range_def objBitsKO_def,
-                         drule dual_order.trans, assumption,
-                         (thin_tac "ya \<le> _", thin_tac "_ \<le> ya",
-                          drule_tac b=ya and a="_ + _" in dual_order.trans, assumption)?,
-                         simp add: s0_ptr_defs)+)[16]
+             drule order.trans, assumption, drule order.trans, assumption,
+              solves \<open>simp add: s0_ptr_defs bit_simps split: if_splits\<close>)+
   apply (clarsimp simp: page_offs_range_def objBitsKO_def archObjSize_def bit_simps)
   apply (drule (1) aligned_le_sharp, simp add: mask_neg_add_aligned', fastforce simp: mask_def)
   done
@@ -2337,11 +2596,33 @@ lemma pd_offs_aligned:
   "is_aligned (High_pd_ptr + (ucast (x :: pt_index) << 3)) 3"
   by (rule is_aligned_add[OF _ is_aligned_shift], simp add: s0_ptr_defs is_aligned_def)+
 
-lemma less_0x200_exists_ucast:
-  "p < 0x200 \<Longrightarrow> \<exists>p'. p = UCAST(9 \<rightarrow> 64) p'"
+lemma less_VSRootBits_exists_ucast:
+  "p < 2 ^ ptTranslationBits VSRootPT_T \<Longrightarrow> \<exists>p'. p = UCAST(vs_index_len \<rightarrow> 64) p'"
+  apply (rule_tac x="UCAST(64 \<rightarrow> vs_index_len) p" in exI)
+  apply (rule sym)
+  apply (rule ucast_ucast_le_mask)
+  apply (simp add: mask_def bit_simps)
+  done
+
+lemma less_eq_0x1FF_exists_ucast:
+  "p \<le> 0x1FF \<Longrightarrow> \<exists>p'. p = UCAST(9 \<rightarrow> 64) p'"
   apply (rule_tac x="UCAST(64 \<rightarrow> 9) p" in exI)
   apply word_bitwise
   apply clarsimp
+  done
+
+lemma less_pageBits_exists_ucast:
+  "p < 2 ^ (pageBitsForSize max_page_size - pageBits) \<Longrightarrow> \<exists>p'. p = UCAST(pg_index_len \<rightarrow> 64) p'"
+  apply (rule_tac x="UCAST(64 \<rightarrow> pg_index_len) p" in exI)
+  apply (rule sym)
+  apply (rule ucast_ucast_le_mask)
+  apply (simp add: mask_def bit_simps split: if_splits)
+  done
+
+lemma koTypeOf_PTET[simp]:
+  "koTypeOf ko = ArchT PTET \<longleftrightarrow> (\<exists>pte. ko = KOArch (KOPTE pte))"
+  apply (case_tac ko; clarsimp)
+  apply (case_tac x8; clarsimp)
   done
 
 lemma valid_caps_s0H[simp]:
@@ -2353,79 +2634,159 @@ lemma valid_caps_s0H[simp]:
   "valid_cap' (CNodeCap Low_cnode_ptr 10 2 10) s0H_internal"
   "valid_cap' (CNodeCap High_cnode_ptr 10 2 10) s0H_internal"
   "valid_cap' (CNodeCap Silc_cnode_ptr 10 2 10) s0H_internal"
-  "valid_cap' (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadWrite RISCVLargePage False (Some (ucast Low_asid, 0)))) s0H_internal"
-  "valid_cap' (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadOnly RISCVLargePage False (Some (ucast High_asid, 0)))) s0H_internal"
-  "valid_cap' (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadOnly RISCVLargePage False (Some (ucast Silc_asid, 0)))) s0H_internal"
-  "valid_cap' (ArchObjectCap (PageTableCap Low_pt_ptr (Some (ucast Low_asid, 0)))) s0H_internal"
-  "valid_cap' (ArchObjectCap (PageTableCap High_pt_ptr (Some (ucast High_asid, 0)))) s0H_internal"
-  "valid_cap' (ArchObjectCap (PageTableCap Low_pd_ptr (Some (ucast Low_asid, 0)))) s0H_internal"
-  "valid_cap' (ArchObjectCap (PageTableCap High_pd_ptr (Some (ucast High_asid, 0)))) s0H_internal"
+  "valid_cap' (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadWrite max_page_size False (Some (ucast Low_asid, 0)))) s0H_internal"
+  "valid_cap' (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadOnly max_page_size False (Some (ucast High_asid, 0)))) s0H_internal"
+  "valid_cap' (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadOnly max_page_size False (Some (ucast Silc_asid, 0)))) s0H_internal"
+  "valid_cap' (ArchObjectCap (PageTableCap Low_pt_ptr NormalPT_T (Some (ucast Low_asid, 0)))) s0H_internal"
+  "valid_cap' (ArchObjectCap (PageTableCap High_pt_ptr NormalPT_T (Some (ucast High_asid, 0)))) s0H_internal"
+  "valid_cap' (ArchObjectCap (PageTableCap Low_pd_ptr VSRootPT_T (Some (ucast Low_asid, 0)))) s0H_internal"
+  "valid_cap' (ArchObjectCap (PageTableCap High_pd_ptr VSRootPT_T (Some (ucast High_asid, 0)))) s0H_internal"
   "valid_cap' (ArchObjectCap (ASIDPoolCap Low_pool_ptr (ucast Low_asid))) s0H_internal"
   "valid_cap' (ArchObjectCap (ASIDPoolCap High_pool_ptr (ucast High_asid))) s0H_internal"
   "valid_cap' (NotificationCap ntfn_ptr 0 True False) s0H_internal"
   "valid_cap' (NotificationCap ntfn_ptr 0 False True) s0H_internal"
   "valid_cap' (ReplyCap Low_tcb_ptr True True) s0H_internal"
   "valid_cap' (ReplyCap High_tcb_ptr True True) s0H_internal"
-  supply option.case_cong[cong] if_cong[cong]
-  apply (simp | simp add: valid_cap'_def s0H_internal_def capAligned_def word_bits_def
-                          objBits_def s0_ptrs_aligned obj_at'_def,
-                intro conjI, simp add: objBitsKO_def s0_ptrs_aligned, simp add: objBitsKO_def,
-                simp add: objBitsKO_def s0_ptrs_aligned mask_def,
-                rule pspace_distinctD'[OF _ s0H_pspace_distinct', simplified s0H_internal_def],
-                simp)+
-   apply (simp add: valid_cap'_def capAligned_def word_bits_def objBits_def s0_ptrs_aligned obj_at'_def)
-   apply (intro conjI)
-      apply (simp add: objBitsKO_def s0_ptrs_aligned)
-     apply (simp add: objBitsKO_def)
-    apply (simp add: objBitsKO_def s0_ptrs_aligned mask_def)
-   apply (clarsimp simp: Low_cte_def Low_cte'_def Low_capsH_def cnode_offs_min2 objBitsKO_def
-                         cnode_offs_max2 cnode_offs_aligned2 add.commute s0_ptrs_aligned empty_cte_def)
-   apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct'])
-   apply (simp add: Low_cte_def Low_cte'_def Low_capsH_def empty_cte_def objBitsKO_def
-                    cnode_offs_min2 cnode_offs_max2 cnode_offs_aligned2 add.commute s0_ptrs_aligned)
-   apply (simp add: valid_cap'_def capAligned_def word_bits_def objBits_def s0_ptrs_aligned obj_at'_def)
-   apply (intro conjI)
-      apply (simp add: objBitsKO_def s0_ptrs_aligned)
-     apply (simp add: objBitsKO_def)
-    apply (simp add: objBitsKO_def s0_ptrs_aligned mask_def)
-   apply (clarsimp simp: High_cte_def High_cte'_def High_capsH_def cnode_offs_min2 cnode_offs_max2
-                         cnode_offs_aligned2 add.commute s0_ptrs_aligned objBitsKO_def empty_cte_def)
-   apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct'])
-   apply (simp add: High_cte_def High_cte'_def High_capsH_def empty_cte_def objBitsKO_def
-                    cnode_offs_min2 cnode_offs_max2 cnode_offs_aligned2 add.commute s0_ptrs_aligned)
-   apply (simp add: valid_cap'_def capAligned_def word_bits_def objBits_def s0_ptrs_aligned obj_at'_def)
-   apply (intro conjI)
-      apply (simp add: objBitsKO_def s0_ptrs_aligned)
-     apply (simp add: objBitsKO_def)
-    apply (simp add: objBitsKO_def s0_ptrs_aligned mask_def)
-   apply (clarsimp simp: Silc_cte_def Silc_cte'_def Silc_capsH_def cnode_offs_min2 objBitsKO_def
-                         empty_cte_def cnode_offs_max2 cnode_offs_aligned2 add.commute s0_ptrs_aligned)
-   apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct'])
-   apply (simp add: Silc_cte_def Silc_cte'_def Silc_capsH_def empty_cte_def objBitsKO_def
-                    cnode_offs_min2 cnode_offs_max2 cnode_offs_aligned2 add.commute s0_ptrs_aligned)
-  apply ((clarsimp simp: valid_cap'_def capAligned_def word_bits_def s0_ptrs_aligned bit_simps
-                         Low_asid_def High_asid_def Silc_asid_def asid_bits_defs
-                         vmsz_aligned_def frame_at'_def typ_at'_def ko_wp_at'_def
-                         wellformed_mapdata'_def asid_wf_def mask_def,
-          drule less_0x200_exists_ucast, clarsimp, clarsimp simp: objBitsKO_def,
-          rule conjI, clarsimp simp: s0_ptr_defs is_aligned_mask bit_simps mask_def, word_bitwise,
-          rule pspace_distinctD''[OF _ s0H_pspace_distinct'],
-          simp add: objBitsKO_def)+)[3]
-  apply ((simp add: valid_cap'_def capAligned_def word_bits_def Low_asid_def High_asid_def
-                    asid_bits_defs asid_wf_def s0_ptrs_aligned wellformed_mapdata'_def
-                    bit_simps mask_def archObjSize_def pt_offs_min objBitsKO_def
-                    page_table_at'_def typ_at'_def ko_wp_at'_def kh0H_obj_def, safe,
-          rule pspace_distinctD''[OF _ s0H_pspace_distinct'],
-          simp add: pt_offs_min kh0H_obj_def archObjSize_def bit_simps objBitsKO_def,
-          clarsimp simp: is_aligned_mask mask_def s0_ptr_defs, word_bitwise,
-          fastforce simp: pt_offs_max add.commute)+)[4]
-  apply ((simp add: valid_cap'_def capAligned_def word_bits_def Low_asid_def High_asid_def
-                    asid_bits_defs asid_wf_def s0_ptrs_aligned bit_simps wellformed_mapdata'_def
-                    mask_def page_table_at'_def typ_at'_def ko_wp_at'_def kh0H_obj_def
-                    objBitsKO_def archObjSize_def pt_offs_min,
-          intro conjI, clarsimp simp: is_aligned_mask mask_def s0_ptr_defs,
-          rule pspace_distinctD''[OF _ s0H_pspace_distinct'],
-          simp add: kh0H_obj_def archObjSize_def bit_simps objBitsKO_def)+)[2]
+                    supply option.case_cong[cong] if_cong[cong]
+                    apply (simp | simp add: valid_cap'_def s0H_internal_def capAligned_def word_bits_def
+                                            objBits_def s0_ptrs_aligned obj_at'_def,
+                                  intro conjI, simp add: objBitsKO_def s0_ptrs_aligned, simp add: objBitsKO_def,
+                                  simp add: objBitsKO_def s0_ptrs_aligned mask_def,
+                                  rule pspace_distinctD'[OF _ s0H_pspace_distinct', simplified s0H_internal_def],
+                                  simp)+
+                 apply (simp add: valid_cap'_def capAligned_def word_bits_def objBits_def s0_ptrs_aligned obj_at'_def)
+                 apply (intro conjI)
+                    apply (simp add: objBitsKO_def s0_ptrs_aligned)
+                   apply (simp add: objBitsKO_def)
+                  apply (simp add: objBitsKO_def s0_ptrs_aligned mask_def)
+                 apply (clarsimp simp: Low_cte_def Low_cte'_def Low_capsH_def cnode_offs_min2 objBitsKO_def
+                                       cnode_offs_max2 cnode_offs_aligned2 add.commute s0_ptrs_aligned empty_cte_def)
+                 apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct'])
+                 apply (simp add: Low_cte_def Low_cte'_def Low_capsH_def empty_cte_def objBitsKO_def
+                                  cnode_offs_min2 cnode_offs_max2 cnode_offs_aligned2 add.commute s0_ptrs_aligned)
+                apply (simp add: valid_cap'_def capAligned_def word_bits_def objBits_def s0_ptrs_aligned obj_at'_def)
+                apply (intro conjI)
+                   apply (simp add: objBitsKO_def s0_ptrs_aligned)
+                  apply (simp add: objBitsKO_def)
+                 apply (simp add: objBitsKO_def s0_ptrs_aligned mask_def)
+                apply (clarsimp simp: High_cte_def High_cte'_def High_capsH_def cnode_offs_min2 cnode_offs_max2
+                                      cnode_offs_aligned2 add.commute s0_ptrs_aligned objBitsKO_def empty_cte_def)
+                apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct'])
+                apply (simp add: High_cte_def High_cte'_def High_capsH_def empty_cte_def objBitsKO_def
+                                 cnode_offs_min2 cnode_offs_max2 cnode_offs_aligned2 add.commute s0_ptrs_aligned)
+               apply (simp add: valid_cap'_def capAligned_def word_bits_def objBits_def s0_ptrs_aligned obj_at'_def)
+               apply (intro conjI)
+                  apply (simp add: objBitsKO_def s0_ptrs_aligned)
+                 apply (simp add: objBitsKO_def)
+                apply (simp add: objBitsKO_def s0_ptrs_aligned mask_def)
+               apply (clarsimp simp: Silc_cte_def Silc_cte'_def Silc_capsH_def cnode_offs_min2 objBitsKO_def
+                                     empty_cte_def cnode_offs_max2 cnode_offs_aligned2 add.commute s0_ptrs_aligned)
+               apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct'])
+               apply (simp add: Silc_cte_def Silc_cte'_def Silc_capsH_def empty_cte_def objBitsKO_def
+                                cnode_offs_min2 cnode_offs_max2 cnode_offs_aligned2 add.commute s0_ptrs_aligned)
+                              (* FIXME AARCH64 IF: boilerplate *)
+              apply (clarsimp simp: valid_cap'_def)
+              apply (intro conjI)
+                 apply (auto simp: valid_cap'_def capAligned_def word_bits_def s0_ptrs_aligned
+                                         Low_asid_def High_asid_def Silc_asid_def asid_bits_defs bit_simps
+                                         vmsz_aligned_def frame_at'_def typ_at'_def ko_wp_at'_def
+                                        s0_ptr_defs is_aligned_def
+                                         wellformed_mapdata'_def asid_wf_def mask_def)[3]
+              apply (clarsimp simp: frame_at'_def typ_at'_def ko_wp_at'_def)
+              apply (drule less_pageBits_exists_ucast)
+              apply (clarsimp simp: pageBits_def objBitsKO_def s0_ptrs_aligned)
+              apply (rule conjI)
+               apply (rule is_aligned_add)
+                apply (clarsimp simp: is_aligned_mask mask_def s0_ptr_defs)
+               apply (rule is_aligned_shift)
+              apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct'])
+              apply (simp add: pt_offs_min kh0H_obj_def archObjSize_def bit_simps objBitsKO_def)
+
+             apply (clarsimp simp: valid_cap'_def)
+             apply (intro conjI)
+                apply (auto simp: valid_cap'_def capAligned_def word_bits_def s0_ptrs_aligned
+                                  Low_asid_def High_asid_def Silc_asid_def asid_bits_defs bit_simps
+                                  vmsz_aligned_def frame_at'_def typ_at'_def ko_wp_at'_def
+                                  s0_ptr_defs is_aligned_def
+                                  wellformed_mapdata'_def asid_wf_def mask_def)[3]
+             apply (clarsimp simp: frame_at'_def typ_at'_def ko_wp_at'_def)
+             apply (drule less_pageBits_exists_ucast)
+             apply (clarsimp simp: pageBits_def objBitsKO_def s0_ptrs_aligned)
+             apply (rule conjI)
+              apply (rule is_aligned_add)
+               apply (clarsimp simp: is_aligned_mask mask_def s0_ptr_defs)
+              apply (rule is_aligned_shift)
+             apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct'])
+             apply (simp add: pt_offs_min kh0H_obj_def archObjSize_def bit_simps objBitsKO_def)
+
+            apply (clarsimp simp: valid_cap'_def)
+            apply (intro conjI)
+               apply (auto simp: valid_cap'_def capAligned_def word_bits_def s0_ptrs_aligned
+                                 Low_asid_def High_asid_def Silc_asid_def asid_bits_defs bit_simps
+                                 vmsz_aligned_def frame_at'_def typ_at'_def ko_wp_at'_def
+                                 s0_ptr_defs is_aligned_def
+                                 wellformed_mapdata'_def asid_wf_def mask_def)[3]
+            apply (clarsimp simp: frame_at'_def typ_at'_def ko_wp_at'_def)
+            apply (drule less_pageBits_exists_ucast)
+            apply (clarsimp simp: pageBits_def objBitsKO_def s0_ptrs_aligned)
+            apply (rule conjI)
+             apply (rule is_aligned_add)
+              apply (clarsimp simp: is_aligned_mask mask_def s0_ptr_defs)
+             apply (rule is_aligned_shift)
+            apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct'])
+            apply (simp add: pt_offs_min kh0H_obj_def archObjSize_def bit_simps objBitsKO_def)
+
+           apply ((clarsimp simp add: valid_cap'_def capAligned_def word_bits_def Low_asid_def High_asid_def
+                             asid_bits_defs asid_wf_def s0_ptrs_aligned wellformed_mapdata'_def
+                             bit_simps mask_def archObjSize_def pt_offs_min objBitsKO_def
+                             page_table_at'_def typ_at'_def ko_wp_at'_def kh0H_obj_def
+                      dest!: less_eq_0x1FF_exists_ucast, safe,
+                   rule pspace_distinctD''[OF _ s0H_pspace_distinct'],
+                   simp add: pt_offs_min kh0H_obj_def archObjSize_def bit_simps objBitsKO_def,
+                   clarsimp simp: is_aligned_mask mask_def s0_ptr_defs, word_bitwise,
+                   fastforce simp: pt_offs_max add.commute)+)[4]
+
+         apply (clarsimp simp add: valid_cap'_def capAligned_def word_bits_def Low_asid_def High_asid_def
+                           asid_bits_defs asid_wf_def s0_ptrs_aligned wellformed_mapdata'_def
+                           mask_def archObjSize_def pt_offs_min objBitsKO_def pte_bits_def word_size_bits_def
+                           page_table_at'_def typ_at'_def ko_wp_at'_def kh0H_obj_def, safe)
+           apply (rule is_aligned_weaken, rule s0_ptrs_aligned, simp add: bit_simps, simp add: bit_simps)
+         apply ((clarsimp simp: valid_cap'_def capAligned_def word_bits_def Low_asid_def High_asid_def
+                                asid_bits_defs asid_wf_def s0_ptrs_aligned wellformed_mapdata'_def
+                                mask_def archObjSize_def pt_offs_min objBitsKO_def pte_bits_def word_size_bits_def
+                                page_table_at'_def typ_at'_def ko_wp_at'_def kh0H_obj_def
+                         dest!: less_VSRootBits_exists_ucast, safe))
+           apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct'])
+           apply (simp add: pt_offs_min kh0H_obj_def archObjSize_def bit_simps objBitsKO_def)
+          apply (rule is_aligned_add)
+           apply (clarsimp simp: is_aligned_mask mask_def s0_ptr_defs)
+          apply (rule is_aligned_shift)
+         apply (simp add: add_mask_fold pt_offs_max)
+
+        apply (clarsimp simp: valid_cap'_def capAligned_def word_bits_def Low_asid_def High_asid_def
+                               asid_bits_defs asid_wf_def s0_ptrs_aligned wellformed_mapdata'_def
+                               mask_def archObjSize_def pt_offs_min objBitsKO_def pte_bits_def word_size_bits_def
+                               page_table_at'_def typ_at'_def ko_wp_at'_def kh0H_obj_def, safe)
+          apply (rule is_aligned_weaken, rule s0_ptrs_aligned, simp add: bit_simps, simp add: bit_simps)
+        apply ((clarsimp simp: valid_cap'_def capAligned_def word_bits_def Low_asid_def High_asid_def
+                               asid_bits_defs asid_wf_def s0_ptrs_aligned wellformed_mapdata'_def
+                               mask_def archObjSize_def pt_offs_min objBitsKO_def pte_bits_def word_size_bits_def
+                               page_table_at'_def typ_at'_def ko_wp_at'_def kh0H_obj_def
+                        dest!: less_VSRootBits_exists_ucast, safe))
+          apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct'])
+          apply (simp add: pt_offs_min kh0H_obj_def archObjSize_def bit_simps objBitsKO_def)
+         apply (rule is_aligned_add)
+          apply (clarsimp simp: is_aligned_mask mask_def s0_ptr_defs)
+         apply (rule is_aligned_shift)
+        apply (simp add: add_mask_fold pt_offs_max)
+
+       apply ((simp add: valid_cap'_def capAligned_def word_bits_def Low_asid_def High_asid_def
+                         asid_bits_defs asid_wf_def s0_ptrs_aligned bit_simps wellformed_mapdata'_def
+                         mask_def page_table_at'_def typ_at'_def ko_wp_at'_def kh0H_obj_def
+                         objBitsKO_def archObjSize_def pt_offs_min,
+               intro conjI, clarsimp simp: is_aligned_mask mask_def s0_ptr_defs,
+               rule pspace_distinctD''[OF _ s0H_pspace_distinct'],
+               simp add: kh0H_obj_def archObjSize_def bit_simps objBitsKO_def)+)[2]
   by (simp add: valid_cap'_def s0H_internal_def capAligned_def word_bits_def objBits_def obj_at'_def,
       intro conjI, simp add: objBitsKO_def s0_ptrs_aligned, simp add: objBitsKO_def,
       simp add: objBitsKO_def s0_ptrs_aligned mask_def,
@@ -2461,9 +2822,10 @@ lemma s0H_valid_objs':
                                      default_priority_def tcb_cte_cases_def)
               defer 2
               apply (auto simp: is_aligned_def addrFromPPtr_def ptrFromPAddr_def pptrBaseOffset_def
-                                valid_obj'_def s0_ptr_defs kh0H_obj_def valid_arch_obj'_def)[5]
+                                valid_obj'_def s0_ptr_defs kh0H_obj_def valid_arch_obj'_def bit_simps
+                                kh0H_all_obj_def canonical_address_def canonical_address_of_def paddrBase_def)[5]
          apply (auto simp: valid_obj'_def valid_cte'_def empty_cte_def irq_cte_def
-                           valid_arch_obj'_def
+                           valid_arch_obj'_def kh0H_all_obj_def
                            Low_cte_def Low_cte'_def Low_capsH_def
                            High_cte_def High_cte'_def High_capsH_def
                            Silc_cte_def Silc_cte'_def Silc_capsH_def)
@@ -2653,28 +3015,28 @@ lemma map_to_ctes_kh0H_simps'[simp]:
   "map_to_ctes kh0H (Low_cnode_ptr + 0x20) = Some (CTE (ThreadCap Low_tcb_ptr) Null_mdb)"
   "map_to_ctes kh0H (Low_cnode_ptr + 0x40) = Some (CTE (CNodeCap Low_cnode_ptr 10 2 10)
                                                        (MDB 0 Low_tcb_ptr False False))"
-  "map_to_ctes kh0H (Low_cnode_ptr + 0x60) = Some (CTE (ArchObjectCap (PageTableCap Low_pd_ptr (Some (ucast Low_asid, 0))))
+  "map_to_ctes kh0H (Low_cnode_ptr + 0x60) = Some (CTE (ArchObjectCap (PageTableCap Low_pd_ptr VSRootPT_T (Some (ucast Low_asid, 0))))
                                                        (MDB 0 (Low_tcb_ptr + 0x20) False False))"
   "map_to_ctes kh0H (Low_cnode_ptr + 0x80) = Some (CTE (ArchObjectCap (ASIDPoolCap Low_pool_ptr (ucast Low_asid))) Null_mdb)"
-  "map_to_ctes kh0H (Low_cnode_ptr + 0xA0) = Some (CTE (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadWrite RISCVLargePage
+  "map_to_ctes kh0H (Low_cnode_ptr + 0xA0) = Some (CTE (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadWrite max_page_size
                                                                                 False (Some (ucast Low_asid, 0))))
                                                        (MDB 0 (Silc_cnode_ptr + 0xA0) False False))"
-  "map_to_ctes kh0H (Low_cnode_ptr + 0xC0) = Some (CTE (ArchObjectCap (PageTableCap Low_pt_ptr (Some (ucast Low_asid, 0)))) Null_mdb)"
+  "map_to_ctes kh0H (Low_cnode_ptr + 0xC0) = Some (CTE (ArchObjectCap (PageTableCap Low_pt_ptr NormalPT_T (Some (ucast Low_asid, 0)))) Null_mdb)"
   "map_to_ctes kh0H (Low_cnode_ptr + 0x27C0) = Some (CTE (NotificationCap ntfn_ptr 0 True False)
                                                          (MDB (Silc_cnode_ptr + 0x27C0) 0 False False))"
   "map_to_ctes kh0H (High_cnode_ptr + 0x20) = Some (CTE (ThreadCap High_tcb_ptr) Null_mdb)"
   "map_to_ctes kh0H (High_cnode_ptr + 0x40) = Some (CTE (CNodeCap High_cnode_ptr 10 2 10) (MDB 0 High_tcb_ptr False False))"
-  "map_to_ctes kh0H (High_cnode_ptr + 0x60) = Some (CTE (ArchObjectCap (PageTableCap High_pd_ptr (Some (ucast High_asid, 0))))
+  "map_to_ctes kh0H (High_cnode_ptr + 0x60) = Some (CTE (ArchObjectCap (PageTableCap High_pd_ptr VSRootPT_T (Some (ucast High_asid, 0))))
                                                         (MDB 0 (High_tcb_ptr + 0x20) False False))"
   "map_to_ctes kh0H (High_cnode_ptr + 0x80) = Some (CTE (ArchObjectCap (ASIDPoolCap High_pool_ptr (ucast High_asid))) Null_mdb)"
-  "map_to_ctes kh0H (High_cnode_ptr + 0xA0) = Some (CTE (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadOnly RISCVLargePage
+  "map_to_ctes kh0H (High_cnode_ptr + 0xA0) = Some (CTE (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadOnly max_page_size
                                                                                  False (Some (ucast High_asid, 0))))
                                                         (MDB (Silc_cnode_ptr + 0xA0) 0 False False))"
-  "map_to_ctes kh0H (High_cnode_ptr + 0xC0) = Some (CTE (ArchObjectCap (PageTableCap High_pt_ptr (Some (ucast High_asid, 0)))) Null_mdb)"
+  "map_to_ctes kh0H (High_cnode_ptr + 0xC0) = Some (CTE (ArchObjectCap (PageTableCap High_pt_ptr NormalPT_T (Some (ucast High_asid, 0)))) Null_mdb)"
   "map_to_ctes kh0H (High_cnode_ptr + 0x27C0) = Some (CTE (NotificationCap ntfn_ptr 0 False True)
                                                           (MDB 0 (Silc_cnode_ptr + 0x27C0) False False))"
   "map_to_ctes kh0H (Silc_cnode_ptr + 0x40) = Some (CTE (CNodeCap Silc_cnode_ptr 10 2 10) Null_mdb)"
-  "map_to_ctes kh0H (Silc_cnode_ptr + 0xA0) = Some (CTE (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadOnly RISCVLargePage
+  "map_to_ctes kh0H (Silc_cnode_ptr + 0xA0) = Some (CTE (ArchObjectCap (FrameCap shared_page_ptr_virt VMReadOnly max_page_size
                                                                                  False (Some (ucast Silc_asid, 0))))
                                                         (MDB (Low_cnode_ptr + 0xA0) (High_cnode_ptr + 0xA0) False False))"
   "map_to_ctes kh0H (Silc_cnode_ptr + 0x27C0) = Some (CTE (NotificationCap ntfn_ptr 0 True False)
@@ -2740,7 +3102,7 @@ lemma mdb_next_s0H:
    apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps
                          ucast_shiftr_13E ucast_shiftr_5 s0_ptrs_aligned
                   split: if_split_asm)
-  apply (clarsimp simp: next_unfold' map_to_ctes_kh0H_dom)
+  apply (clarsimp simp: next_unfold')
   apply (elim disjE, simp_all add: kh0H_all_obj_def')
   done
 
@@ -2795,7 +3157,7 @@ lemma mdb_next_trancl_s0H:
    apply (subst (asm) mdb_next_s0H)
     apply (clarsimp simp: s0_ptr_defs)
    apply (clarsimp simp: s0_ptr_defs del: disjCI)
-   apply ((erule_tac P="y = _ \<and> _" in disjE | clarsimp)+)[1]
+  subgoal for y by ((erule_tac P="y = _ \<and> _" in disjE | clarsimp)+)[1]
   apply (elim disjE)
            apply (rule r_into_trancl, simp add: mdb_next_s0H)
           apply (rule r_into_trancl, simp add: mdb_next_s0H)
@@ -2846,8 +3208,8 @@ lemma sameRegionAs_s0H:
           apply (clarsimp simp: to_bl_use_of_bl the_nat_to_bl_simps kh0H_all_obj_def' ucast_shiftr_2
                          split: if_split_asm)
          apply ((frule_tac x=p' in map_to_ctes_kh0H_SomeD,
-                (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps)[1],
-                ((clarsimp simp: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps to_bl_use_of_bl
+                (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps)[1],
+                ((clarsimp simp: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps to_bl_use_of_bl
                                  the_nat_to_bl_simps kh0H_all_obj_def' ucast_shiftr_2 ucast_shiftr_3
                           split: if_split_asm)+)[3])+)[5]
     apply (clarsimp simp: kh0H_all_obj_def' split: if_split_asm)
@@ -2862,7 +3224,7 @@ lemma sameRegionAs_s0H:
       apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_13E
                      split: if_split_asm)
      apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-     apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+     apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                                split: if_split_asm)[1]
        apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps split: if_split_asm)
        apply (drule(2) ucast_shiftr_5; clarsimp)
@@ -2874,7 +3236,7 @@ lemma sameRegionAs_s0H:
      apply (drule(2) ucast_shiftr_5; clarsimp)
      apply (drule(2) ucast_shiftr_5; clarsimp)
     apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-    apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+    apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                               split: if_split_asm)[1]
       apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps split: if_split_asm)
       apply (drule(2) ucast_shiftr_2; clarsimp)
@@ -2892,7 +3254,7 @@ lemma sameRegionAs_s0H:
          apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_13E
                         split: if_split_asm)
         apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-        apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+        apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                                   split: if_split_asm)[1]
           apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3
                          split: if_split_asm)
@@ -2902,7 +3264,7 @@ lemma sameRegionAs_s0H:
          apply (drule(2) ucast_shiftr_6; clarsimp)
         apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps split: if_split_asm)
        apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-       apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+       apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                                  split: if_split_asm)[1]
          apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3
                         split: if_split_asm)
@@ -2915,7 +3277,7 @@ lemma sameRegionAs_s0H:
        apply (drule(2) ucast_shiftr_5; clarsimp)
        apply (drule(2) ucast_shiftr_5; clarsimp)
       apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-      apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+      apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                                 split: if_split_asm)[1]
         apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3
                        split: if_split_asm)
@@ -2924,7 +3286,7 @@ lemma sameRegionAs_s0H:
        apply (drule(2) ucast_shiftr_4; clarsimp)
       apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps split: if_split_asm)
      apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-     apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+     apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                                split: if_split_asm)[1]
         apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3
                        split: if_split_asm)
@@ -2934,7 +3296,7 @@ lemma sameRegionAs_s0H:
       apply (drule(2) ucast_shiftr_3; clarsimp)
      apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps split: if_split_asm)
     apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-    apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+    apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                               split: if_split_asm)[1]
        apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3
                       split: if_split_asm)
@@ -2945,7 +3307,7 @@ lemma sameRegionAs_s0H:
      apply (drule(2) ucast_shiftr_2; clarsimp)
     apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps split: if_split_asm)
    apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-   apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+   apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                              split: if_split_asm)[1]
      apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3
                     split: if_split_asm)
@@ -2966,7 +3328,7 @@ lemma sameRegionAs_s0H:
         apply (drule(2) ucast_shiftr_13E; clarsimp)
         apply (drule(2) ucast_shiftr_13E; clarsimp)
        apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-       apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+       apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                                  split: if_split_asm)[1]
          apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3
                         split: if_split_asm)
@@ -2975,7 +3337,7 @@ lemma sameRegionAs_s0H:
        apply (drule(2) ucast_shiftr_6; clarsimp)
        apply (drule(2) ucast_shiftr_6; clarsimp)
       apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-      apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+      apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                                 split: if_split_asm)[1]
         apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3
                        split: if_split_asm)
@@ -2990,7 +3352,7 @@ lemma sameRegionAs_s0H:
       apply (drule(2) ucast_shiftr_5; clarsimp)
       apply (drule(2) ucast_shiftr_5; clarsimp)
      apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-     apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+     apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                                split: if_split_asm)[1]
        apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3
                       split: if_split_asm)
@@ -2999,7 +3361,7 @@ lemma sameRegionAs_s0H:
      apply (drule(2) ucast_shiftr_4; clarsimp)
      apply (drule(2) ucast_shiftr_4; clarsimp)
     apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-    apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+    apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                               split: if_split_asm)[1]
        apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3
                       split: if_split_asm)
@@ -3009,7 +3371,7 @@ lemma sameRegionAs_s0H:
     apply (drule(2) ucast_shiftr_3; clarsimp)
     apply (drule(2) ucast_shiftr_3; clarsimp)
    apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-   apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+   apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                              split: if_split_asm)[1]
       apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3
                      split: if_split_asm)
@@ -3020,7 +3382,7 @@ lemma sameRegionAs_s0H:
    apply (drule(2) ucast_shiftr_2; clarsimp)
    apply (drule(2) ucast_shiftr_2; clarsimp)
   apply (frule_tac x=p' in map_to_ctes_kh0H_SomeD)
-  apply (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def isCap_simps
+  apply (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def isCap_simps
                             split: if_split_asm)[1]
     apply (clarsimp simp: kh0H_all_obj_def' to_bl_use_of_bl the_nat_to_bl_simps ucast_shiftr_3
                    split: if_split_asm)
@@ -3037,6 +3399,13 @@ lemma mdb_prevI:
 lemma mdb_nextI:
   "m p = Some c \<Longrightarrow> m \<turnstile> p \<leadsto> mdbNext (cteMDBNode c)"
   by (simp add: mdb_next_unfold)
+
+lemma above_pptr_base_canonical:
+  "\<lbrakk> pptr_base \<le> p; p \<le> pptrTop - 1 \<rbrakk> \<Longrightarrow> canonical_address p"
+  apply (simp add: canonical_address_range pptr_base_def pptrBase_def NOT_mask canonical_bit_def pptrTop_def mask_def)
+  apply (erule order.trans)
+  apply clarsimp
+  done
 
 lemma s0H_valid_pspace':
   notes pteBits_def[simp] objBits_defs[simp]
@@ -3055,16 +3424,15 @@ lemma s0H_valid_pspace':
                                  split: if_splits)
      apply (clarsimp simp: pspace_canonical'_def)
      apply (drule kh0H_SomeD')
+    apply (rule above_pptr_base_canonical)
      apply (fastforce elim: dual_order.trans
                      intro: above_pptr_base_canonical
-                      simp: irq_node_offs_range_def cnode_offs_range_def
+                      simp: irq_node_offs_range_def cnode_offs_range_def pptrTop_def
                             pt_offs_range_def page_offs_range_def s0_ptr_defs)
-    apply (clarsimp simp: pspace_in_kernel_mappings'_def)
-    apply (clarsimp simp: kernel_mappings_def)
-    apply (drule kh0H_SomeD')
-    apply (fastforce elim: dual_order.trans
-                     simp: s0_ptr_defs irq_node_offs_range_def cnode_offs_range_def
-                           pt_offs_range_def page_offs_range_def kernel_mappings_def)
+    apply (elim disjE; clarsimp simp: irq_node_offs_range_def2 cnode_offs_range_def pptrTop_def
+                                      pt_offs_range_def page_offs_range_def s0_ptr_defs bit_simps mask_def
+                               split: if_splits)
+             apply (fastforce elim: order.trans)+
    apply (clarsimp simp: no_0_obj'_def)
    apply (rule ccontr, clarsimp)
    apply (drule kh0H_SomeD)
@@ -3114,6 +3482,7 @@ lemma s0H_valid_pspace':
                     apply (rule r_r_into_trancl[OF next_fold next_fold], simp+)[1]
                    apply (erule r_into_trancl[OF next_fold], simp)+
             apply (clarsimp simp: valid_badges_def)
+            apply (rule conjI)
             apply (frule_tac x=p in map_to_ctes_kh0H_SomeD)
             apply (elim disjE, (clarsimp simp: Low_cte_cte_def High_cte_cte_def Silc_cte_cte_def
                                                kh0H_all_obj_def isCap_simps
@@ -3138,6 +3507,12 @@ lemma s0H_valid_pspace':
             apply (elim disjE, (clarsimp simp: High_cte_cte_def Low_cte_cte_def
                                                Silc_cte_cte_def kh0H_all_obj_def
                                         split: if_split_asm)+)[1]
+             apply (case_tac "p' = 0")
+              apply clarsimp
+              apply (frule_tac x=0 in map_to_ctes_kh0H_SomeD)
+              apply (clarsimp simp: s0_ptr_defs irq_node_offs_range_def cnode_offs_range_def)
+             apply (clarsimp simp: mdb_next_s0H)
+             apply (auto simp: isArchSGISignalCap_def)[1]
            apply (clarsimp simp: caps_contained'_def)
            apply (drule_tac x=p in map_to_ctes_kh0H_SomeD)
            apply (elim disjE, simp_all)[1]
@@ -3145,7 +3520,7 @@ lemma s0H_valid_pspace':
             apply (clarsimp simp: High_cte_cte_def kh0H_all_obj_def split: if_split_asm)
            apply (clarsimp simp: Low_cte_cte_def kh0H_all_obj_def split: if_split_asm)
           apply (clarsimp simp: mdb_chunked_def)
-          apply (frule(3) sameRegionAs_s0H)
+          apply (frule sameRegionAs_s0H, simp, simp, simp)
           apply (clarsimp simp: conj_disj_distribL)
           apply (prop_tac "p \<noteq> 0 \<and> p' \<noteq> 0")
            apply (elim disjE; clarsimp simp: s0_ptr_defs)
@@ -3158,7 +3533,7 @@ lemma s0H_valid_pspace':
                     apply ((clarsimp simp: is_chunk_def,
                             drule mdb_next_rtrancl_not_0_s0H, fastforce simp: s0_ptr_defs,
                             clarsimp simp: mdb_next_trancl_s0H,
-                            (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def
+                            (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def
                                                        isCap_simps kh0H_all_obj_def'
                                        , (fastforce simp: s0_ptr_defs)+)[1])+)[10]
           apply (thin_tac "_ \<or> _")
@@ -3167,7 +3542,7 @@ lemma s0H_valid_pspace':
                    apply ((clarsimp simp: is_chunk_def,
                            drule mdb_next_rtrancl_not_0_s0H, fastforce simp: s0_ptr_defs,
                            clarsimp simp: mdb_next_trancl_s0H,
-                           (elim disjE, simp_all add: sameRegionAs_def RISCV64_H.sameRegionAs_def
+                           (elim disjE, simp_all add: sameRegionAs_def AARCH64_H.sameRegionAs_def
                                                       isCap_simps kh0H_all_obj_def'
                                       , (fastforce simp: s0_ptr_defs)+)[1])+)[10]
          apply (clarsimp simp: untyped_mdb'_def)
@@ -3237,20 +3612,17 @@ lemma valid_arch_state_s0H:
   apply (intro conjI)
     apply (clarsimp simp: valid_asid_table'_def s0H_internal_def arch_state0H_def asid_bits_defs
                           asid_high_bits_of_def Low_asid_def High_asid_def mask_def s0_ptr_defs)
-   apply (clarsimp simp: valid_global_pts'_def is_aligned_riscv_global_pt_ptr[simplified bit_simps]
-                         arch_state0H_def page_table_at'_def typ_at'_def ko_wp_at'_def
-                         bit_simps global_ptH_def pt_offs_min)
-   apply (subst objBitsKO_def)
-   apply (clarsimp simp: archObjSize_def bit_simps)
-   apply (intro conjI)
-     apply (fastforce intro: pspace_distinctD'[OF _ s0H_pspace_distinct']
-                       simp: global_ptH_def pt_offs_min)
-    apply (clarsimp simp: is_aligned_mask mask_def s0_ptr_defs)
-    apply word_bitwise
-   apply (clarsimp simp: s0_ptr_defs)
-   apply word_bitwise
-  apply (clarsimp simp: arch_state0H_def)
+     apply (clarsimp simp: arch_state0H_def)
+    apply (clarsimp simp: arch_state0H_def)
+   apply (clarsimp simp: arch_state0H_def max_armKSGICVCPUNumListRegs_def)
+  apply (clarsimp simp: arch_state0H_def s0_ptr_defs)
+  apply (clarsimp simp: canonical_address_def canonical_address_of_def addrFromKPPtr_def
+                        kernelELFBaseOffset_def kernelELFBase_def kernelELFPAddrBase_def)
   done
+
+lemma timer_irq_not_outside_range[simp]:
+  "\<not> maxIRQ < timer_irq"
+  by (simp add: timer_irq_def)
 
 lemma s0H_invs:
   assumes "1 \<le> maxDomain"
@@ -3284,14 +3656,21 @@ lemma s0H_invs:
             apply (erule notE, rule pspace_distinctD''[OF _ s0H_pspace_distinct'])
             apply (simp add: objBitsKO_def ntfnH_def)
            apply (clarsimp simp: tcb_st_refs_of'_def idle_tcbH_def)
-          apply (clarsimp simp: global_ptH_def)
-         apply (clarsimp simp: Low_ptH_def)
-        apply (clarsimp simp: High_ptH_def)
-       apply (clarsimp simp: Low_pdH_def)
-      apply (clarsimp simp: High_pdH_def)
+          apply (clarsimp simp: global_ptH_def split: if_splits)
+         apply (clarsimp simp: Low_ptH_def split: if_splits)
+        apply (clarsimp simp: High_ptH_def split: if_splits)
+       apply (clarsimp simp: Low_pdH_def split: if_splits)
+      apply (clarsimp simp: High_pdH_def split: if_splits)
      apply (clarsimp simp: Low_cte_def Low_cte'_def split: if_split_asm)
     apply (clarsimp simp: High_cte_def High_cte'_def split: if_split_asm)
    apply (clarsimp simp: Silc_cte_def Silc_cte'_def split: if_split_asm)
+  apply (rule conjI)
+   apply (subgoal_tac "state_hyp_refs_of' s0H_internal = (\<lambda>p. {})")
+    apply (clarsimp simp: sym_refs_def)
+   apply (rule ext, rule equals0I)
+    apply (clarsimp simp: state_hyp_refs_of'_def hyp_refs_of'_def tcb_vcpu_refs'_def
+                   split: option.splits if_splits dest!: kh0H_SomeD)
+   apply (elim disjE; clarsimp simp: tcb_vcpu_refs'_def kh0H_all_obj_def split: if_splits)
   apply (rule conjI)
    apply (clarsimp simp: if_live_then_nonz_cap'_def ko_wp_at'_def)
    apply (drule kh0H_SomeD)
@@ -3305,7 +3684,7 @@ lemma s0H_invs:
            apply (clarsimp simp: ex_nonz_cap_to'_def cte_wp_at_ctes_of)
            apply (rule_tac x="High_cnode_ptr + 0x20" in exI)
            apply (clarsimp simp: kh0H_all_obj_def')
-          apply (clarsimp split: if_split_asm simp: live'_def hyp_live'_def)+
+          apply (clarsimp split: if_split_asm simp: live'_def hyp_live'_def arch_live'_def)+
   apply (rule conjI)
    apply (clarsimp simp: if_unsafe_then_cap'_def ex_cte_cap_wp_to'_def cte_wp_at_ctes_of)
    apply (frule map_to_ctes_kh0H_SomeD)
@@ -3429,7 +3808,7 @@ lemma s0H_invs:
   apply (rule conjI)
    apply (clarsimp simp: valid_machine_state'_def s0H_internal_def machine_state0_def)
   apply (rule conjI)
-   apply (clarsimp simp: irqs_masked'_def s0H_internal_def maxIRQ_def timer_irq_def irqInvalid_def)
+   apply (clarsimp simp: irqs_masked'_def s0H_internal_def)
   apply (rule conjI)
    apply (clarsimp simp: sym_heap_def opt_map_def projectKOs split: option.splits)
    using kh0H_dom_tcb
@@ -3439,7 +3818,7 @@ lemma s0H_invs:
    using kh0H_dom_tcb
    apply (fastforce simp: kh0H_obj_def)
   apply (rule conjI)
-   apply (clarsimp simp: valid_bitmaps_def valid_bitmapQ_def bitmapQ_def s0H_internal_def
+   apply (clarsimp simp: valid_bitmaps_def valid_bitmapQ_def bitmapQ_def s0H_internal_def emptyHeadEndPtrs_def
                          tcbQueueEmpty_def bitmapQ_no_L1_orphans_def bitmapQ_no_L2_orphans_def)
   apply (rule conjI)
    apply (clarsimp simp: ct_not_inQ_def obj_at'_def objBitsKO_def
@@ -3453,12 +3832,34 @@ lemma s0H_invs:
    apply (simp add: objBitsKO_def)
   apply (rule conjI)
    apply (clarsimp simp: kdr_pspace_domain_valid) (* use axiomatization for now *)
-  apply (clarsimp simp: s0H_internal_def cteCaps_of_def untyped_ranges_zero_inv_def
-                        dschDomain_def dschLength_def)
-  apply (clarsimp simp: newKernelState_def newKSDomSched)
+    apply (clarsimp simp: s0H_internal_def cteCaps_of_def untyped_ranges_zero_inv_def
+                          dschDomain_def dschLength_def valid_dom_schedule'_def maxDomainDuration_def mask_def)
   apply (clarsimp simp: cur_tcb'_def obj_at'_def  s0H_internal_def objBitsKO_def s0_ptrs_aligned)
   apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct', simplified s0H_internal_def])
   apply (simp add: objBitsKO_def)
+  done
+
+lemma ptTranslationBits_NormalPT[simp]:
+  "ptTranslationBits NormalPT_T = 9"
+  by (simp add: bit_simps)
+
+lemma less_0x200_exists_ucast:
+  "p < 0x200 \<Longrightarrow> \<exists>p'. p = UCAST(pg_index_len \<rightarrow> 64) p'"
+  apply (rule_tac x="UCAST(64 \<rightarrow> pg_index_len) p" in exI)
+  apply (rule sym)
+  apply (rule ucast_ucast_le_mask)
+  apply (simp add: mask_def bit_simps)
+  apply word_bitwise
+  apply auto
+  done
+
+lemma less_0x40000_exists_ucast:
+  "\<lbrakk> p < 0x40000;  \<not> config_ARM_PA_SIZE_BITS_40 \<rbrakk> \<Longrightarrow> \<exists>p'. p = UCAST(pg_index_len \<rightarrow> 64) p'"
+  apply (rule_tac x="UCAST(64 \<rightarrow> pg_index_len) p" in exI)
+  apply (rule sym)
+  apply (rule ucast_ucast_le_mask)
+  apply (simp add: mask_def bit_simps)
+  apply word_bitwise
   done
 
 lemma kh0_pspace_dom:
@@ -3469,18 +3870,20 @@ lemma kh0_pspace_dom:
                     cnode_offs_range Silc_cnode_ptr \<union>
                     cnode_offs_range High_cnode_ptr \<union>
                     cnode_offs_range Low_cnode_ptr \<union>
-                    pt_offs_range riscv_global_pt_ptr \<union>
-                    pt_offs_range High_pd_ptr \<union>
-                    pt_offs_range Low_pd_ptr \<union>
-                    pt_offs_range High_pt_ptr \<union>
-                    pt_offs_range Low_pt_ptr"
+                    pt_offs_range VSRootPT_T arm_global_pt_ptr \<union>
+                    pt_offs_range VSRootPT_T High_pd_ptr \<union>
+                    pt_offs_range VSRootPT_T Low_pd_ptr \<union>
+                    pt_offs_range NormalPT_T High_pt_ptr \<union>
+                    pt_offs_range NormalPT_T Low_pt_ptr"
   apply (rule equalityI)
    apply (simp add: dom_def pspace_dom_def)
    apply clarsimp
-   apply (clarsimp simp: kh0_def obj_relation_cuts_def page_offs_in_range pt_offs_in_range
-                         cnode_offs_in_range irq_node_offs_in_range s0_ptrs_aligned bit_simps
-                         kh0_obj_def cte_map_def' caps_dom_length_10
-                   dest!: less_0x200_exists_ucast split: if_split_asm)
+   apply (clarsimp simp: kh0_def obj_relation_cuts_def page_offs_in_range pt_offs_in_range pageBits_def
+                         cnode_offs_in_range irq_node_offs_in_range s0_ptrs_aligned pte_bits_def word_size_bits_def
+                         kh0_obj_def cte_map_def' caps_dom_length_10 mask_def max_page_size_def
+                   dest!: less_VSRootBits_exists_ucast less_eq_0x1FF_exists_ucast
+                          less_0x40000_exists_ucast less_0x200_exists_ucast
+                  split: if_split_asm)
   apply (clarsimp simp: pspace_dom_def dom_def)
   apply (rule conjI)
    apply (rule_tac x=idle_tcb_ptr in exI)
@@ -3513,10 +3916,21 @@ lemma kh0_pspace_dom:
    apply clarsimp
    apply (rule_tac x=shared_page_ptr_virt in exI)
    apply (drule offs_range_correct)
-   apply (clarsimp simp: kh0_def kh0_obj_def image_def s0_ptr_defs cte_map_def' dom_caps bit_simps)
-   apply (rule_tac x="UCAST (9 \<rightarrow> 64) y" in exI)
-   apply clarsimp
-   apply word_bitwise
+   apply (auto simp: kh0_def kh0_obj_def image_def s0_ptr_defs cte_map_def' dom_caps bit_simps max_page_size_def)[1]
+    apply (rule_tac x="UCAST (pg_index_len \<rightarrow> 64) y" in exI)
+    apply clarsimp
+    apply (rule xtr7[rotated])
+     apply (rule ucast_leq_mask)
+     apply simp
+     apply (rule order.refl)
+    apply (clarsimp simp: bit_simps mask_def)
+    apply (rule_tac x="UCAST (pg_index_len \<rightarrow> 64) y" in exI)
+    apply clarsimp
+    apply (rule xtr7[rotated])
+     apply (rule ucast_leq_mask)
+     apply simp
+     apply (rule order.refl)
+    apply (clarsimp simp: bit_simps mask_def)
   apply (rule conjI)
    apply clarsimp
    apply (rule_tac x=Silc_cnode_ptr in exI)
@@ -3534,28 +3948,53 @@ lemma kh0_pspace_dom:
    apply (force simp: kh0_def kh0_obj_def image_def s0_ptr_defs cte_map_def' dom_caps)
   apply (rule conjI)
    apply clarsimp
-   apply (rule_tac x=riscv_global_pt_ptr in exI)
+   apply (rule_tac x=arm_global_pt_ptr in exI)
    apply (drule offs_range_correct)
-   apply (force simp: kh0_def kh0_obj_def image_def s0_ptr_defs bit_simps)
+   apply (clarsimp simp: kh0_def kh0_obj_def image_def s0_ptr_defs)
+   apply (rule exI)
+   apply (rule_tac x="UCAST(vs_index_len \<rightarrow> 64) y" in bexI)
+    apply (rule conjI, simp add: bit_simps, rule refl)
+   apply clarsimp
+   apply (rule ucast_leq_mask, simp add: bit_simps)
   apply (rule conjI)
    apply clarsimp
    apply (rule_tac x=High_pd_ptr in exI)
    apply (drule offs_range_correct)
-   apply (force simp: kh0_def kh0_obj_def image_def s0_ptr_defs bit_simps)
+   apply (clarsimp simp: kh0_def kh0_obj_def image_def s0_ptr_defs)
+   apply (rule exI)
+   apply (rule_tac x="UCAST(vs_index_len \<rightarrow> 64) y" in bexI)
+    apply (rule conjI, simp add: bit_simps, rule refl)
+   apply clarsimp
+   apply (rule ucast_leq_mask, simp add: bit_simps)
   apply (rule conjI)
    apply clarsimp
    apply (rule_tac x=Low_pd_ptr in exI)
    apply (drule offs_range_correct)
-   apply (force simp: kh0_def kh0_obj_def image_def s0_ptr_defs bit_simps)
+   apply (clarsimp simp: kh0_def kh0_obj_def image_def s0_ptr_defs)
+   apply (rule exI)
+   apply (rule_tac x="UCAST(vs_index_len \<rightarrow> 64) y" in bexI)
+    apply (rule conjI, simp add: bit_simps, rule refl)
+   apply clarsimp
+   apply (rule ucast_leq_mask, simp add: bit_simps)
   apply (rule conjI)
    apply clarsimp
    apply (rule_tac x=High_pt_ptr in exI)
    apply (drule offs_range_correct)
-   apply (force simp: kh0_def kh0_obj_def image_def s0_ptr_defs bit_simps)
+   apply (clarsimp simp: kh0_def kh0_obj_def image_def s0_ptr_defs bit_simps)
+   apply (rule exI)
+   apply (rule_tac x="UCAST(9 \<rightarrow> 64) y" in bexI)
+    apply (rule conjI, rule refl, rule refl)
+   apply clarsimp
+   apply (rule ucast_leq_mask, simp)
   apply clarsimp
   apply (rule_tac x=Low_pt_ptr in exI)
   apply (drule offs_range_correct)
-  apply (force simp: kh0_def kh0_obj_def image_def s0_ptr_defs bit_simps)
+  apply (clarsimp simp: kh0_def kh0_obj_def image_def s0_ptr_defs bit_simps)
+  apply (rule exI)
+  apply (rule_tac x="UCAST(9 \<rightarrow> 64) y" in bexI)
+  apply (rule conjI, rule refl, rule refl)
+  apply clarsimp
+  apply (rule ucast_leq_mask, simp)
   done
 
 
@@ -3592,7 +4031,7 @@ lemma to_bl_ucast_of_bl[simp]:
   done
 
 lemma is_aligned_shiftr_3[simp]:
-  "is_aligned (riscv_global_pt_ptr + (n << 3)) 3"
+  "is_aligned (arm_global_pt_ptr + (n << 3)) 3"
   "is_aligned (High_pd_ptr + (n << 3)) 3"
   "is_aligned (Low_pd_ptr + (n << 3)) 3"
   "is_aligned (High_pt_ptr + (n << 3)) 3"
@@ -3600,8 +4039,33 @@ lemma is_aligned_shiftr_3[simp]:
       apply (rule is_aligned_add[OF is_aligned_weaken[OF s0_ptrs_aligned(1), where y=3, simplified bit_simps]]; fastforce)
      apply (rule is_aligned_add[OF is_aligned_weaken[OF s0_ptrs_aligned(2), where y=3, simplified bit_simps]]; fastforce)
     apply (rule is_aligned_add[OF is_aligned_weaken[OF s0_ptrs_aligned(3), where y=3, simplified bit_simps]]; fastforce)
-   apply (rule is_aligned_add[OF is_aligned_weaken[OF s0_ptrs_aligned(4), where y=3, simplified bit_simps]]; fastforce)
-  apply (rule is_aligned_add[OF is_aligned_weaken[OF s0_ptrs_aligned(5), where y=3, simplified bit_simps]]; fastforce)
+   apply (rule is_aligned_add[OF is_aligned_weaken[OF s0_ptrs_aligned(7), where y=3, simplified bit_simps]]; fastforce)
+  apply (rule is_aligned_add[OF is_aligned_weaken[OF s0_ptrs_aligned(8), where y=3, simplified bit_simps]]; fastforce)
+  done
+
+lemma ucast_ucast_vs_index_helper[simp]:
+  "UCAST(64 \<rightarrow> vs_index_len) (UCAST(vs_index_len \<rightarrow> 64) p) = p"
+  apply (rule ucast_up_ucast_id)
+  by (simp add: is_up_def source_size_def target_size_def bit_simps)
+
+lemma less_eq_VSRootBits_exists_ucast:
+  "p \<le> 2 ^ ptTranslationBits VSRootPT_T - 1 \<Longrightarrow> \<exists>p'. p = UCAST(vs_index_len \<rightarrow> 64) p'"
+  apply (rule_tac x="UCAST(64 \<rightarrow> vs_index_len) p" in exI)
+  apply (rule sym)
+  apply (rule ucast_ucast_le_mask)
+  apply (simp add: mask_def bit_simps)
+  done
+
+lemma shiftl_shiftr_3_vs_index[simp]:
+  "ucast (((ucast (x :: vs_index) << 3) :: obj_ref) >> 3) = x"
+  apply (subst shiftl_shiftr_id)
+    apply simp
+   apply (cut_tac ucast_less[where x=x])
+    apply (erule less_trans)
+    apply (simp add: bit_simps)
+   apply simp
+  apply (rule ucast_ucast_id)
+  apply simp
   done
 
 lemma s0_pspace_rel:
@@ -3610,20 +4074,58 @@ lemma s0_pspace_rel:
   apply clarsimp
   apply (drule kh0_SomeD)
   apply (elim disjE)
-                  apply (clarsimp simp: kh0_obj_def bit_simps dest!: less_0x200_exists_ucast)
+                  apply (clarsimp simp: kh0_obj_def)
+                  apply (drule less_pageBits_exists_ucast)
+                  apply (clarsimp simp: kh0_obj_def bit_simps max_page_size_def dest!: less_0x40000_exists_ucast)
                  defer
                  apply ((clarsimp simp: kh0_obj_def kh0H_obj_def bit_simps word_bits_def
                                         fault_rel_optionation_def tcb_relation_cut_def
                                         tcb_relation_def arch_tcb_relation_def the_nat_to_bl_simps
                              split del: if_split)+)[3]
               prefer 13
-              apply ((clarsimp simp: kh0_obj_def kh0H_all_obj_def bit_simps add.commute
-                                     pt_offs_max pt_offs_min pte_relation_def
-                          split del: if_split,
-                      clarsimp simp: s0_ptr_defs shared_page_ptr_phys_def addrFromPPtr_def pptrBaseOffset_def paddrBase_def
-                                     vmrights_map_def vm_read_only_def vm_read_write_def
-                                     kh0_obj_def kh0H_all_obj_def elf_index_value,
-                      (clarsimp simp: bit_simps mask_def)?)+)[5]
+              apply (clarsimp simp: kh0_obj_def mask_def )
+              apply (drule less_VSRootBits_exists_ucast)
+              apply ((auto simp: kh0_obj_def kh0H_all_obj_def  add.commute pte_bits_def
+                                 pt_offs_max pt_offs_min pte_relation_def mask_def bit_simps))[1]
+               apply (insert pt_offs_max(5)[simplified mask_2pm1])[2]
+               apply (erule_tac x=p' in meta_allE)
+               apply (clarsimp simp: bit_simps)
+              apply (erule_tac x=p' in meta_allE)
+              apply (clarsimp simp: bit_simps)
+             apply (((clarsimp simp: kh0_obj_def kh0H_all_obj_def bit_simps add.commute
+                                     pt_offs_max pt_offs_min pte_relation_def mask_def
+                                     vm_read_only_def vmrights_map_def ucast_ucast_id vm_read_write_def
+                                     kh0H_simps(14,15)[where y=0, simplified]
+                             dest!: less_eq_0x1FF_exists_ucast,
+                     clarsimp simp: s0_ptr_defs is_aligned_def addrFromPPtr_def ppn_from_pptr_def
+                                    pageBits_def pptrBaseOffset_def pptrBase_def paddrBase_def); fail?)+)[2]
+           apply (clarsimp simp: kh0_obj_def mask_def)
+           apply (drule less_VSRootBits_exists_ucast)
+           apply (clarsimp simp: pte_bits_def word_size_bits_def kh0H_all_obj_def)
+           apply (((clarsimp simp: kh0_obj_def kh0H_all_obj_def  add.commute
+                                  pt_offs_max pt_offs_min pte_relation_def mask_def
+                                  vm_read_only_def vmrights_map_def ucast_ucast_id vm_read_write_def
+                                    pte_bits_def word_size_bits_def
+                           dest!: less_eq_VSRootBits_exists_ucast)))
+           apply (auto simp: ppn_from_pptr_def)[1]
+            apply (clarsimp simp: bit_simps s0_ptr_defs is_aligned_def addrFromPPtr_def pageBits_def
+                                  ppn_from_pptr_def pptrBaseOffset_def pptrBase_def paddrBase_def)
+           apply (insert pt_offs_max(2)[simplified mask_2pm1])[1]
+           apply (erule_tac x=p' in meta_allE)
+           apply (clarsimp simp: bit_simps add_diff_eq)
+          apply (clarsimp simp: kh0_obj_def mask_def)
+          apply (drule less_VSRootBits_exists_ucast)
+          apply (clarsimp simp: pte_bits_def word_size_bits_def kh0H_all_obj_def)
+          apply (((clarsimp simp: kh0_obj_def kh0H_all_obj_def  add.commute
+                                 pt_offs_max pt_offs_min pte_relation_def mask_def
+                                 vm_read_only_def vmrights_map_def ucast_ucast_id vm_read_write_def
+                                   pte_bits_def word_size_bits_def
+                          dest!: less_eq_VSRootBits_exists_ucast)))
+          apply (auto simp: ppn_from_pptr_def)[1]
+           apply (clarsimp simp:  bit_simps s0_ptr_defs is_aligned_def addrFromPPtr_def ppn_from_pptr_def pageBits_def pptrBaseOffset_def pptrBase_def paddrBase_def)
+          apply (insert pt_offs_max(1)[simplified mask_2pm1])[1]
+          apply (erule_tac x=p' in meta_allE)
+          apply (clarsimp simp: bit_simps add_diff_eq)
          apply (clarsimp simp: kh0_obj_def kh0H_obj_def well_formed_cnode_n_def
                                cte_relation_def cte_map_def bit_simps)
         apply (clarsimp simp: kh0H_obj_def bit_simps ntfn_def other_obj_relation_def ntfn_relation_def)
@@ -3631,20 +4133,19 @@ lemma s0_pspace_rel:
        apply ((clarsimp simp: kh0_obj_def kh0H_obj_def other_obj_relation_def
                               asid_pool_relation_def comp_def inv_into_def2 other_aobj_relation_def,
                rule ext,
-               clarsimp simp: asid_low_bits_of_def asid_low_bits_def High_asid_def,
-               word_bitwise, fastforce)+)[2]
+               clarsimp simp: asid_low_bits_of_def asid_low_bits_def High_asid_def abs_asid_entry_def, word_bitwise)+)[2]
      apply (clarsimp simp: kh0H_obj_def kh0_obj_def cte_relation_def cte_map_def')
      apply (cut_tac dom_caps(2))[1]
      apply (frule_tac m=High_caps in domI)
      apply (cut_tac x=y in cnode_offs_in_range(2), simp)
-     apply (clarsimp simp: cnode_offs_range_def kh0H_all_obj_def High_caps_def
+     apply (clarsimp simp: cnode_offs_range_def kh0H_all_obj_def High_caps_def max_page_size_def
                            the_nat_to_bl_simps vmrights_map_def vm_read_only_def
                     split: if_split_asm)
     apply (clarsimp simp: kh0H_obj_def kh0_obj_def cte_relation_def cte_map_def')
     apply (cut_tac dom_caps(3))[1]
     apply (frule_tac m=Low_caps in domI)
     apply (cut_tac x=y in cnode_offs_in_range(1), simp)
-    apply (clarsimp simp: cnode_offs_range_def kh0H_all_obj_def Low_caps_def
+    apply (clarsimp simp: cnode_offs_range_def kh0H_all_obj_def Low_caps_def max_page_size_def
                           the_nat_to_bl_simps vmrights_map_def vm_read_write_def
                    split: if_split_asm)
    apply (fastforce simp: kh0H_obj_def cte_map_def cte_relation_def well_formed_cnode_n_def
@@ -3653,7 +4154,7 @@ lemma s0_pspace_rel:
   apply (cut_tac dom_caps(1))[1]
   apply (frule_tac m=Silc_caps in domI)
   apply (cut_tac x=y in cnode_offs_in_range(3), simp)
-  apply (clarsimp simp: cnode_offs_range_def kh0H_all_obj_def Silc_caps_def
+  apply (clarsimp simp: cnode_offs_range_def kh0H_all_obj_def Silc_caps_def max_page_size_def
                         the_nat_to_bl_simps vmrights_map_def vm_read_only_def
                  split: if_split_asm)
   done
@@ -3662,128 +4163,120 @@ lemma subtree_node_Some:
   "m \<turnstile> a \<rightarrow> b \<Longrightarrow> m a \<noteq> None"
   by (erule subtree.cases) (auto simp: parentOf_def)
 
+lemma max_numlistregs_rel[simp]:
+  "max_numlistregs = max_armKSGICVCPUNumListRegs"
+  by (simp add: max_numlistregs_def max_armKSGICVCPUNumListRegs_def)
+
 lemma s0_srel:
   "1 \<le> maxDomain \<Longrightarrow> (s0_internal, s0H_internal) \<in> state_relation"
   apply (simp add: state_relation_def)
   apply (intro conjI)
-                  apply (simp add: s0_pspace_rel)
-                 apply (simp add: s0_internal_def exst0_def s0H_internal_def sched_act_relation_def)
-                apply (clarsimp simp: s0_internal_def exst0_def s0H_internal_def
-                                      ready_queues_relation_def ready_queue_relation_def
-                                      list_queue_relation_def queue_end_valid_def
-                                      prev_queue_head_def inQ_def tcbQueueEmpty_def
-                                      projectKOs opt_map_def opt_pred_def
-                               split: option.splits)
-                using kh0H_dom_tcb
-                apply (fastforce simp: kh0H_obj_def)
-               apply (clarsimp simp: s0_internal_def exst0_def s0H_internal_def ghost_relation_def)
-               apply (rule conjI)
-                apply (fastforce simp: kh0_def kh0_obj_def dest: kh0_SomeD)
-               apply clarsimp
-               apply (rule conjI)
-                apply clarsimp
-                apply (rule iffI)
+                   apply (simp add: s0_pspace_rel)
+                  apply (simp add: s0_internal_def exst0_def s0H_internal_def sched_act_relation_def)
+                 apply (clarsimp simp: s0_internal_def exst0_def s0H_internal_def
+                                       ready_queues_relation_def ready_queue_relation_def
+                                       list_queue_relation_def queue_end_valid_def
+                                       prev_queue_head_def inQ_def tcbQueueEmpty_def
+                                       projectKOs opt_map_def opt_pred_def emptyHeadEndPtrs_def
+                                split: option.splits)
+                 using kh0H_dom_tcb
+                 apply (fastforce simp: kh0H_obj_def)
+                apply (clarsimp simp: s0_internal_def exst0_def s0H_internal_def ghost_relation_def)
+                apply (intro conjI)
+                  apply (fastforce simp: kh0_def kh0_obj_def max_page_size_def dest: kh0_SomeD)
                  apply clarsimp
-                 apply (drule kh0_SomeD)
-                 apply (clarsimp simp: irq_node_offs_in_range)
-                apply (fastforce simp: kh0_def well_formed_cnode_n_def empty_cnode_def dom_def)
-               apply clarsimp
-               apply (clarsimp simp: s0_ptr_defs)
-               apply (subgoal_tac "a \<notin> irq_node_offs_range")
-                prefer 2
-                apply (clarsimp simp: irq_node_offs_range_def s0_ptr_defs)
-                apply (erule_tac x="ucast (a - 0xFFFFFFC000003000 >> 5)" in allE)
-                apply (subst (asm) ucast_ucast_len)
-                 apply (rule shiftr_less_t2n)
-                 apply (rule word_less_sub_right)
-                  apply (erule dual_order.strict_trans[rotated], clarsimp)
+                 apply (rule conjI)
+                  apply clarsimp
+                  apply (rule iffI)
+                   apply clarsimp
+                   apply (drule kh0_SomeD)
+                   apply (clarsimp simp: irq_node_offs_in_range)
+                  apply (fastforce simp: kh0_def well_formed_cnode_n_def empty_cnode_def dom_def)
                  apply clarsimp
-                apply (simp add: shiftr_shiftl1)
-                apply (subst(asm) is_aligned_neg_mask_eq)
-                 apply (rule aligned_sub_aligned[where n=5])
-                   apply simp
-                  apply (simp add: is_aligned_def)
-                 apply simp
-                apply simp
-               apply (intro conjI impI)
+                 apply (prop_tac "a \<notin> irq_node_offs_range")
+                  apply (fastforce dest: irq_node_offs_range_correct)
+                 apply (clarsimp simp: s0_ptr_defs)
+                 apply (intro conjI impI)
+                     apply clarsimp
+                     apply (rule iffI)
+                      apply clarsimp
+                      apply (drule kh0_SomeD)
+                      apply (clarsimp simp: s0_ptr_defs kh0_obj_def)
+                     apply (fastforce simp: kh0_def kh0_obj_def dom_def s0_ptr_defs Low_caps_def
+                                            well_formed_cnode_n_def empty_cnode_def)
+                    apply clarsimp
+                    apply (rule iffI)
+                     apply clarsimp
+                     apply (drule kh0_SomeD)
+                     apply (clarsimp simp: s0_ptr_defs kh0_obj_def)
+                    apply (fastforce simp: kh0_def kh0_obj_def dom_def s0_ptr_defs High_caps_def
+                                           well_formed_cnode_n_def empty_cnode_def)
                    apply clarsimp
                    apply (rule iffI)
                     apply clarsimp
                     apply (drule kh0_SomeD)
                     apply (clarsimp simp: s0_ptr_defs kh0_obj_def)
-                   apply (fastforce simp: kh0_def kh0_obj_def dom_def s0_ptr_defs Low_caps_def
+                   apply (fastforce simp: kh0_def kh0_obj_def dom_def s0_ptr_defs Silc_caps_def
                                           well_formed_cnode_n_def empty_cnode_def)
                   apply clarsimp
                   apply (rule iffI)
                    apply clarsimp
                    apply (drule kh0_SomeD)
                    apply (clarsimp simp: s0_ptr_defs kh0_obj_def)
-                  apply (fastforce simp: kh0_def kh0_obj_def dom_def s0_ptr_defs High_caps_def
+                  apply (fastforce simp: kh0_def kh0_obj_def dom_def s0_ptr_defs Silc_caps_def
                                          well_formed_cnode_n_def empty_cnode_def)
-                 apply clarsimp
-                 apply (rule iffI)
-                  apply clarsimp
-                  apply (drule kh0_SomeD)
-                  apply (clarsimp simp: s0_ptr_defs kh0_obj_def)
-                 apply (fastforce simp: kh0_def kh0_obj_def dom_def s0_ptr_defs Silc_caps_def
-                                        well_formed_cnode_n_def empty_cnode_def)
-                apply clarsimp
-                apply (rule iffI)
                  apply clarsimp
                  apply (drule kh0_SomeD)
                  apply (clarsimp simp: s0_ptr_defs kh0_obj_def)
-                apply (fastforce simp: kh0_def kh0_obj_def dom_def s0_ptr_defs Silc_caps_def
-                                       well_formed_cnode_n_def empty_cnode_def)
-               apply clarsimp
-               apply (drule kh0_SomeD)
-               apply (clarsimp simp: s0_ptr_defs kh0_obj_def)
-              apply (clarsimp simp: s0H_internal_def cdt_relation_def)
-              apply (clarsimp simp: descendants_of'_def)
-              apply (frule subtree_parent)
-              apply (drule subtree_mdb_next)
-              apply (case_tac "x = 0")
-               apply (cut_tac s0H_valid_pspace')
-                apply (simp add: valid_pspace'_def valid_mdb'_def valid_mdb_ctes_def
-                                 parentOf_def isMDBParentOf_def kh0H_all_obj_def')
-               apply simp
-              apply (clarsimp simp: mdb_next_trancl_s0H)
-              apply (elim disjE, (clarsimp simp: parentOf_def isMDBParentOf_def kh0H_all_obj_def')+)[1]
-             apply (clarsimp simp: cdt_list_relation_def s0_internal_def exst0_def split: option.splits)
-             apply (clarsimp simp: next_slot_def)
-             apply (cut_tac p="(a, b)" and t="(const [])" and m="Map.empty" in next_not_child_NoneI)
-                apply fastforce
-               apply (simp add: next_sib_def)
-              apply (simp add: finite_depth_def)
-             apply simp
-            apply (clarsimp simp: revokable_relation_def)
-            apply (clarsimp simp: null_filter_def split: if_split_asm)
-            apply (drule s0_caps_of_state)
-            apply clarsimp
-            apply (elim disjE)
-                                  apply (clarsimp simp: s0H_internal_def s0_internal_def
-                                                        cte_map_def' kh0H_all_obj_def'
-                                                 split: if_split_asm)+
-                 apply (clarsimp simp: tcb_cnode_index_def ucast_bl[symmetric]
-                                       Low_tcb_cte_def Low_tcbH_def High_tcb_cte_def High_tcbH_def)
-                apply ((clarsimp simp: cte_map_def' s0H_internal_def s0_internal_def,
-                        clarsimp simp: tcb_cnode_index_def ucast_bl[symmetric]
-                                       Low_tcb_cte_def Low_tcbH_def High_tcb_cte_def High_tcbH_def)+)[5]
-           apply (clarsimp simp: s0_internal_def s0H_internal_def arch_state0_def arch_state0H_def
-                                 arch_state_relation_def asid_high_bits_of_def asid_low_bits_def
-                                 High_asid_def Low_asid_def max_pt_level_def2 maxPTLevel_def comp_def
-                          split: if_splits)
-           apply safe
+                apply (clarsimp simp: s0H_internal_def arch_state0H_def)
+                apply auto[1]
+                          apply (drule kh0_SomeD, clarsimp simp: kh0_obj_def, clarsimp simp: kh0_def kh0_obj_def)+
+                apply (drule kh0_SomeD, clarsimp simp: kh0_obj_def)
+               apply (clarsimp simp: s0H_internal_def cdt_relation_def)
+               apply (clarsimp simp: descendants_of'_def)
+               apply (frule subtree_parent)
+               apply (drule subtree_mdb_next)
+               apply (case_tac "x = 0")
+                apply (cut_tac s0H_valid_pspace')
+                 apply (simp add: valid_pspace'_def valid_mdb'_def valid_mdb_ctes_def
+                                  parentOf_def isMDBParentOf_def kh0H_all_obj_def')
+                apply simp
+               apply (clarsimp simp: mdb_next_trancl_s0H)
+               apply (elim disjE, (clarsimp simp: parentOf_def isMDBParentOf_def kh0H_all_obj_def')+)[1]
+              apply (clarsimp simp: cdt_list_relation_def s0_internal_def exst0_def split: option.splits)
+              apply (clarsimp simp: next_slot_def)
+              apply (cut_tac p="(a, b)" and t="(const [])" and m="Map.empty" in next_not_child_NoneI)
+                 apply fastforce
+                apply (simp add: next_sib_def)
+               apply (simp add: finite_depth_def)
+              apply simp
+             apply (clarsimp simp: revokable_relation_def)
+             apply (clarsimp simp: null_filter_def split: if_split_asm)
+             apply (drule s0_caps_of_state)
+             apply clarsimp
+             apply (elim disjE)
+                                   apply (clarsimp simp: s0H_internal_def s0_internal_def
+                                                         cte_map_def' kh0H_all_obj_def'
+                                                  split: if_split_asm)+
+                  apply (clarsimp simp: tcb_cnode_index_def ucast_bl[symmetric]
+                                        Low_tcb_cte_def Low_tcbH_def High_tcb_cte_def High_tcbH_def)
+                 apply ((clarsimp simp: cte_map_def' s0H_internal_def s0_internal_def,
+                         clarsimp simp: tcb_cnode_index_def ucast_bl[symmetric]
+                                        Low_tcb_cte_def Low_tcbH_def High_tcb_cte_def High_tcbH_def)+)[5]
+            apply (clarsimp simp: s0_internal_def s0H_internal_def arch_state0_def arch_state0H_def
+                                  arch_state_relation_def asid_high_bits_of_def asid_low_bits_def
+                                  High_asid_def Low_asid_def max_pt_level_def2 maxPTLevel_def comp_def
+                           split: if_splits)
+            apply safe
+             apply (rule ext)
+             apply clarsimp
+             apply (word_bitwise, fastforce)
+
             apply (rule ext)
-            apply clarsimp
-            apply (word_bitwise, fastforce)
-           apply (rule ext)
-           apply (clarsimp split: if_splits)
-           subgoal for level
-           by (induct level; simp only: size_maxPTLevel[simplified maxPTLevel_def, symmetric]
-                                        bit0.size_inj max_pt_level_def2)
-          apply (clarsimp simp: s0_internal_def s0H_internal_def exst0_def cte_level_bits_def
-                                interrupt_state_relation_def irq_state_relation_def)
-         apply (clarsimp simp: s0_internal_def exst0_def s0H_internal_def)+
+            apply (clarsimp simp: vmid_for_asid_2'_def obind_def opt_map_def asid_pool_of'_def kh0H_all_obj_def vmids_of_pool'_def)
+           apply (clarsimp simp: s0_internal_def s0H_internal_def exst0_def cte_level_bits_def
+                                 interrupt_state_relation_def irq_state_relation_def)
+          apply (clarsimp simp: s0_internal_def exst0_def s0H_internal_def)+
   done
 
 definition
@@ -3808,8 +4301,13 @@ lemma step_restrict_s0:
   apply (rule conjI)
    apply (simp only: ex_abs_def)
    apply (rule_tac x="s0_internal" in exI)
+   apply (subst pred_conj_def[where f=einvs])
    apply (simp only: einvs_s0 s0_srel)
-  apply (simp add: s0H_internal_def valid_domain_list'_def)
+   apply (simp add: no_domain_caps_def)
+  apply (rule_tac x="s0_internal" in exI)
+  apply (clarsimp simp: domain_sep_inv_def F[symmetric])
+  apply (drule s0_caps_of_state)
+  apply auto[1]
   apply (clarsimp simp: ct_in_state'_def st_tcb_at'_def obj_at'_def
                         s0H_internal_def objBits_simps' s0_ptrs_aligned Low_tcbH_def)
   apply (rule pspace_distinctD''[OF _ s0H_pspace_distinct', simplified s0H_internal_def])

--- a/proof/infoflow/refine/ADT_IF_Refine.thy
+++ b/proof/infoflow/refine/ADT_IF_Refine.thy
@@ -64,7 +64,7 @@ definition prod_lift where
 
 definition handlePreemption_if :: "user_context \<Rightarrow> user_context kernel" where
   "handlePreemption_if tc \<equiv> do
-     maybeHandleInterrupt False;
+     maybeHandleInterrupt True;
      stateAssert
        (\<lambda>s. ksDomainTime s = 0 \<longrightarrow> ksSchedulerAction s = ChooseNewThread) [];
      return tc
@@ -229,11 +229,11 @@ locale ADT_IF_Refine_1 =
        (invs' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread) and ct_running')
        (do_user_op_if f tc) (doUserOp_if f tc)"
   and dmo_getActiveIRQ_corres:
-    "corres (=) \<top> \<top> (do_machine_op (getActiveIRQ in_kernel)) (doMachineOp (getActiveIRQ in_kernel'))"
+    "corres (=) \<top> \<top> (do_machine_op (getActiveIRQ in_kernel)) (doMachineOp (getActiveIRQ in_kernel))"
   and dmo'_getActiveIRQ_wp:
     "\<lbrace>\<lambda>s. P (irq_at (irq_state (ksMachineState s) + 1) (irq_masks (ksMachineState s)))
             (s\<lparr>ksMachineState := (ksMachineState s\<lparr>irq_state := irq_state (ksMachineState s) + 1\<rparr>)\<rparr>)\<rbrace>
-     doMachineOp (getActiveIRQ in_kernel)
+     doMachineOp (getActiveIRQ False)
      \<lbrace>P\<rbrace>"
   and handlePreemption_arch_extras[wp]:
     "handlePreemption_if tc \<lbrace>arch_extras\<rbrace>"
@@ -272,8 +272,6 @@ locale ADT_IF_Refine_1 =
               and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)
               and arch_extras)
        (handle_event event) (handleEvent event)"
-  and maybeHandleInterrupt_corres_True_False:
-    "corres dc einvs invs' (maybe_handle_interrupt True) (maybeHandleInterrupt False)"
   and kernel_entry_if_corres:
     "\<And>event tc.
      corres (prod_lift (dc \<oplus> dc))
@@ -361,16 +359,11 @@ lemma checkActiveIRQ_ex_abs[wp]:
   apply (clarsimp simp: ex_abs_def)
   done
 
-lemma handlePreemption_invs'[wp]:
-  "handlePreemption_if tc \<lbrace>invs'\<rbrace>"
-  unfolding handlePreemption_if_def
-  by (wpsimp wp: dmo'_getActiveIRQ_wp hoare_drop_imps)
-
 lemma handle_preemption_if_corres:
   "corres (=) (einvs and valid_domain_list and (\<lambda>s. 0 < domain_time s))
               (invs') (handle_preemption_if tc) (handlePreemption_if tc)"
   apply (simp add: handlePreemption_if_def handle_preemption_if_def)
-  apply (corres corres: maybeHandleInterrupt_corres_True_False)
+  apply (corres corres: maybeHandleInterrupt_corres)
       apply (rule corres_stateAssert_assume_stronger[where Q=\<top> and
                     P="\<lambda>s. valid_domain_list s \<and>
                            (domain_time s = 0 \<longrightarrow> scheduler_action s = choose_new_thread)"])
@@ -832,6 +825,11 @@ definition ADT_H_if where
 lemma ex_abs_pred_conjD1: (* FIXME: move *)
   "ex_abs (P and Q) s \<Longrightarrow> ex_abs P s"
   by (auto simp: ex_abs_def)
+
+lemma handlePreemption_invs'[wp]:
+  "handlePreemption_if tc \<lbrace>invs'\<rbrace>"
+  unfolding handlePreemption_if_def
+  by (wpsimp wp: dmo'_getActiveIRQ_wp hoare_drop_imps)
 
 lemma haskell_invs:
   "global_automaton_invs checkActiveIRQ_H_if (doUserOp_H_if uop)

--- a/proof/infoflow/refine/ADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/ADT_IF_Refine_C.thy
@@ -82,10 +82,68 @@ definition handleVMFaultEvent_C_body_if
 
 context kernel_m begin
 
+definition
+  checkActiveIRQ_C_if :: "user_context \<Rightarrow> (cstate, irq option \<times> user_context) nondet_monad"
+  where
+  "checkActiveIRQ_C_if tc \<equiv>
+   do
+      getActiveIRQ_C;
+      irq \<leftarrow>  gets ret__unsigned_long_';
+      return (if irq = ucast irqInvalid then None else Some (ucast irq), tc)
+   od"
+
+definition
+  check_active_irq_C_if
+  where
+  "check_active_irq_C_if \<equiv> {((tc, s), irq, (tc', s')). ((irq, tc'), s') \<in> fst (checkActiveIRQ_C_if tc s)}"
+
 definition handleInterruptEntry_C_body_if (*:: "(globals myvars, int, l4c_errortype) com"*) where
-"handleInterruptEntry_C_body_if \<equiv> (
+  "handleInterruptEntry_C_body_if \<equiv> (
       (CALL checkInterrupt());;
        \<acute>ret__unsigned_long :== scast EXCEPTION_NONE)"
+
+definition
+  handlePreemption_C_if :: "user_context \<Rightarrow> (cstate,user_context) nondet_monad" where
+  "handlePreemption_C_if tc \<equiv> do (exec_C \<Gamma> handleInterruptEntry_C_body_if); return tc od"
+
+end
+
+
+locale ADT_IF_Refine_1 = kernel_m +
+  fixes doUserOp_C_if ::
+    "user_transition_if \<Rightarrow> user_context \<Rightarrow> (cstate, (event option \<times> user_context)) nondet_monad"
+  and handleHypervisorFault_C_body_if :: "machine_word \<Rightarrow> (globals myvars, int, strictc_errortype) com"
+  and hyp_fault_type_from_H :: "hyp_fault_type \<Rightarrow> machine_word"
+  assumes do_user_op_if_C_corres:
+    "corres_underlying rf_sr False False (=) (invs' and ex_abs einvs and (\<lambda>_. uop_nonempty f))
+                       \<top> (doUserOp_if f tc) (doUserOp_C_if f tc)"
+  and handleInvocation_ccorres':
+    "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
+       (invs' and arch_extras and ct_active' and sch_act_simple)
+       (UNIV \<inter> {s. isCall_' s = from_bool isCall} \<inter> {s. isBlocking_' s = from_bool isBlocking}) []
+       (handleInvocation isCall isBlocking) (Call handleInvocation_'proc)"
+  and handleHypervisorFault_C_body_ccorres:
+    "ccorres ((\<lambda>irq :: irq. K dc irq) \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
+             (invs' and arch_extras and ct_running' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread))
+             (UNIV) []
+             (liftE (do thread <- getCurThread;
+                        handleHypervisorFault thread flt
+                     od))
+             (handleHypervisorFault_C_body_if (hyp_fault_type_from_H flt))"
+  and checkInterrupt_ccorres':
+    "ccorres dc xfdc (\<lambda>s. invs' s \<and> (\<not>inKernel \<longrightarrow> sch_act_not (ksCurThread s) s)) UNIV []
+       (maybeHandleInterrupt inKernel) (Call checkInterrupt_'proc)"
+  and hvmf_invs_lift:
+    "\<lbrakk> \<And>s m. P (s\<lparr>ksMachineState := ksMachineState s\<lparr>machine_state_rest := m\<rparr>\<rparr>) = P s \<rbrakk>
+       \<Longrightarrow> \<lbrace>P\<rbrace> handleVMFault t hf \<lbrace>\<lambda>_ _. True\<rbrace>, \<lbrace>\<lambda>_. P\<rbrace>"
+  and check_active_irq_corres_C:
+    "corres_underlying rf_sr False False (=) \<top> \<top> (checkActiveIRQ_if tc) (checkActiveIRQ_C_if tc)"
+  and obs_cpspace_user_data_relation:
+    "\<lbrakk> pspace_aligned' bd; pspace_distinct' bd;
+       cpspace_user_data_relation (ksPSpace bd) (underlying_memory (ksMachineState bd)) hgs \<rbrakk>
+       \<Longrightarrow> cpspace_user_data_relation (ksPSpace bd)
+             (underlying_memory (observable_memory (ksMachineState bd) (user_mem' bd))) hgs"
+begin
 
 definition
   "callKernel_C_body_if e \<equiv> case e of
@@ -94,7 +152,7 @@ definition
   | UserLevelFault w1 w2 \<Rightarrow> (handleUserLevelFault_C_body_if w1 w2)
   | Interrupt \<Rightarrow> (handleInterruptEntry_C_body_if)
   | VMFaultEvent t \<Rightarrow> (handleVMFaultEvent_C_body_if (vm_fault_type_from_H t))
-  | HypervisorEvent t \<Rightarrow> (SKIP ;; \<acute>ret__unsigned_long :== scast EXCEPTION_NONE)"
+  | HypervisorEvent t \<Rightarrow> (handleHypervisorFault_C_body_if (hyp_fault_type_from_H t))"
 
 definition
   kernelEntry_C_if (*::
@@ -121,60 +179,10 @@ definition
       {(s, b, (tc,s'))|s b tc s' r. ((r,tc),s') \<in> fst (split (kernelEntry_C_if fp e) s) \<and>
                    b = (case r of Inl x \<Rightarrow> True | Inr x \<Rightarrow> False)}"
 
-definition
-  checkActiveIRQ_C_if :: "user_context \<Rightarrow> (cstate, irq option \<times> user_context) nondet_monad"
-  where
-  "checkActiveIRQ_C_if tc \<equiv>
-   do
-      getActiveIRQ_C;
-      irq \<leftarrow>  gets ret__unsigned_long_';
-      return (if irq = ucast irqInvalid then None else Some (ucast irq), tc)
-   od"
-
-definition
-  check_active_irq_C_if
-  where
-  "check_active_irq_C_if \<equiv> {((tc, s), irq, (tc', s')). ((irq, tc'), s') \<in> fst (checkActiveIRQ_C_if tc s)}"
-
-lemma corres_select_f':
-  "\<lbrakk> \<And>s s'. P s \<Longrightarrow> P' s' \<Longrightarrow> \<forall>s' \<in> fst S'. \<exists>s \<in> fst S. rvr s s'; nf' \<Longrightarrow> \<not> snd S' \<rbrakk>
-      \<Longrightarrow> corres_underlying sr nf nf' rvr P P' (select_f S) (select_f S')"
-  by (clarsimp simp: select_f_def corres_underlying_def)
-
-lemma cur_thread_of_absKState[simp]:
-   "cur_thread (absKState s) = (ksCurThread s)"
-   by (clarsimp simp: cstate_relation_def Let_def absKState_def cstate_to_H_def)
-
-lemma absKState_crelation:
-  "\<lbrakk> cstate_relation s (globals s'); invs' s; ksReadyQueues_asrt s\<rbrakk>
-   \<Longrightarrow>  cstate_to_A s' = absKState s"
-  apply (clarsimp simp add: cstate_to_H_correct invs'_def cstate_to_A_def)
-  apply (clarsimp simp: absKState_def absExst_def observable_memory_def)
-  apply (case_tac s)
-  apply clarsimp
-  apply (case_tac ksMachineState)
-  apply clarsimp
-  apply (rule ext)
-  by (clarsimp simp: option_to_0_def user_mem'_def pointerInUserData_def ko_wp_at'_def
-                     obj_at'_def typ_at'_def ps_clear_def
-              split: if_splits)
-
-definition
-  handlePreemption_C_if :: "user_context \<Rightarrow> (cstate,user_context) nondet_monad" where
-  "handlePreemption_C_if tc \<equiv> do (exec_C \<Gamma> handleInterruptEntry_C_body_if); return tc od"
-
-lemma handlePreemption_if_def2:
-  "handlePreemption_if tc = do
-     r \<leftarrow> handleEvent Interrupt;
-          stateAssert (\<lambda>s. ksDomainTime s = 0 \<longrightarrow> ksSchedulerAction s = ChooseNewThread) [];
-          return tc
-   od"
-  by (clarsimp simp: handlePreemption_if_def maybeHandleInterrupt_def handleEvent_def
-                     liftE_def bind_assoc)
-
 lemma handleInterrupt_no_fail:
   "no_fail (ex_abs (einvs) and invs'
-                           and (\<lambda>s. intStateIRQTable (ksInterruptState s) a \<noteq> irqstate.IRQInactive))
+                           and (\<lambda>s. intStateIRQTable (ksInterruptState s) a \<noteq> irqstate.IRQInactive)
+                           and (\<lambda>s. a \<in> non_kernel_IRQs \<longrightarrow> sch_act_not (ksCurThread s) s))
            (handleInterrupt a)"
   apply (rule no_fail_pre)
   apply (rule corres_nofail)
@@ -190,49 +198,45 @@ lemma handleSpuriousIRQ_no_fail[intro!, wp, simp]:
   by wpsimp
 
 lemma handleEvent_Interrupt_no_fail:
-  "no_fail (invs' and ex_abs einvs) (handleEvent Interrupt)"
+  "no_fail (invs' and ex_abs einvs and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)) (handleEvent Interrupt)"
   apply (simp add: handleEvent_def maybeHandleInterrupt_def)
   apply (wpsimp wp: handleInterrupt_no_fail)
     apply (simp add: crunch_simps)
     apply (rule_tac Q'="\<lambda>r s. ex_abs (einvs) s \<and> invs' s \<and>
                              (\<forall>irq. r = Some irq
-                                    \<longrightarrow> intStateIRQTable (ksInterruptState s) irq \<noteq> irqstate.IRQInactive)"
+                                    \<longrightarrow> intStateIRQTable (ksInterruptState s) irq \<noteq> irqstate.IRQInactive)
+                                      \<and> (\<forall>irq. r = Some irq \<longrightarrow> irq \<in> non_kernel_IRQs \<longrightarrow> sch_act_not (ksCurThread s) s)"
                  in hoare_strengthen_post)
      apply (rule hoare_vcg_conj_lift)
       apply (rule corres_ex_abs_lift)
        apply (rule dmo_getActiveIRQ_corres)
       apply wpsimp
      apply (wpsimp wp: doMachineOp_getActiveIRQ_IRQ_active)
+     apply (wp hoare_vcg_all_lift hoare_drop_imps)
+     apply wpsimp
     apply clarsimp
    apply wpsimp
   apply (clarsimp simp: invs'_def valid_state'_def)
   done
 
-end
-
-
-locale ADT_IF_Refine_1 = kernel_m +
-  fixes doUserOp_C_if ::
-    "user_transition_if \<Rightarrow> user_context \<Rightarrow> (cstate, (event option \<times> user_context)) nondet_monad"
-  assumes do_user_op_if_C_corres:
-    "corres_underlying rf_sr False False (=) (invs' and ex_abs einvs and (\<lambda>_. uop_nonempty f))
-                       \<top> (doUserOp_if f tc) (doUserOp_C_if f tc)"
-  assumes handleInterrupt_if_ccorres:
-    "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_') (invs') (UNIV) []
-             (handleEvent Interrupt) (handleInterruptEntry_C_body_if)"
-  and handleInvocation_ccorres':
-    "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
-       (invs' and arch_extras and ct_active' and sch_act_simple)
-       (UNIV \<inter> {s. isCall_' s = from_bool isCall} \<inter> {s. isBlocking_' s = from_bool isBlocking}) []
-       (handleInvocation isCall isBlocking) (Call handleInvocation_'proc)"
-  and check_active_irq_corres_C:
-    "corres_underlying rf_sr False False (=) \<top> \<top> (checkActiveIRQ_if tc) (checkActiveIRQ_C_if tc)"
-  and obs_cpspace_user_data_relation:
-    "\<lbrakk> pspace_aligned' bd; pspace_distinct' bd;
-       cpspace_user_data_relation (ksPSpace bd) (underlying_memory (ksMachineState bd)) hgs \<rbrakk>
-       \<Longrightarrow> cpspace_user_data_relation (ksPSpace bd)
-             (underlying_memory (observable_memory (ksMachineState bd) (user_mem' bd))) hgs"
-begin
+lemma handleInterrupt_if_ccorres:
+  "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
+           (\<lambda>s. invs' s \<and> (\<not>inKernel \<longrightarrow> sch_act_not (ksCurThread s) s))
+           (UNIV)
+           []
+           (liftE (maybeHandleInterrupt inKernel))
+           (handleInterruptEntry_C_body_if)"
+  apply (rule ccorres_guard_imp2)
+   apply (simp add: handleInterruptEntry_C_body_if_def)
+   apply (rule ccorres_add_return2)
+   apply (ctac (no_vcg) add: checkInterrupt_ccorres)
+    apply (rule_tac R="\<lambda>_. rv = Inr ()" in ccorres_return[where R'=UNIV])
+    apply (rule conseqPre, vcg)
+    apply (clarsimp simp: return_def)
+   apply (simp add: liftE_def)
+   apply wpsimp
+  apply clarsimp
+  done
 
 lemma handleEvent_ccorres:
   notes K_def[simp del]
@@ -342,7 +346,8 @@ lemma handleEvent_ccorres:
             apply simp
            apply simp
           apply simp
-         apply (wp hv_inv_ex')
+         apply (wp hvmf_invs_lift)
+         apply (fastforce simp: invs'_machine valid_machine_state'_def)
         apply (simp add: guard_is_UNIV_def)
         apply (vcg exspec=handleVMFault_modifies)
        apply ceqv
@@ -352,20 +357,12 @@ lemma handleEvent_ccorres:
       apply (clarsimp simp: return_def)
      apply wp
     apply (simp add: guard_is_UNIV_def)
-   apply (auto simp: ct_in_state'_def isReply_def is_cap_fault_def
-                     cfault_rel_def seL4_Fault_UnknownSyscall_lift seL4_Fault_UserException_lift
-               elim: pred_tcb'_weakenE st_tcb_ex_cap''
-               dest: st_tcb_at_idle_thread' rf_sr_ksCurThread)
   \<comment> \<open>HypervisorEvent\<close>
-  apply (simp add: liftE_def bind_assoc)
-  apply (rule ccorres_guard_imp2)
-   apply (rule ccorres_symb_exec_l)
-      apply (case_tac x6; simp add: handleHypervisorFault_def)
-      apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
-      apply (rule allI, rule conseqPre, vcg)
-      apply (clarsimp simp: return_def)
-     apply wp+
-  apply clarsimp
+   apply (rule handleHypervisorFault_C_body_ccorres)
+  apply (auto simp: ct_in_state'_def isReply_def is_cap_fault_def
+                    cfault_rel_def seL4_Fault_UnknownSyscall_lift seL4_Fault_UserException_lift
+              elim: pred_tcb'_weakenE st_tcb_ex_cap''
+              dest: st_tcb_at_idle_thread' rf_sr_ksCurThread split: if_splits)
   done
 
 lemma kernelEntry_corres_C:
@@ -428,14 +425,60 @@ lemma kernelEntry_corres_C:
   apply fastforce
   done
 
+lemma handleInterrupt_if_ccorres':
+  "ccorres dc (liftxf errstate id (K ()) ret__unsigned_long_')
+           (\<lambda>s. invs' s \<and> (\<not>inKernel \<longrightarrow> sch_act_not (ksCurThread s) s))
+           (UNIV)
+           []
+           (maybeHandleInterrupt inKernel)
+           (handleInterruptEntry_C_body_if)"
+  apply (rule ccorres_guard_imp2)
+   apply (simp add: handleInterruptEntry_C_body_if_def)
+   apply (rule ccorres_add_return2)
+   apply (ctac (no_vcg) add: checkInterrupt_ccorres')
+    apply (rule_tac R="\<top>" in ccorres_return[where R'=UNIV])
+    apply (rule conseqPre, vcg)
+    apply (clarsimp simp: return_def)
+   apply wpsimp
+  apply simp
+  done
+
+(* FIXME AARCH64 IF: getActiveIRQ_neq_non_kernel should be exposed *)
+lemma dmo_getActiveIRQ_notin_non_kernel_IRQs[wp]:
+  "\<lbrace>\<top>\<rbrace> doMachineOp (getActiveIRQ True) \<lbrace>\<lambda>irq _. irq \<notin> Some ` non_kernel_IRQs\<rbrace>"
+  unfolding doMachineOp_def
+  apply wpsimp
+  apply (drule use_valid, rule getActiveIRQ_neq_non_kernel, rule TrueI)
+  apply clarsimp
+  done
+
+lemma maybeHandleInterrupt_True_no_fail:
+  "no_fail (invs' and ex_abs einvs) (maybeHandleInterrupt True)"
+  apply (simp add: handleEvent_def maybeHandleInterrupt_def)
+  apply (wpsimp wp: handleInterrupt_no_fail)
+    apply (simp add: crunch_simps)
+    apply (rule_tac Q'="\<lambda>r s. ex_abs (einvs) s \<and> invs' s \<and> r \<notin> Some ` non_kernel_IRQs \<and>
+                             (\<forall>irq. r = Some irq
+                                    \<longrightarrow> intStateIRQTable (ksInterruptState s) irq \<noteq> irqstate.IRQInactive)"
+                 in hoare_strengthen_post)
+     apply (rule hoare_vcg_conj_lift)
+      apply (rule corres_ex_abs_lift)
+       apply (rule dmo_getActiveIRQ_corres)
+      apply wpsimp
+     apply (wpsimp wp: doMachineOp_getActiveIRQ_IRQ_active)
+    apply clarsimp
+   apply wpsimp
+  apply (clarsimp simp: invs'_def valid_state'_def)
+  done
+
 lemma handle_preemption_corres_C:
   "corres_underlying rf_sr False False (=)
      (invs' and (\<lambda>s. 0 < ksDomainTime s) and ex_abs einvs) \<top>
      (handlePreemption_if tc) (handlePreemption_C_if tc)"
-  apply (simp add: handlePreemption_if_def2 handlePreemption_C_if_def)
+  apply (simp add: handlePreemption_if_def handlePreemption_C_if_def)
   apply (rule corres_stateAssert_no_fail)
   using corres_nofail[OF handle_preemption_if_corres[of tc], simplified]
-   apply (simp add: handlePreemption_if_def2)
+   apply (simp add: handlePreemption_if_def)
    apply (erule no_fail_pre)
    apply (clarsimp simp: ex_abs_underlying_def ex_abs_def)
    apply (rule exI, rule conjI, assumption)
@@ -445,21 +488,16 @@ lemma handle_preemption_corres_C:
        apply (rule ccorres_corres_u)
         apply (rule ccorres_guard_imp)
           apply (rule ccorres_rel_imp)
-           apply (rule handleInterrupt_if_ccorres)
+           apply (ctac add: handleInterrupt_if_ccorres')
           apply simp
          prefer 3
-         apply (rule handleEvent_Interrupt_no_fail)
+         apply (rule maybeHandleInterrupt_True_no_fail)
         apply clarsimp
        apply simp
       apply simp
      apply (rule wp_post_taut)+
    apply (fastforce simp: ex_abs_def schedaction_related)+
   done
-
-end
-
-
-context kernel_m begin
 
 definition
   handle_preemption_C_if
@@ -557,6 +595,34 @@ lemma preserves_trivial: "preserves mode mode' UNIV f"
 lemma preserves'_trivial: "preserves' mode UNIV f"
   apply (simp add: preserves'_def)
   done
+
+lemma corres_select_f':
+  "\<lbrakk> \<And>s s'. P s \<Longrightarrow> P' s' \<Longrightarrow> \<forall>s' \<in> fst S'. \<exists>s \<in> fst S. rvr s s'; nf' \<Longrightarrow> \<not> snd S' \<rbrakk>
+      \<Longrightarrow> corres_underlying sr nf nf' rvr P P' (select_f S) (select_f S')"
+  by (clarsimp simp: select_f_def corres_underlying_def)
+
+
+context kernel_m begin
+
+lemma cur_thread_of_absKState[simp]:
+   "cur_thread (absKState s) = (ksCurThread s)"
+   by (clarsimp simp: cstate_relation_def Let_def absKState_def cstate_to_H_def)
+
+lemma absKState_crelation:
+  "\<lbrakk> cstate_relation s (globals s'); invs' s; ksReadyQueues_asrt s\<rbrakk>
+   \<Longrightarrow>  cstate_to_A s' = absKState s"
+  apply (clarsimp simp add: cstate_to_H_correct invs'_def cstate_to_A_def)
+  apply (clarsimp simp: absKState_def absExst_def observable_memory_def)
+  apply (case_tac s)
+  apply clarsimp
+  apply (case_tac ksMachineState)
+  apply clarsimp
+  apply (rule ext)
+  by (clarsimp simp: option_to_0_def user_mem'_def pointerInUserData_def ko_wp_at'_def
+                     obj_at'_def typ_at'_def ps_clear_def
+              split: if_splits)
+
+end
 
 
 context ADT_IF_Refine_1 begin

--- a/proof/infoflow/refine/ARM/ArchADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/ARM/ArchADT_IF_Refine_C.thy
@@ -12,21 +12,6 @@ context kernel_m begin
 
 named_theorems ADT_IF_Refine_assms
 
-lemma handleInterrupt_ccorres[ADT_IF_Refine_assms]:
-  "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_') (invs') (UNIV) []
-           (handleEvent Interrupt) (handleInterruptEntry_C_body_if)"
-  apply (rule ccorres_guard_imp2)
-   apply (simp add: handleEvent_def minus_one_norm handleInterruptEntry_C_body_if_def)
-   apply (rule ccorres_add_return2)
-   apply (ctac (no_vcg) add: checkInterrupt_ccorres)
-    apply (rule_tac R="\<lambda>_. rv = Inr ()" in ccorres_return[where R'=UNIV])
-    apply (rule conseqPre, vcg)
-    apply (clarsimp simp: return_def)
-   apply (simp add: liftE_def)
-   apply wpsimp
-  apply clarsimp
-  done
-
 lemma handleInvocation_ccorres'[ADT_IF_Refine_assms]:
   "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
        (invs' and arch_extras and ct_active' and sch_act_simple)
@@ -298,10 +283,78 @@ lemma obs_cpspace_user_data_relation[ADT_IF_Refine_assms]:
   apply simp
   done
 
+declare handleSpuriousIRQ_ccorres[ADT_IF_Refine_assms]
+
+lemma dmo_getActiveIRQ_inKernel_sch_act_not:
+  "\<lbrace>\<lambda>s. \<not>inKernel \<longrightarrow> sch_act_not (ksCurThread s) s\<rbrace>
+   doMachineOp (getActiveIRQ inKernel)
+   \<lbrace>\<lambda>rv s. \<forall>irq. rv = Some irq \<longrightarrow> irq \<in> non_kernel_IRQs \<longrightarrow> sch_act_not (ksCurThread s) s\<rbrace>"
+  unfolding doMachineOp_def
+  apply (cases inKernel; wpsimp)
+  apply (drule use_valid, rule getActiveIRQ_neq_non_kernel, rule TrueI)
+  apply clarsimp
+  done
+
+lemma checkInterrupt_ccorres'[ADT_IF_Refine_assms]:
+  "ccorres dc xfdc (\<lambda>s. invs' s \<and> (\<not>inKernel \<longrightarrow> sch_act_not (ksCurThread s) s)) UNIV []
+           (maybeHandleInterrupt inKernel) (Call checkInterrupt_'proc)"
+  unfolding maybeHandleInterrupt_def
+  apply cinit'
+  apply (rule ccorres_guard_imp)
+    apply (simp add: liftE_def bind_assoc)
+    apply (ctac (no_vcg) add: getActiveIRQ_ccorres)
+         apply (rule_tac P="\<lambda>_. rv \<noteq> None" and R=\<top> in ccorres_cond_both)
+           apply (auto simp: irq_type_never_invalid split: option.splits)[1]
+          apply (rule_tac P="rv \<noteq> None" in ccorres_gen_asm)
+          apply clarsimp
+          apply (rule ccorres_call[where xf'=xfdc, OF handleInterrupt_ccorres]; simp)
+         apply (rule_tac P="rv = None" in ccorres_gen_asm)
+         apply clarsimp
+         apply (ctac (no_vcg) add: handleSpuriousIRQ_ccorres)
+      apply wp
+     apply (simp add: guard_is_UNIV_def)
+    apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>x. rv = Some x \<longrightarrow> x \<le> maxIRQ)"
+                    in hoare_post_imp)
+     apply (solves clarsimp)
+    apply (wpsimp wp: getActiveIRQ_le_maxIRQ)
+    apply assumption
+   apply assumption
+  apply (clarsimp simp: invs'_def valid_state'_def)
+  done
+
+lemma hvmf_invs_lift[ADT_IF_Refine_assms]:
+    "\<lbrakk> \<And>s m. P (s\<lparr>ksMachineState := ksMachineState s\<lparr>machine_state_rest := m\<rparr>\<rparr>) = P s \<rbrakk>
+       \<Longrightarrow> \<lbrace>P\<rbrace> handleVMFault t hf \<lbrace>\<lambda>_ _. True\<rbrace>, \<lbrace>\<lambda>_. P\<rbrace>"
+  by (rule hv_inv_ex')
+
+definition handleHypervisorFault_C_body_if :: "machine_word \<Rightarrow> (globals myvars, int, strictc_errortype) com"
+  where
+  "handleHypervisorFault_C_body_if hyp_fault_type ==
+     (SKIP ;; \<acute>ret__unsigned_long :== scast EXCEPTION_NONE)"
+
+definition hyp_fault_type_from_H :: "hyp_fault_type \<Rightarrow> machine_word" where
+  "hyp_fault_type_from_H fault \<equiv> undefined"
+
+lemma handleHypervisorFault_C_body_ccorres[ADT_IF_Refine_assms]:
+  "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
+            (invs' and arch_extras and ct_running' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)) UNIV []
+            (liftE (do thread <- getCurThread;
+                       handleHypervisorFault thread flt
+                    od))
+            (handleHypervisorFault_C_body_if (hyp_fault_type_from_H flt))"
+  apply (case_tac flt)
+  apply (simp add: liftE_def bind_assoc handleHypervisorFault_def handleHypervisorFault_C_body_if_def)
+  apply (rule ccorres_guard_imp)
+    apply (rule ccorres_pre_getCurThread)
+    apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
+    apply (rule allI, rule conseqPre, vcg)
+    apply (auto simp: return_def)
+  done
+
 end
 
 
-sublocale kernel_m \<subseteq> ADT_IF_Refine_1?: ADT_IF_Refine_1 _ _ _ doUserOp_C_if
+sublocale kernel_m \<subseteq> ADT_IF_Refine_1?: ADT_IF_Refine_1 _ _ _ doUserOp_C_if handleHypervisorFault_C_body_if hyp_fault_type_from_H
 proof goal_cases
   interpret Arch .
   case 1 show ?case

--- a/proof/infoflow/refine/InfoFlowC_Image_Toplevel.thy
+++ b/proof/infoflow/refine/InfoFlowC_Image_Toplevel.thy
@@ -1,0 +1,17 @@
+(*
+ * Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ *)
+
+(* This theory serves as a top-level theory for testing InfoFlowC.
+   It should import everything that we want tested as part of building the
+   InfoFlowC image.
+*)
+
+theory InfoFlowC_Image_Toplevel
+imports
+  Noninterference_Refinement
+  Example_Valid_StateH
+begin
+end

--- a/proof/infoflow/refine/RISCV64/ArchADT_IF_Refine_C.thy
+++ b/proof/infoflow/refine/RISCV64/ArchADT_IF_Refine_C.thy
@@ -12,25 +12,6 @@ context kernel_m begin
 
 named_theorems ADT_IF_Refine_assms
 
-lemma handleInterrupt_ccorres[ADT_IF_Refine_assms]:
-  "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
-           (invs')
-           (UNIV)
-           []
-           (handleEvent Interrupt)
-           (handleInterruptEntry_C_body_if)"
-  apply (rule ccorres_guard_imp2)
-   apply (simp add: handleEvent_def minus_one_norm handleInterruptEntry_C_body_if_def)
-   apply (rule ccorres_add_return2)
-   apply (ctac (no_vcg) add: checkInterrupt_ccorres)
-    apply (rule_tac R="\<lambda>_. rv = Inr ()" in ccorres_return[where R'=UNIV])
-    apply (rule conseqPre, vcg)
-    apply (clarsimp simp: return_def)
-   apply (simp add: liftE_def)
-   apply wpsimp
-  apply clarsimp
-  done
-
 lemma handleInvocation_ccorres'[ADT_IF_Refine_assms]:
   "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
        (invs' and arch_extras and ct_active' and sch_act_simple)
@@ -224,10 +205,91 @@ lemma obs_cpspace_user_data_relation[ADT_IF_Refine_assms]:
   apply simp
   done
 
+lemma irqInvalid_eq[simp]:
+  "ucast irqInvalid = scast Kernel_C.irqInvalid"
+  by (simp add: irqInvalid_def Kernel_C.irqInvalid_def)
+
+lemma handleSpuriousIRQ_ccorres:
+  "ccorres dc xfdc \<top> UNIV [] handleSpuriousIRQ (Call handleSpuriousIRQ_'proc)"
+  apply (simp add: handleSpuriousIRQ_def)
+  apply (rule ccorres_from_vcg)
+  apply (rule allI, rule conseqPre, vcg)
+  apply (clarsimp simp: return_def)
+  done
+
+lemma dmo_getActiveIRQ_inKernel_sch_act_not:
+  "\<lbrace>\<lambda>s. \<not>inKernel \<longrightarrow> sch_act_not (ksCurThread s) s\<rbrace>
+   doMachineOp (getActiveIRQ inKernel)
+   \<lbrace>\<lambda>rv s. \<forall>irq. rv = Some irq \<longrightarrow> irq \<in> non_kernel_IRQs \<longrightarrow> sch_act_not (ksCurThread s) s\<rbrace>"
+  unfolding doMachineOp_def
+  apply (cases inKernel; wpsimp)
+  apply (drule use_valid, rule getActiveIRQ_neq_non_kernel, rule TrueI)
+  apply clarsimp
+  done
+
+lemma checkInterrupt_ccorres'[ADT_IF_Refine_assms]:
+  "ccorres dc xfdc (\<lambda>s. invs' s \<and> (\<not>inKernel \<longrightarrow> sch_act_not (ksCurThread s) s)) UNIV []
+           (maybeHandleInterrupt inKernel) (Call checkInterrupt_'proc)"
+  unfolding maybeHandleInterrupt_def
+  apply cinit'
+  apply (rule ccorres_guard_imp)
+    apply (simp add: liftE_def bind_assoc)
+    apply (ctac (no_vcg) add: getActiveIRQ_ccorres)
+         apply (rule_tac P="\<lambda>_. rv \<noteq> None" and R=\<top> in ccorres_cond_both)
+           apply (auto split: option.splits)[1]
+          apply (rule_tac P="rv \<noteq> None" in ccorres_gen_asm)
+          apply clarsimp
+          apply wpfix
+          apply (rule ccorres_call[where xf'=xfdc, OF handleInterrupt_ccorres]; simp)
+         apply (rule_tac P="rv = None" in ccorres_gen_asm)
+         apply clarsimp
+         apply wpfix
+         apply (ctac (no_vcg) add: handleSpuriousIRQ_ccorres)
+      apply wp
+     apply (simp add: guard_is_UNIV_def)
+    apply (rule_tac Q'="\<lambda>rv s. invs' s \<and> (\<forall>irq. rv = Some irq \<longrightarrow> irq \<in> non_kernel_IRQs \<longrightarrow>
+                                                sch_act_not (ksCurThread s) s)"
+                    in hoare_post_imp)
+     apply (solves clarsimp)
+    apply (wpsimp wp: dmo_getActiveIRQ_inKernel_sch_act_not)
+    apply assumption
+   apply assumption
+  apply (clarsimp simp: invs'_def valid_state'_def)
+  done
+
+lemma hvmf_invs_lift[ADT_IF_Refine_assms]:
+    "\<lbrakk> \<And>s m. P (s\<lparr>ksMachineState := ksMachineState s\<lparr>machine_state_rest := m\<rparr>\<rparr>) = P s \<rbrakk>
+       \<Longrightarrow> \<lbrace>P\<rbrace> handleVMFault t hf \<lbrace>\<lambda>_ _. True\<rbrace>, \<lbrace>\<lambda>_. P\<rbrace>"
+  by (rule hv_inv_ex')
+
+definition handleHypervisorFault_C_body_if :: "64 word \<Rightarrow> (globals myvars, int, strictc_errortype) com"
+  where
+  "handleHypervisorFault_C_body_if hyp_fault_type ==
+     (SKIP ;; \<acute>ret__unsigned_long :== scast EXCEPTION_NONE)"
+
+definition hyp_fault_type_from_H :: "hyp_fault_type \<Rightarrow> machine_word" where
+  "hyp_fault_type_from_H fault \<equiv> undefined"
+
+lemma handleHypervisorFault_C_body_ccorres[ADT_IF_Refine_assms]:
+  "ccorres (K dc \<currency> dc) (liftxf errstate id (K ()) ret__unsigned_long_')
+            (invs' and arch_extras and ct_running' and (\<lambda>s. ksSchedulerAction s = ResumeCurrentThread)) UNIV []
+            (liftE (do thread <- getCurThread;
+                       handleHypervisorFault thread flt
+                    od))
+            (handleHypervisorFault_C_body_if (hyp_fault_type_from_H flt))"
+  apply (case_tac flt)
+  apply (simp add: liftE_def bind_assoc handleHypervisorFault_def handleHypervisorFault_C_body_if_def)
+  apply (rule ccorres_guard_imp)
+    apply (rule ccorres_pre_getCurThread)
+    apply (rule_tac P=\<top> and P'=UNIV in ccorres_from_vcg)
+    apply (rule allI, rule conseqPre, vcg)
+    apply (auto simp: return_def)
+  done
+
 end
 
 
-sublocale kernel_m \<subseteq> ADT_IF_Refine_1?: ADT_IF_Refine_1 _ _ _ doUserOp_C_if
+sublocale kernel_m \<subseteq> ADT_IF_Refine_1?: ADT_IF_Refine_1 _ _ _ doUserOp_C_if handleHypervisorFault_C_body_if hyp_fault_type_from_H
 proof goal_cases
   interpret Arch .
   case 1 show ?case

--- a/run_tests
+++ b/run_tests
@@ -64,7 +64,6 @@ EXCLUDE["RISCV64"]=[
 EXCLUDE["AARCH64"]=[
     # To be eliminated/refined as development progresses
     "ASepSpec",
-    "InfoFlow",
 
     # Tools and unrelated content, removed for development
     "AutoCorres",


### PR DESCRIPTION
Make ArchArch_IF.thy pass `isabelle build` by fix two occurrences of `bit1.pred` -> `bit0.pred` in `vs_lookup_split_Some` calls within `pt_walk_reads_equiv` (line 331) and `pt_lookup_from_level_reads_respects` (line 356).