### PR TITLE
arm-hyp+aarch64: sync VCPU context switching

### DIFF
--- a/proof/crefine/AARCH64/ArchMove_C.thy
+++ b/proof/crefine/AARCH64/ArchMove_C.thy
@@ -471,10 +471,9 @@ crunch readVCPUReg
 crunch readVCPUReg
   for ksCurThread[wp]: "\<lambda>s. P (ksCurThread s)"
 
-(* schematic_goal leads to Suc (Suc ..) form only *)
-lemma fromEnum_maxBound_vcpureg_def:
-  "fromEnum (maxBound :: vcpureg) = 23"
-  by (clarsimp simp: fromEnum_def maxBound_def enum_vcpureg)
+schematic_goal fromEnum_maxBound_vcpureg_def:
+  "fromEnum (maxBound :: vcpureg) = numeral ?n"
+  by (simp add: fromEnum_def maxBound_def enum_vcpureg flip: One_nat_def)
 
 lemma unat_of_nat_mword_fromEnum_vcpureg[simp]:
   "unat ((of_nat (fromEnum e)) :: machine_word) = fromEnum (e :: vcpureg)"

--- a/proof/crefine/AARCH64/SR_lemmas_C.thy
+++ b/proof/crefine/AARCH64/SR_lemmas_C.thy
@@ -2376,7 +2376,7 @@ lemmas seL4_VCPUReg_defs =
   seL4_VCPUReg_AFSR1_def
   seL4_VCPUReg_ESR_def
   seL4_VCPUReg_FAR_def
-  seL4_VCPUReg_ISR_def
+  seL4_VCPUReg_PAR_def
   seL4_VCPUReg_VBAR_def
   seL4_VCPUReg_TPIDR_EL1_def
   seL4_VCPUReg_VMPIDR_EL2_def

--- a/proof/crefine/ARM_HYP/ArchMove_C.thy
+++ b/proof/crefine/ARM_HYP/ArchMove_C.thy
@@ -432,10 +432,9 @@ crunch readVCPUReg
 crunch readVCPUReg
   for ksCurThread[wp]: "\<lambda>s. P (ksCurThread s)"
 
-(* schematic_goal leads to Suc (Suc ..) form only *)
-lemma fromEnum_maxBound_vcpureg_def:
-  "fromEnum (maxBound :: vcpureg) = 43"
-  by (clarsimp simp: fromEnum_def maxBound_def enum_vcpureg)
+schematic_goal fromEnum_maxBound_vcpureg_def:
+  "fromEnum (maxBound :: vcpureg) = numeral ?n"
+  by (simp add: fromEnum_def maxBound_def enum_vcpureg flip: One_nat_def)
 
 lemma unat_of_nat_mword_fromEnum_vcpureg[simp]:
   "unat ((of_nat (fromEnum e)) :: machine_word) = fromEnum (e :: vcpureg)"

--- a/spec/abstract/ARM_HYP/ArchVSpace_A.thy
+++ b/spec/abstract/ARM_HYP/ArchVSpace_A.thy
@@ -523,7 +523,7 @@ where
                   od)
             gicIndices;
 
-          vcpu_save_reg_range vr VCPURegACTLR VCPURegSPSRfiq;
+          vcpu_save_reg_range vr VCPURegACTLR VCPURegPARlow;
           do_machine_op isb
        od
      | _ \<Rightarrow> fail"
@@ -546,7 +546,7 @@ where
               (map (\<lambda>i. (i, (vgic_lr vgic) i)) gicIndices)
      od;
     \<comment> \<open>restore banked VCPU registers except SCTLR (that's in VCPUEnable)\<close>
-     vcpu_restore_reg_range vr VCPURegACTLR VCPURegSPSRfiq;
+     vcpu_restore_reg_range vr VCPURegACTLR VCPURegPARlow;
      vcpu_enable vr
   od"
 

--- a/spec/haskell/src/SEL4/Machine/RegisterSet/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Machine/RegisterSet/AARCH64.hs
@@ -83,7 +83,7 @@ data VCPUReg =
     | VCPURegAFSR1
     | VCPURegESR
     | VCPURegFAR
-    | VCPURegISR
+    | VCPURegPAR
     | VCPURegVBAR
     | VCPURegTPIDR_EL1
     | VCPURegVMPIDR_EL2

--- a/spec/haskell/src/SEL4/Machine/RegisterSet/ARM.lhs
+++ b/spec/haskell/src/SEL4/Machine/RegisterSet/ARM.lhs
@@ -87,6 +87,8 @@ This module defines the ARM register set.
 >     | VCPURegSPSRund
 >     | VCPURegSPSRirq
 >     | VCPURegSPSRfiq
+>     | VCPURegPARhigh
+>     | VCPURegPARlow
 >     | VCPURegCNTV_CTL
 >     | VCPURegCNTV_CVALhigh
 >     | VCPURegCNTV_CVALlow

--- a/spec/haskell/src/SEL4/Object/VCPU/ARM.lhs
+++ b/spec/haskell/src/SEL4/Object/VCPU/ARM.lhs
@@ -398,7 +398,7 @@ For initialisation, see makeVCPUObject.
 
 > armvVCPUSave :: PPtr VCPU -> Bool -> Kernel ()
 > armvVCPUSave vcpuPtr active = do
->     vcpuSaveRegRange vcpuPtr VCPURegACTLR VCPURegSPSRfiq
+>     vcpuSaveRegRange vcpuPtr VCPURegACTLR VCPURegPARlow
 >     doMachineOp isb
 
 > vcpuSave :: Maybe (PPtr VCPU, Bool) -> Kernel ()
@@ -447,7 +447,7 @@ For initialisation, see makeVCPUObject.
 >         mapM_ (uncurry set_gic_vcpu_ctrl_lr) (map (\i -> (fromIntegral i, (vgicLR vgic) ! i)) gicIndices)
 >
 >     -- restore banked VCPU registers except SCTLR (that's in VCPUEnable)
->     vcpuRestoreRegRange vcpuPtr VCPURegACTLR VCPURegSPSRfiq
+>     vcpuRestoreRegRange vcpuPtr VCPURegACTLR VCPURegPARlow
 >
 >     vcpuEnable vcpuPtr
 


### PR DESCRIPTION
Minor spec tweak and trivial proof update to sync VCPU context switching with seL4 PR seL4/seL4#1318:

- context switch PAR on AArch64 and PARhigh/PARlow on AArch32
- remove ISR from VCPU context switch, because it is read only

Test with: https://github.com/seL4/seL4/pull/1318