### PR TITLE
arm+arm-hyp+aarch64 spec+proof: additional dsb for doFlush/Unify

### DIFF
--- a/proof/crefine/AARCH64/Arch_C.thy
+++ b/proof/crefine/AARCH64/Arch_C.thy
@@ -1631,10 +1631,11 @@ lemma doFlush_ccorres:
    apply (ctac (no_vcg) add: cleanCacheRange_PoU_ccorres)
     apply (ctac (no_vcg) add: dsb_ccorres)
      apply (ctac (no_vcg) add: invalidateCacheRange_I_ccorres)
-      apply (ctac (no_vcg) add: isb_ccorres)
-     apply wp+
-   apply (fastforce simp: flushtype_relation_def
-                          sel4_arch_invocation_label_defs arch_invocation_label_defs)
+      apply (ctac (no_vcg) add: dsb_ccorres)
+       apply (ctac (no_vcg) add: isb_ccorres)
+      apply wp+
+  apply (fastforce simp: flushtype_relation_def
+                         sel4_arch_invocation_label_defs arch_invocation_label_defs)
   done
 
 (* The precondition is slightly different here to ARM/ARM_HYP, because we're flushing on kernel

--- a/proof/crefine/ARM/VSpace_C.thy
+++ b/proof/crefine/ARM/VSpace_C.thy
@@ -1597,16 +1597,16 @@ lemma doFlush_ccorres:
      apply (rule ccorres_cond_false)
      apply (rule ccorres_cond_false)
      apply (rule ccorres_cond_true)
-     apply (simp add: empty_fail_cond empty_fail_cleanCacheRange_PoU empty_fail_dsb
-                      empty_fail_invalidateCacheRange_I empty_fail_branchFlushRange empty_fail_isb
+     apply (simp add: empty_fail_cond empty_fail_dsb empty_fail_isb
                       doMachineOp_bind)
      apply (rule ccorres_rhs_assoc)+
      apply (ctac (no_vcg) add: cleanCacheRange_PoU_ccorres)
       apply (ctac (no_vcg) add: dsb_ccorres)
        apply (ctac (no_vcg) add: invalidateCacheRange_I_ccorres)
         apply (ctac (no_vcg) add: branchFlushRange_ccorres)
-         apply (ctac (no_vcg) add: isb_ccorres)
-        apply wp+
+         apply (ctac (no_vcg) add: dsb_ccorres)
+          apply (ctac (no_vcg) add: isb_ccorres)
+         apply wp+
     apply simp
    apply (clarsimp simp: Collect_const_mem)
   apply (auto simp: flushtype_relation_def

--- a/proof/crefine/ARM_HYP/VSpace_C.thy
+++ b/proof/crefine/ARM_HYP/VSpace_C.thy
@@ -2811,8 +2811,9 @@ lemma doFlush_ccorres:
     apply (ctac (no_vcg) add: dsb_ccorres)
      apply (ctac (no_vcg) add: invalidateCacheRange_I_ccorres)
       apply (ctac (no_vcg) add: branchFlushRange_ccorres)
-       apply (ctac (no_vcg) add: isb_ccorres)
-      apply wp+
+       apply (ctac (no_vcg) add: dsb_ccorres)
+        apply (ctac (no_vcg) add: isb_ccorres)
+       apply wp+
   apply (clarsimp simp: Collect_const_mem)
   apply (auto simp: flushtype_relation_def o_def
                         Kernel_C.ARMPageClean_Data_def Kernel_C.ARMPDClean_Data_def

--- a/spec/abstract/AARCH64/Arch_A.thy
+++ b/spec/abstract/AARCH64/Arch_A.thy
@@ -126,6 +126,7 @@ definition do_flush :: "flush_type \<Rightarrow> vspace_ref \<Rightarrow> vspace
          cleanCacheRange_PoU vstart vend pstart;
          dsb;
          invalidateCacheRange_I vstart vend pstart;
+         dsb;
          isb
        od"
 

--- a/spec/abstract/ARM/ArchVSpace_A.thy
+++ b/spec/abstract/ARM/ArchVSpace_A.thy
@@ -400,6 +400,7 @@ do_flush :: "flush_type \<Rightarrow> vspace_ref \<Rightarrow> vspace_ref \<Righ
          dsb;
          invalidateCacheRange_I vstart vend pstart;
          branchFlushRange vstart vend pstart;
+         dsb;
          isb
      od"
 

--- a/spec/abstract/ARM_HYP/ArchVSpace_A.thy
+++ b/spec/abstract/ARM_HYP/ArchVSpace_A.thy
@@ -747,6 +747,7 @@ do_flush :: "flush_type \<Rightarrow> vspace_ref \<Rightarrow> vspace_ref \<Righ
          dsb;
          invalidateCacheRange_I vstart' vend' pstart;
          branchFlushRange vstart' vend' pstart;
+         dsb;
          isb
      od)"
 

--- a/spec/haskell/src/SEL4/Kernel/VSpace/AARCH64.hs
+++ b/spec/haskell/src/SEL4/Kernel/VSpace/AARCH64.hs
@@ -263,6 +263,7 @@ doFlush flushType vstart vend pstart =
                                cleanCacheRange_PoU vstart vend pstart
                                dsb
                                invalidateCacheRange_I vstart vend pstart
+                               dsb
                                isb
 
 {- Unmapping and Deletion -}

--- a/spec/haskell/src/SEL4/Kernel/VSpace/ARM.lhs
+++ b/spec/haskell/src/SEL4/Kernel/VSpace/ARM.lhs
@@ -1105,6 +1105,7 @@ FIXME ARMHYP TODO unify hyp/non-hyp to share more code
 >                      dsb
 >                      invalidateCacheRange_I vstart' vend' pstart
 >                      branchFlushRange vstart' vend' pstart
+>                      dsb
 >                      isb
 >     where vstart' = VPtr $ fromPPtr $ ptrFromPAddr pstart
 >           vend' = vstart' + (vend - vstart)
@@ -1121,6 +1122,7 @@ FIXME ARMHYP TODO unify hyp/non-hyp to share more code
 >     dsb
 >     invalidateCacheRange_I vstart vend pstart
 >     branchFlushRange vstart vend pstart
+>     dsb
 >     isb
 #endif
 


### PR DESCRIPTION
seL4 PR seL4/seL4#1710 discovered missing `dsb` instructions in the cache flush path. Add these to the specs and proofs.

Test with: seL4/seL4#1710