### PR TITLE
crefine: adjust for ptr name mangling change

### DIFF
--- a/proof/crefine/AARCH64/Retype_C.thy
+++ b/proof/crefine/AARCH64/Retype_C.thy
@@ -203,13 +203,15 @@ lemma memzero_spec:
                                                (replicate (unat (n_' s - n_' t)) 0))
                                                       (t_hrs_' (globals s))\<rparr> }"
             and V1=undefined in subst [OF whileAnno_def])
+  apply (rename_tac s)
   apply vcg
     apply (clarsimp simp add: hrs_mem_update_def)
 
    apply clarsimp
-   apply (case_tac s, case_tac p___ptr_to_unsigned_char)
+   apply (rename_tac p n')
+   apply (case_tac s, case_tac p)
 
-   apply (subgoal_tac "8 \<le> unat na")
+   apply (subgoal_tac "8 \<le> unat n'")
     apply (intro conjI)
            apply (simp add: ptr_safe_def s_footprint_def s_footprint_untyped_def
                             typ_uinfo_t_def typ_info_word)
@@ -237,7 +239,7 @@ lemma memzero_spec:
     apply (subst to_bytes_machine_word_0)
     apply (rule heap_update_list_replicate)
      apply clarsimp
-    apply (rule_tac s="unat ((n - na) + 8)" in trans)
+    apply (rule_tac s="unat ((n - n') + 8)" in trans)
      apply (simp add: field_simps)
     apply (subst Word.unat_plus_simple[THEN iffD1])
      apply (rule is_aligned_no_overflow''[where n=3, simplified])
@@ -290,6 +292,7 @@ lemma memset_spec:
      apply (rule is_aligned_and_2_to_k, clarsimp simp: mask_def)
     apply (rule is_aligned_and_2_to_k, clarsimp simp: mask_def)
    apply clarsimp
+   apply (rename_tac p n')
    apply (intro conjI)
         apply (simp add: ptr_safe_def s_footprint_def s_footprint_untyped_def
                          typ_uinfo_t_def typ_info_word)
@@ -306,14 +309,14 @@ lemma memset_spec:
         apply assumption
        apply (erule order_trans [rotated])
        apply (simp add: lt1_neq0)
-      apply (case_tac p___ptr_to_unsigned_char, simp add: CTypesDefs.ptr_add_def unat_minus_one field_simps)
+      apply (case_tac p, simp add: CTypesDefs.ptr_add_def unat_minus_one field_simps)
      apply (metis word_must_wrap word_not_simps(1) linear)
     apply (erule order_trans[rotated])
     apply (clarsimp simp: ptr_val_case split: ptr.splits)
     apply (erule subsetD[OF intvl_sub_offset, rotated])
     apply (simp add: unat_sub word_le_nat_alt word_less_nat_alt)
    apply (clarsimp simp: ptr_val_case unat_minus_one hrs_mem_update_def split: ptr.splits)
-   apply (subgoal_tac "unat (n - (na - 1)) = Suc (unat (n - na))")
+   apply (subgoal_tac "unat (n - (n' - 1)) = Suc (unat (n - n'))")
     apply (erule ssubst, subst replicate_Suc_append)
     apply (subst heap_update_list_append)
     apply (simp add: heap_update_word8)

--- a/proof/crefine/ARM/Retype_C.thy
+++ b/proof/crefine/ARM/Retype_C.thy
@@ -161,9 +161,10 @@ lemma memzero_spec:
     apply (clarsimp simp add: hrs_mem_update_def)
 
    apply clarsimp
-   apply (case_tac s, case_tac p___ptr_to_unsigned_char)
+   apply (rename_tac p n')
+   apply (case_tac s, case_tac p)
 
-   apply (subgoal_tac "4 \<le> unat na")
+   apply (subgoal_tac "4 \<le> unat n'")
     apply (intro conjI)
            apply (simp add: ptr_safe_def s_footprint_def s_footprint_untyped_def
                             typ_uinfo_t_def typ_info_word)
@@ -191,7 +192,7 @@ lemma memzero_spec:
     apply (subst to_bytes_word32_0)
     apply (rule heap_update_list_replicate)
      apply clarsimp
-    apply (rule_tac s="unat ((n - na) + 4)" in trans)
+    apply (rule_tac s="unat ((n - n') + 4)" in trans)
      apply (simp add: field_simps)
     apply (subst Word.unat_plus_simple[THEN iffD1])
      apply (rule is_aligned_no_overflow''[where n=2, simplified])
@@ -250,6 +251,7 @@ lemma memset_spec:
      apply (rule is_aligned_and_2_to_k, clarsimp simp: mask_def)
     apply (rule is_aligned_and_2_to_k, clarsimp simp: mask_def)
    apply clarsimp
+   apply (rename_tac p n')
    apply (intro conjI)
         apply (simp add: ptr_safe_def s_footprint_def s_footprint_untyped_def
                          typ_uinfo_t_def typ_info_word)
@@ -266,14 +268,14 @@ lemma memset_spec:
         apply assumption
        apply (erule order_trans [rotated])
        apply (simp add: lt1_neq0)
-      apply (case_tac p___ptr_to_unsigned_char, simp add: CTypesDefs.ptr_add_def unat_minus_one field_simps)
+      apply (case_tac p, simp add: CTypesDefs.ptr_add_def unat_minus_one field_simps)
      apply (metis word_must_wrap word_not_simps(1) linear)
     apply (erule order_trans[rotated])
     apply (clarsimp simp: ptr_val_case split: ptr.splits)
     apply (erule subsetD[OF intvl_sub_offset, rotated])
     apply (simp add: unat_sub word_le_nat_alt word_less_nat_alt)
    apply (clarsimp simp: ptr_val_case unat_minus_one hrs_mem_update_def split: ptr.splits)
-   apply (subgoal_tac "unat (n - (na - 1)) = Suc (unat (n - na))")
+   apply (subgoal_tac "unat (n - (n' - 1)) = Suc (unat (n - n'))")
     apply (erule ssubst, subst replicate_Suc_append)
     apply (subst heap_update_list_append)
     apply (simp add: heap_update_word8)

--- a/proof/crefine/ARM_HYP/Retype_C.thy
+++ b/proof/crefine/ARM_HYP/Retype_C.thy
@@ -187,9 +187,10 @@ lemma memzero_spec:
     apply (clarsimp simp add: hrs_mem_update_def)
 
    apply clarsimp
-   apply (case_tac s, case_tac p___ptr_to_unsigned_char)
+   apply (rename_tac p n')
+   apply (case_tac s, case_tac p)
 
-   apply (subgoal_tac "4 \<le> unat na")
+   apply (subgoal_tac "4 \<le> unat n'")
     apply (intro conjI)
            apply (simp add: ptr_safe_def s_footprint_def s_footprint_untyped_def
                             typ_uinfo_t_def typ_info_word)
@@ -217,7 +218,7 @@ lemma memzero_spec:
     apply (subst to_bytes_word32_0)
     apply (rule heap_update_list_replicate)
      apply clarsimp
-    apply (rule_tac s="unat ((n - na) + 4)" in trans)
+    apply (rule_tac s="unat ((n - n') + 4)" in trans)
      apply (simp add: field_simps)
     apply (subst Word.unat_plus_simple[THEN iffD1])
      apply (rule is_aligned_no_overflow''[where n=2, simplified])
@@ -264,6 +265,7 @@ lemma memset_spec:
      apply (rule is_aligned_and_2_to_k, clarsimp simp: mask_def)
     apply (rule is_aligned_and_2_to_k, clarsimp simp: mask_def)
    apply clarsimp
+   apply (rename_tac p n')
    apply (intro conjI)
         apply (simp add: ptr_safe_def s_footprint_def s_footprint_untyped_def
                          typ_uinfo_t_def typ_info_word)
@@ -280,14 +282,14 @@ lemma memset_spec:
         apply assumption
        apply (erule order_trans [rotated])
        apply (simp add: lt1_neq0)
-      apply (case_tac p___ptr_to_unsigned_char, simp add: CTypesDefs.ptr_add_def unat_minus_one field_simps)
+      apply (case_tac p, simp add: CTypesDefs.ptr_add_def unat_minus_one field_simps)
      apply (metis word_must_wrap word_not_simps(1) linear)
     apply (erule order_trans[rotated])
     apply (clarsimp simp: ptr_val_case split: ptr.splits)
     apply (erule subsetD[OF intvl_sub_offset, rotated])
     apply (simp add: unat_sub word_le_nat_alt word_less_nat_alt)
    apply (clarsimp simp: ptr_val_case unat_minus_one hrs_mem_update_def split: ptr.splits)
-   apply (subgoal_tac "unat (n - (na - 1)) = Suc (unat (n - na))")
+   apply (subgoal_tac "unat (n - (n' - 1)) = Suc (unat (n - n'))")
     apply (erule ssubst, subst replicate_Suc_append)
     apply (subst heap_update_list_append)
     apply (simp add: heap_update_word8)

--- a/proof/crefine/RISCV64/Retype_C.thy
+++ b/proof/crefine/RISCV64/Retype_C.thy
@@ -203,13 +203,15 @@ lemma memzero_spec:
                                                (replicate (unat (n_' s - n_' t)) 0))
                                                       (t_hrs_' (globals s))\<rparr> }"
             and V1=undefined in subst [OF whileAnno_def])
+  apply (rename_tac s)
   apply vcg
     apply (clarsimp simp add: hrs_mem_update_def)
 
    apply clarsimp
-   apply (case_tac s, case_tac p___ptr_to_unsigned_char)
+   apply (rename_tac p n')
+   apply (case_tac s, case_tac p)
 
-   apply (subgoal_tac "8 \<le> unat na")
+   apply (subgoal_tac "8 \<le> unat n'")
     apply (intro conjI)
            apply (simp add: ptr_safe_def s_footprint_def s_footprint_untyped_def
                             typ_uinfo_t_def typ_info_word)
@@ -237,7 +239,7 @@ lemma memzero_spec:
     apply (subst to_bytes_machine_word_0)
     apply (rule heap_update_list_replicate)
      apply clarsimp
-    apply (rule_tac s="unat ((n - na) + 8)" in trans)
+    apply (rule_tac s="unat ((n - n') + 8)" in trans)
      apply (simp add: field_simps)
     apply (subst Word.unat_plus_simple[THEN iffD1])
      apply (rule is_aligned_no_overflow''[where n=3, simplified])
@@ -290,6 +292,7 @@ lemma memset_spec:
      apply (rule is_aligned_and_2_to_k, clarsimp simp: mask_def)
     apply (rule is_aligned_and_2_to_k, clarsimp simp: mask_def)
    apply clarsimp
+   apply (rename_tac p n')
    apply (intro conjI)
         apply (simp add: ptr_safe_def s_footprint_def s_footprint_untyped_def
                          typ_uinfo_t_def typ_info_word)
@@ -306,14 +309,14 @@ lemma memset_spec:
         apply assumption
        apply (erule order_trans [rotated])
        apply (simp add: lt1_neq0)
-      apply (case_tac p___ptr_to_unsigned_char, simp add: CTypesDefs.ptr_add_def unat_minus_one field_simps)
+      apply (case_tac p, simp add: CTypesDefs.ptr_add_def unat_minus_one field_simps)
      apply (metis word_must_wrap word_not_simps(1) linear)
     apply (erule order_trans[rotated])
     apply (clarsimp simp: ptr_val_case split: ptr.splits)
     apply (erule subsetD[OF intvl_sub_offset, rotated])
     apply (simp add: unat_sub word_le_nat_alt word_less_nat_alt)
    apply (clarsimp simp: ptr_val_case unat_minus_one hrs_mem_update_def split: ptr.splits)
-   apply (subgoal_tac "unat (n - (na - 1)) = Suc (unat (n - na))")
+   apply (subgoal_tac "unat (n - (n' - 1)) = Suc (unat (n - n'))")
     apply (erule ssubst, subst replicate_Suc_append)
     apply (subst heap_update_list_append)
     apply (simp add: heap_update_word8)

--- a/proof/crefine/X64/Retype_C.thy
+++ b/proof/crefine/X64/Retype_C.thy
@@ -203,13 +203,15 @@ lemma memzero_spec:
                                                (replicate (unat (n_' s - n_' t)) 0))
                                                       (t_hrs_' (globals s))\<rparr> }"
             and V1=undefined in subst [OF whileAnno_def])
+  apply (rename_tac s)
   apply vcg
     apply (clarsimp simp add: hrs_mem_update_def)
 
    apply clarsimp
-   apply (case_tac s, case_tac p___ptr_to_unsigned_char)
+   apply (rename_tac p n')
+   apply (case_tac s, case_tac p)
 
-   apply (subgoal_tac "8 \<le> unat na")
+   apply (subgoal_tac "8 \<le> unat n'")
     apply (intro conjI)
            apply (simp add: ptr_safe_def s_footprint_def s_footprint_untyped_def
                             typ_uinfo_t_def typ_info_word)
@@ -237,7 +239,7 @@ lemma memzero_spec:
     apply (subst to_bytes_machine_word_0)
     apply (rule heap_update_list_replicate)
      apply clarsimp
-    apply (rule_tac s="unat ((n - na) + 8)" in trans)
+    apply (rule_tac s="unat ((n - n') + 8)" in trans)
      apply (simp add: field_simps)
     apply (subst Word.unat_plus_simple[THEN iffD1])
      apply (rule is_aligned_no_overflow''[where n=3, simplified])
@@ -290,6 +292,7 @@ lemma memset_spec:
      apply (rule is_aligned_and_2_to_k, clarsimp simp: mask_def)
     apply (rule is_aligned_and_2_to_k, clarsimp simp: mask_def)
    apply clarsimp
+   apply (rename_tac p n')
    apply (intro conjI)
         apply (simp add: ptr_safe_def s_footprint_def s_footprint_untyped_def
                          typ_uinfo_t_def typ_info_word)
@@ -306,14 +309,14 @@ lemma memset_spec:
         apply assumption
        apply (erule order_trans [rotated])
        apply (simp add: lt1_neq0)
-      apply (case_tac p___ptr_to_unsigned_char, simp add: CTypesDefs.ptr_add_def unat_minus_one field_simps)
+      apply (case_tac p, simp add: CTypesDefs.ptr_add_def unat_minus_one field_simps)
      apply (metis word_must_wrap word_not_simps(1) linear)
     apply (erule order_trans[rotated])
     apply (clarsimp simp: ptr_val_case split: ptr.splits)
     apply (erule subsetD[OF intvl_sub_offset, rotated])
     apply (simp add: unat_sub word_le_nat_alt word_less_nat_alt)
    apply (clarsimp simp: ptr_val_case unat_minus_one hrs_mem_update_def split: ptr.splits)
-   apply (subgoal_tac "unat (n - (na - 1)) = Suc (unat (n - na))")
+   apply (subgoal_tac "unat (n - (n' - 1)) = Suc (unat (n - n'))")
     apply (erule ssubst, subst replicate_Suc_append)
     apply (subst heap_update_list_append)
     apply (simp add: heap_update_word8)


### PR DESCRIPTION
seL4 PR seL4/seL4#728 removes a use of the pointer name `p` under a different type and changes the mangled name.

While this was already robust for references in Simpl, the pointer name produced by vcg was still dependent on order and other types, because people relied and generated names and not use rename_tac.

Make this robust against internal name changes as it should have been for the start.

Test with: seL4/seL4#728

(this should also work with current master)