### PR TITLE
arm spec+proof: stale cap check for PageFlush

### DIFF
--- a/lib/Monads/nondet/Nondet_Lemmas.thy
+++ b/lib/Monads/nondet/Nondet_Lemmas.thy
@@ -115,27 +115,35 @@ lemma whenE_True_bind[simp]:
   by (simp add: whenE_def bindE_def returnOk_def lift_def)
 
 lemma when_True[simp]:
-  "when True X = X"
+  "when True m = m"
   by (clarsimp simp: when_def)
 
 lemma when_False[simp]:
-  "when False X = return ()"
+  "when False m = return ()"
   by (clarsimp simp: when_def)
 
+lemma whenE_True[simp]:
+  "whenE True m = m"
+  by (clarsimp simp: whenE_def)
+
+lemma whenE_False[simp]:
+  "whenE False m = returnOk ()"
+  by (clarsimp simp: whenE_def)
+
 lemma unless_False[simp]:
-  "unless False X = X"
+  "unless False m = m"
   by (clarsimp simp: unless_def)
 
 lemma unlessE_False[simp]:
-  "unlessE False f = f"
+  "unlessE False m = m"
   unfolding unlessE_def by fastforce
 
 lemma unless_True[simp]:
-  "unless True X = return ()"
+  "unless True m = return ()"
   by (clarsimp simp: unless_def)
 
 lemma unlessE_True[simp]:
-  "unlessE True f = returnOk ()"
+  "unlessE True m = returnOk ()"
   unfolding unlessE_def by fastforce
 
 lemma unlessE_whenE:

--- a/lib/Monads/trace/Trace_Lemmas.thy
+++ b/lib/Monads/trace/Trace_Lemmas.thy
@@ -127,27 +127,35 @@ lemma whenE_True_bind[simp]:
   by (simp add: whenE_def bindE_def returnOk_def lift_def)
 
 lemma when_True[simp]:
-  "when True X = X"
+  "when True m = m"
   by (clarsimp simp: when_def)
 
 lemma when_False[simp]:
-  "when False X = return ()"
+  "when False m = return ()"
   by (clarsimp simp: when_def)
 
+lemma whenE_True[simp]:
+  "whenE True m = m"
+  by (clarsimp simp: whenE_def)
+
+lemma whenE_False[simp]:
+  "whenE False m = returnOk ()"
+  by (clarsimp simp: whenE_def)
+
 lemma unless_False[simp]:
-  "unless False X = X"
+  "unless False m = m"
   by (clarsimp simp: unless_def)
 
 lemma unlessE_False[simp]:
-  "unlessE False f = f"
+  "unlessE False m = m"
   unfolding unlessE_def by fastforce
 
 lemma unless_True[simp]:
-  "unless True X = return ()"
+  "unless True m = return ()"
   by (clarsimp simp: unless_def)
 
 lemma unlessE_True[simp]:
-  "unlessE True f = returnOk ()"
+  "unlessE True m = returnOk ()"
   unfolding unlessE_def by fastforce
 
 lemma unlessE_whenE:

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -2145,6 +2145,10 @@ where
                       x (to_option (to_bool \<circ> resolve_ret_C.valid_C) y)"
 
 
+lemma to_option_SomeD:
+  "to_option f x = Some y \<Longrightarrow> f x \<and> y = x"
+  by (simp add: to_option_def split: if_split_asm)
+
 lemma resolve_ret_rel_None[simp]:
   "resolve_ret_rel None y = (valid_C y = scast false)"
   by (clarsimp simp: resolve_ret_rel_def to_option_def to_bool_def split: if_splits)
@@ -2297,6 +2301,7 @@ lemma decodeARMFrameInvocation_ccorres:
        (Call decodeARMFrameInvocation_'proc)"
   supply if_cong[cong] option.case_cong[cong] tl_drop_1[simp]
   apply (clarsimp simp only: isCap_simps)
+  apply (rename_tac dev p rights vmsz m_opt)
   apply (cinit' lift: invLabel_' length___unsigned_long_' cte_' current_extra_caps_' cap_' buffer_' call_'
                 simp: decodeARMMMUInvocation_def decodeARMPageFlush_def)
    apply (simp add: Let_def isCap_simps invocation_eq_use_types split_def
@@ -2371,46 +2376,139 @@ lemma decodeARMFrameInvocation_ccorres:
          apply (ctac add: getSyscallArg_ccorres_foo[where args=args and n=0 and buffer=buffer])
            apply (rule ccorres_add_return)
            apply (ctac add: getSyscallArg_ccorres_foo[where args = args and n = 1 and buffer = buffer])
-             apply (simp only: if_to_top_of_bindE)
+             apply (simp only: if_to_top_of_bindE cong: ccorres_prog_only_cong)
              apply (rule ccorres_if_cond_throws[rotated -1,where Q = \<top> and Q' = \<top>])
                 apply vcg
                apply (clarsimp simp: hd_drop_conv_nth hd_conv_nth)
               apply (simp add: injection_handler_throwError)
               apply (rule syscall_error_throwError_ccorres_n)
               apply (simp add: syscall_error_to_H_cases)
-             apply (simp only: returnOk_bindE)
+             apply (simp only: returnOk_bindE injection_liftE liftE_bindE cong: ccorres_prog_only_cong)
              apply csymbr
              apply csymbr
              apply (rule ccorres_Guard_Seq)
              apply csymbr
              apply csymbr
              apply csymbr
-             apply (rule ccorres_if_cond_throws[rotated -1,where Q = \<top> and Q' = \<top>])
+             apply (ctac add: resolveVAddr_ccorres)
+               apply (rename_tac resolve_rv resolve_ret)
+               (* instantiate to enable case_tac for IF chain compiled from logical shortcut
+                  operator (valid || addr+size match) *)
+               apply (rule_tac P="\<lambda>s. tcb_at' thread s \<and> sch_act_simple s \<and> invs' s \<and>
+                                      st_tcb_at' (\<lambda>st'. tcb_st_refs_of' st' = {} \<and> st' \<noteq> Inactive \<and>
+                                                        st' \<noteq> IdleThreadState) thread s \<and>
+                                      thread \<noteq> ksIdleThread s \<and>
+                                      (obj_at' tcbQueued thread s \<longrightarrow> st_tcb_at' runnable' thread s) \<and>
+                                      fst (the m_opt) \<le> mask asid_bits \<and>
+                                      is_aligned p (pageBitsForSize vmsz) \<and>
+                                      hd args + snd (the m_opt) && mask cacheLineBits =
+                                        addrFromPPtr p + hd args && mask cacheLineBits \<and>
+                                      2 ^ pageBitsForSize vmsz \<le> gsMaxObjectSize s" and
+                               P'="\<lbrace>\<acute>ksCurThread = tcb_ptr_to_ctcb_ptr thread \<and>
+                                     flushtype_relation (labelToFlushType label) (ucast label)\<rbrace>"
+                               in ccorres_inst)
+               apply (case_tac resolve_rv; clarsimp)
+               (* not mapped (= resolve_ret not valid) *)
+                apply (simp add: injection_handler_throwError)
+                apply (rule ccorres_symb_exec_r2)
+                  (* SKIP case of first IF (= resolve_ret not valdid) *)
+                  apply (rule ccorres_cond_true_seq)
+                  apply ccorres_rewrite
+                  (* pass-through means exception (True) case of second IF *)
+                  apply (rule ccorres_cond_true_seq)
+                  apply ccorres_rewrite
+                  apply (rule ccorres_guard_imp)
+                    apply (rule syscall_error_throwError_ccorres_n)
+                    apply (simp add: syscall_error_to_H_cases)
+                   apply clarsimp
+                  apply assumption
+                 apply clarsimp
+                 apply vcg
+                 apply clarsimp
                 apply vcg
-               apply (clarsimp simp: hd_drop_conv_nth hd_conv_nth)
-               apply (clarsimp dest!: ccap_relation_PageCap_generics)
-              apply (simp add: injection_handler_throwError)
-              apply (rule syscall_error_throwError_ccorres_n)
-              apply (simp add: syscall_error_to_H_cases)
-             apply csymbr
-             apply csymbr
-             apply csymbr
-             apply (simp add: performARMMMUInvocations bindE_assoc)
-             apply (ctac add: setThreadState_ccorres)
-               apply (ctac(no_vcg) add: performPageFlush_ccorres)
-                 apply (rule ccorres_gen_asm)
-                 apply (erule ssubst[OF if_P, where P="\<lambda>x. ccorres _ _ _ _ _ x _"])
-                 apply (rule ccorres_alternative2)
-                 apply (rule ccorres_return_CE, simp+)[1]
-                apply (rule ccorres_inst[where P=\<top> and P'=UNIV], simp)
-               apply (wpsimp simp: performPageInvocation_def)
-              apply simp
-              apply (strengthen unat_sub_le_strg[where v="2 ^ pageBitsForSize (capVPSize cp)"])
-              apply (simp add: linorder_not_less linorder_not_le order_less_imp_le)
-              apply (wp sts_invs_minor')
-             apply simp
-             apply (vcg exspec=setThreadState_modifies)
-            apply simp
+                apply (clarsimp simp: meq_def)
+               (* frame is mapped, check for size and base match *)
+               apply (rename_tac sz base asid vaddr)
+               apply (clarsimp simp: resolve_ret_rel_def option_rel_Some1 to_bool_neq_0
+                               dest!: to_option_SomeD)
+               apply (case_tac "sz \<noteq> vmsz \<or> frameBase_C resolve_ret \<noteq> addrFromPPtr p"; clarsimp)
+                (* size or base do not match *)
+                apply (simp add: whenE_True injection_handler_throwError)
+                apply (rule ccorres_symb_exec_r2)
+                  (* valid resolve_ret *)
+                  apply (rule ccorres_cond_false_seq)
+                  apply (rule ccorres_rhs_assoc)+
+                  apply csymbr
+                  apply csymbr
+                  (* size/base check fails (True case, throw exception) *)
+                  apply (rule ccorres_cond_true_seq)
+                  apply ccorres_rewrite
+                  apply (rule ccorres_guard_imp)
+                    apply (rule syscall_error_throwError_ccorres_n)
+                    apply (simp add: syscall_error_to_H_cases)
+                   apply clarsimp
+                  apply assumption
+                 apply clarsimp
+                 apply vcg
+                 apply clarsimp
+                 apply (frule ccap_relation_PageCap_generics)
+                 apply (clarsimp simp: cap_get_tag_isCap_unfolded_H_cap_page framesize_from_H_eq_eqs
+                                 split: if_split)
+                apply vcg
+                apply (clarsimp simp: meq_def)
+               (* size and base do match; continue decode *)
+               apply (simp add: whenE_False injection_handler_returnOk)
+               apply (rule ccorres_symb_exec_r2)
+                 (* valid resolve_ret *)
+                 apply (rule ccorres_cond_false_seq)
+                 apply (rule ccorres_rhs_assoc)+
+                 apply csymbr
+                 apply csymbr
+                 (* size/base check succeeds (False case, no exception) *)
+                 apply (rule ccorres_cond_false_seq)
+                 apply ccorres_rewrite
+                 apply (rule ccorres_guard_imp)
+                   apply (rule ccorres_if_cond_throws[rotated -1,where Q = \<top> and Q' = \<top>])
+                      apply vcg
+                     apply (clarsimp simp: hd_drop_conv_nth hd_conv_nth)
+                     apply (clarsimp dest!: ccap_relation_PageCap_generics)
+                    apply (simp add: injection_handler_throwError)
+                    apply (rule syscall_error_throwError_ccorres_n)
+                    apply (simp add: syscall_error_to_H_cases)
+                   apply csymbr
+                   apply csymbr
+                   apply csymbr
+                   apply (simp add: performARMMMUInvocations bindE_assoc)
+                   apply (ctac add: setThreadState_ccorres)
+                     apply (ctac(no_vcg) add: performPageFlush_ccorres)
+                       apply (rule ccorres_gen_asm)
+                       apply (erule ssubst[OF if_P, where P="\<lambda>x. ccorres _ _ _ _ _ x _"])
+                       apply (rule ccorres_alternative2)
+                       apply (rule ccorres_return_CE, simp+)[1]
+                      apply (rule ccorres_inst[where P=\<top> and P'=UNIV], simp)
+                     apply (wpsimp simp: performPageInvocation_def)
+                    apply simp
+                    apply (strengthen unat_sub_le_strg[where v="2 ^ pageBitsForSize (capVPSize cp)"])
+                    apply (simp add: linorder_not_less linorder_not_le order_less_imp_le)
+                    apply (wp sts_invs_minor')
+                   apply simp
+                   apply (vcg exspec=setThreadState_modifies)
+                  apply (clarsimp simp: hd_drop_conv_nth hd_conv_nth not_le not_less
+                                        order_less_imp_le)
+                  apply (prop_tac "is_aligned (addrFromPPtr p) (pageBitsForSize vmsz)")
+                   apply (simp add: vmsz_aligned_addrFromPPtr)
+                  apply (fastforce elim: is_aligned_no_overflow3)
+                 apply assumption
+                apply clarsimp
+                apply vcg
+                apply (clarsimp simp: hd_drop_conv_nth hd_conv_nth)
+                apply (frule ccap_relation_PageCap_generics)
+                apply (clarsimp simp: cap_get_tag_isCap_unfolded_H_cap_page framesize_from_H_eq_eqs
+                                  split: if_split)
+               apply vcg
+               apply (clarsimp simp: meq_def)
+              apply wp
+             apply (vcg exspec=resolveVAddr_modifies)
             apply wp
            apply vcg
           apply wp
@@ -2425,7 +2523,7 @@ lemma decodeARMFrameInvocation_ccorres:
                              syscall_error_to_H_cases exception_defs)
        apply (erule lookup_failure_rel_fault_lift[rotated])
        apply (simp add: exception_defs)
-      apply (wp injection_wp[OF refl])
+      apply (wp injection_wp[OF refl] hoare_drop_imps)
      apply simp
      apply (vcg exspec=findPDForASID_modifies)
 

--- a/proof/drefine/Arch_DR.thy
+++ b/proof/drefine/Arch_DR.thy
@@ -883,7 +883,7 @@ next
         apply (clarsimp)
         apply (rule corres_from_rdonly)
            apply (wp, clarsimp)
-          apply (simp only: Let_unfold, (wp whenE_inv)+, clarsimp)
+          apply (wpsimp simp: Let_unfold wp: hoare_drop_imps hoare_vcg_op_lift)
          apply (rule validE_cases_valid, rule hoare_pre)
           apply (wpsimp simp: Let_unfold arch_invocation_relation_def
                               translate_arch_invocation_def transform_page_inv_def)+
@@ -894,7 +894,7 @@ next
        (* PageInvalidate *)
        apply (rule corres_from_rdonly)
           apply (wp, clarsimp)
-         apply (simp only: Let_unfold, (wp whenE_inv)+, clarsimp)
+         apply (wpsimp simp: Let_unfold wp: hoare_drop_imps hoare_vcg_op_lift)
         apply (rule validE_cases_valid, rule hoare_pre)
          apply (wpsimp simp: Let_unfold arch_invocation_relation_def
                              translate_arch_invocation_def transform_page_inv_def)+
@@ -905,7 +905,7 @@ next
       (* PageCleanInvalidate *)
       apply (rule corres_from_rdonly)
          apply (wp, clarsimp)
-        apply (simp only: Let_unfold, (wp whenE_inv)+, clarsimp)
+        apply (wpsimp simp: Let_unfold wp: hoare_drop_imps hoare_vcg_op_lift)
        apply (rule validE_cases_valid, rule hoare_pre)
         apply (wpsimp simp: Let_unfold arch_invocation_relation_def
                             translate_arch_invocation_def transform_page_inv_def)+
@@ -916,7 +916,7 @@ next
      (* PageUnify *)
      apply (rule corres_from_rdonly)
         apply (wp, clarsimp)
-       apply (simp only: Let_unfold, (wp whenE_inv)+, clarsimp)
+       apply (wpsimp simp: Let_unfold wp: hoare_drop_imps hoare_vcg_op_lift)
       apply (rule validE_cases_valid, rule hoare_pre)
        apply (wpsimp simp: Let_unfold arch_invocation_relation_def
                            translate_arch_invocation_def transform_page_inv_def)+

--- a/proof/drefine/CNode_DR.thy
+++ b/proof/drefine/CNode_DR.thy
@@ -693,10 +693,9 @@ lemma cap_revoke_corres_helper:
                       od
               od)
          False)
-       (cap_revoke slot')
-  "
-  proof (induct rule: cap_revoke.induct)
-    case (1 slot' sfix)
+       (cap_revoke slot')"
+proof (induct rule: cap_revoke.induct)
+  case (1 slot' sfix)
   show ?case
   supply if_cong[cong]
   apply (subst cap_revoke.simps)
@@ -738,7 +737,6 @@ lemma cap_revoke_corres_helper:
                apply (rule monadic_trancl_preemptible_return)
               apply (rule corres_trivial)
               apply (clarsimp simp:returnOk_def boolean_exception_def)+
-           apply (clarsimp simp:whenE_def empty_set_eq)
            apply (subst gets_def)
            apply (simp add: bind_assoc bindE_def)
            apply (rule dcorres_absorb_get_l)

--- a/proof/infoflow/ARM/ArchDecode_IF.thy
+++ b/proof/infoflow/ARM/ArchDecode_IF.thy
@@ -193,6 +193,19 @@ lemma decode_sgi_signal_invocation_reads_respects_f[wp]:
   "reads_respects_f aag l \<top> (decode_sgi_signal_invocation (SGISignalCap irq target))"
   by (wpsimp simp: decode_sgi_signal_invocation_def)
 
+lemma is_subject_asid_trans:
+  "\<lbrakk> is_subject_asid aag x; pas_refined aag s;
+     (pasASIDAbs aag x, Control, pasObjectAbs aag y) \<in> pasPolicy aag \<rbrakk>
+   \<Longrightarrow> is_subject aag y"
+  by (subst aag_has_Control_iff_owns[symmetric]; simp)
+
+(* 2 = pde_bits (does not exist here), 20 = whatever lookup_pd_slot does *)
+lemma lookup_pd_slot_aligned_pd:
+  "is_aligned pd pd_bits \<Longrightarrow>
+   lookup_pd_slot pd vaddr && mask pd_bits >> 2 = vaddr >> 20"
+  using vaddr_segment_nonsense2
+  by (simp add: lookup_pd_slot_def pd_bits_def pageBits_def)
+
 lemma arch_decode_invocation_reads_respects_f[Decode_IF_assms]:
   notes reads_respects_f_inv' = reads_respects_f_inv[where st=st]
   notes whenE_wps[wp_split del]
@@ -226,85 +239,104 @@ lemma arch_decode_invocation_reads_respects_f[Decode_IF_assms]:
           | simp add: Let_def unlessE_whenE
           | wp (once) whenE_throwError_wp)+
   apply (intro impI allI conjI)
-                              apply (rule requiv_arm_asid_table_asid_high_bits_of_asid_eq')
+                                apply (rule requiv_arm_asid_table_asid_high_bits_of_asid_eq')
+                                  apply fastforce
+                                 apply (simp add: reads_equiv_f_def)
+                                apply blast
+                               apply (fastforce simp: aag_cap_auth_ASIDPoolCap)
+                              apply (rule pas_cap_cur_auth_ASIDControlCap[where aag=aag])
                                 apply fastforce
                                apply (simp add: reads_equiv_f_def)
                               apply blast
-                             apply (fastforce simp: aag_cap_auth_ASIDPoolCap)
-                            apply (rule pas_cap_cur_auth_ASIDControlCap[where aag=aag])
-                              apply fastforce
-                             apply (simp add: reads_equiv_f_def)
-                            apply blast
+                             apply clarify
+                             apply (subgoal_tac "excaps ! 0 \<in> set excaps", fastforce)
+                             apply (rule nth_mem)
+                             apply (erule less_trans[rotated], simp)
+                            apply (subgoal_tac "excaps ! (Suc 0) \<in> set excaps")
+                             apply (rule_tac slot="snd (excaps ! (Suc 0))"
+                                          in owns_cnode_owns_obj_ref_of_child_cnodes)
+                                apply blast
+                               apply (fastforce)
+                              apply (fastforce)
+                             apply assumption
+                            apply (fastforce intro: nth_mem)
                            apply clarify
-                           apply (subgoal_tac "excaps ! 0 \<in> set excaps", fastforce)
-                           apply (rule nth_mem)
-                            apply (erule less_trans[rotated], simp)
-                          apply (subgoal_tac "excaps ! (Suc 0) \<in> set excaps")
-                           apply (rule_tac slot="snd (excaps ! (Suc 0))"
-                                        in owns_cnode_owns_obj_ref_of_child_cnodes)
-                              apply blast
-                             apply (fastforce)
-                            apply (fastforce)
-                           apply assumption
-                          apply (fastforce intro: nth_mem)
-                         apply clarify
-                         apply (subgoal_tac "excaps ! Suc 0 \<in> set excaps")
-                          apply (rule_tac cap="fst (excaps ! Suc 0)" and p="snd (excaps ! Suc 0)"
-                                       in caps_of_state_pasObjectAbs_eq)
-                              apply (rule cte_wp_at_caps_of_state')
+                           apply (subgoal_tac "excaps ! Suc 0 \<in> set excaps")
+                            apply (rule_tac cap="fst (excaps ! Suc 0)" and p="snd (excaps ! Suc 0)"
+                                         in caps_of_state_pasObjectAbs_eq)
+                                apply (rule cte_wp_at_caps_of_state')
+                                apply fastforce
+                               apply (erule cap_auth_conferred_cnode_cap)
                               apply fastforce
-                             apply (erule cap_auth_conferred_cnode_cap)
-                            apply fastforce
-                           apply assumption
-                          apply (fastforce intro: nth_mem)
-                         apply (fastforce intro: nth_mem)
+                             apply assumption
+                            apply (fastforce intro: nth_mem)
+                           apply (fastforce intro: nth_mem)
+                          apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+                           apply (fastforce intro: aag_cap_auth_PageDirectoryCap_asid)
+                          apply fastforce
+                         apply (simp add: lookup_pd_slot_def)
+                         apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+                          apply (subst vaddr_segment_nonsense)
+                           apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                                            simp: obj_ref_of_def cap_aligned_def cap_bits_def)
+                          apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+                         apply fastforce
+                        apply (simp add: lookup_pd_slot_def)
                         apply (subgoal_tac "excaps ! 0 \<in> set excaps")
-                         apply (fastforce intro: aag_cap_auth_PageDirectoryCap_asid)
+                         apply (subst vaddr_segment_nonsense)
+                          apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                                           simp: obj_ref_of_def cap_aligned_def cap_bits_def)
+                         apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
                         apply fastforce
-                       apply (simp add: lookup_pd_slot_def)
-                       apply (subgoal_tac "excaps ! 0 \<in> set excaps")
-                        apply (subst vaddr_segment_nonsense)
-                         apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
-                                          simp: obj_ref_of_def cap_aligned_def cap_bits_def)
-                        apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
                        apply fastforce
-                      apply (simp add: lookup_pd_slot_def)
                       apply (subgoal_tac "excaps ! 0 \<in> set excaps")
-                       apply (subst vaddr_segment_nonsense)
-                        apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
-                                         simp: obj_ref_of_def cap_aligned_def cap_bits_def)
                        apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
                       apply fastforce
                      apply fastforce
-                    apply (subgoal_tac "excaps ! 0 \<in> set excaps")
-                     apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
-                    apply fastforce
-                   apply fastforce
-                  apply (simp add: linorder_not_le aligned_sum_less_kernel_base)
-                 apply (rule ball_subset[OF _ vspace_cap_rights_to_auth_mask_vm_rights])
-                 apply (fastforce simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def)
-                apply (simp add: lookup_pd_slot_def)
-                apply (subgoal_tac "excaps ! 0 \<in> set excaps")
-                 apply (subst vaddr_segment_nonsense)
-                  apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
-                                   simp: obj_ref_of_def cap_aligned_def cap_bits_def)
-                 apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+                    apply (simp add: linorder_not_le aligned_sum_less_kernel_base)
+                   apply (rule ball_subset[OF _ vspace_cap_rights_to_auth_mask_vm_rights])
+                   apply (fastforce simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def)
+                  apply (simp add: lookup_pd_slot_def)
+                  apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+                   apply (subst vaddr_segment_nonsense)
+                    apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                                     simp: obj_ref_of_def cap_aligned_def cap_bits_def)
+                   apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+                  apply fastforce
+                 apply (simp add: lookup_pd_slot_def)
+                 apply (subgoal_tac "excaps ! 0 \<in> set excaps")
+                  apply (subst vaddr_segment_nonsense)
+                   apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
+                                    simp: obj_ref_of_def cap_aligned_def cap_bits_def)
+                  apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+                 apply fastforce
                 apply fastforce
-               apply (simp add: lookup_pd_slot_def)
                apply (subgoal_tac "excaps ! 0 \<in> set excaps")
-                apply (subst vaddr_segment_nonsense)
-                 apply (fastforce dest: cte_wp_valid_cap cap_aligned_valid
-                                  simp: obj_ref_of_def cap_aligned_def cap_bits_def)
                 apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
                apply fastforce
               apply fastforce
-             apply (subgoal_tac "excaps ! 0 \<in> set excaps")
-              apply (fastforce dest: aag_cap_auth_PageDirectoryCap)
+             apply (fastforce dest: cte_wp_valid_cap simp: valid_cap_simps)
+            apply (rule ball_subset[OF _ vspace_cap_rights_to_auth_mask_vm_rights])
+            apply (fastforce simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def)
+           apply clarsimp
+           apply (simp add: lookup_pd_slot_def)
+           apply (subst vaddr_segment_nonsense)
+            apply (fastforce simp: pd_bits_def pageBits_def)
+           apply (fastforce elim!: is_subject_asid_trans)
+          apply (subst lookup_pd_slot_eq, fastforce)
+          apply (subst lookup_pd_slot_aligned_pd, fastforce)
+          apply (clarsimp split: option.split kernel_object.split arch_kernel_obj.split pde.split)
+          apply (rule lookup_pt_slot_no_fail_is_subject)
+                  apply fastforce
+                 apply fastforce
+                apply fastforce
+               apply fastforce
+              apply (fastforce elim!: is_subject_asid_trans)
              apply fastforce
-            apply fastforce
-           apply (fastforce dest: cte_wp_valid_cap simp: valid_cap_simps)
-          apply (rule ball_subset[OF _ vspace_cap_rights_to_auth_mask_vm_rights])
-          apply (fastforce simp: aag_cap_auth_def cap_auth_conferred_def arch_cap_auth_conferred_def)
+            apply (drule cte_wp_valid_cap, fastforce)
+            apply (clarsimp simp: valid_cap_def)
+           apply fastforce
+          apply fastforce
          apply (subgoal_tac "excaps ! 0 \<in> set excaps")
           apply (fastforce intro: aag_cap_auth_PageDirectoryCap_asid)
          apply fastforce

--- a/proof/invariant-abstract/ARM/ArchArch_AI.thy
+++ b/proof/invariant-abstract/ARM/ArchArch_AI.thy
@@ -1405,11 +1405,9 @@ lemma arch_decode_inv_wf[wp]:
       apply (simp add: valid_unmap_def)
       apply (fastforce simp: vmsz_aligned_def elim: is_aligned_weaken intro!: pbfs_atleast_pageBits)
      apply (cases "isPageFlushLabel (invocation_type label)")
-      apply (rule hoare_pre)
-       apply simp
-       apply (wp whenE_throwError_wp hoare_weak_lift_imp hoare_drop_imps)
-         apply (simp add: valid_arch_inv_def valid_page_inv_def)
-         apply (wp find_pd_for_asid_pd_at_asid | wpc)+
+      apply (wpsimp wp: whenE_throwError_wp hoare_weak_lift_imp hoare_drop_imps hoare_vcg_op_lift
+                        find_pd_for_asid_pd_at_asid
+                    simp: valid_arch_inv_def valid_page_inv_def)
       apply (clarsimp simp: valid_cap_def mask_def)
      apply (cases "invocation_type label = ArchInvocationLabel ARMPageGetAddress")
       apply simp

--- a/proof/refine/ARM/ArchArch_R.thy
+++ b/proof/refine/ARM/ArchArch_R.thy
@@ -426,6 +426,15 @@ lemma resolveVAddr_corres:
   apply (clarsimp simp: page_directory_pde_at_lookupI' page_directory_at_state_relation)
   done
 
+lemma resolveVAddr_corres':
+  "\<lbrakk> pd' = pd; vaddr' = vaddr \<rbrakk> \<Longrightarrow>
+   corres (=) (pspace_aligned and valid_vspace_objs and page_directory_at pd and
+               (\<exists>\<rhd> (lookup_pd_slot pd vaddr && ~~ mask pd_bits)) and
+               K (is_aligned pd pd_bits \<and> vaddr < kernel_base))
+              (\<lambda>s. pspace_aligned' s \<and> pspace_distinct' s \<and> vs_valid_duplicates' (ksPSpace s))
+              (resolve_vaddr pd vaddr) (resolveVAddr pd' vaddr')"
+  by (fastforce intro: resolveVAddr_corres corres_gen_asm)
+
 lemma decodeARMPageFlush_corres:
   "ARM_H.isPageFlushLabel (invocation_type (mi_label mi)) \<Longrightarrow>
    corres (ser \<oplus> archinv_relation)
@@ -442,23 +451,30 @@ lemma decodeARMPageFlush_corres:
             (\<lambda>s. \<forall>x\<in>set excaps'. valid_cap' (fst x) s \<and> cte_wp_at' (\<lambda>_. True) (snd x) s) and
             (\<lambda>s. vs_valid_duplicates' (ksPSpace s)))
            (if Suc 0 < length args
-            then let start = args ! 0; end = args ! 1
-                 in doE (asid, vaddr) \<leftarrow>
-                        case option of
-                        None \<Rightarrow> throwError ExceptionTypes_A.syscall_error.IllegalOperation
-                        | Some x \<Rightarrow> returnOk x;
-                        pd \<leftarrow> lookup_error_on_failure False $ find_pd_for_asid asid;
-                        whenE (end \<le> start) $
-                        throwError $ ExceptionTypes_A.syscall_error.InvalidArgument 1;
-                        page_size \<leftarrow> returnOk $ 1 << pageBitsForSize vmpage_size;
-                        whenE (page_size \<le> start \<or> page_size < end) $
-                        throwError $ ExceptionTypes_A.syscall_error.InvalidArgument 0;
-                        returnOk $
-                        arch_invocation.InvokePage $
-                        ARM_A.page_invocation.PageFlush
-                         (label_to_flush_type (invocation_type (mi_label mi))) (start + vaddr)
-                         (end + vaddr - 1) (addrFromPPtr word + start) pd asid
-                    odE
+            then
+              let start = args ! 0; end = args ! 1
+              in doE (asid, vaddr) \<leftarrow>
+                       case option of
+                         None \<Rightarrow> throwError ExceptionTypes_A.syscall_error.IllegalOperation
+                       | Some x \<Rightarrow> returnOk x;
+                     pd \<leftarrow> lookup_error_on_failure False $ find_pd_for_asid asid;
+                     whenE (end \<le> start) $
+                       throwError $ ExceptionTypes_A.syscall_error.InvalidArgument 1;
+                     page_size \<leftarrow> returnOk $ 1 << pageBitsForSize vmpage_size;
+                     page_base <- returnOk $ addrFromPPtr word;
+                     frame_info <- liftE $ resolve_vaddr pd vaddr;
+                     case frame_info of
+                       None \<Rightarrow> throwError $ ExceptionTypes_A.syscall_error.InvalidCapability 0
+                     | Some (sz', base') \<Rightarrow>
+                         whenE (sz' \<noteq> vmpage_size \<or> base' \<noteq> page_base) $
+                           throwError $ ExceptionTypes_A.syscall_error.InvalidCapability 0;
+                     whenE (page_size \<le> start \<or> page_size < end) $
+                       throwError $ ExceptionTypes_A.syscall_error.InvalidArgument 0;
+                     returnOk $ arch_invocation.InvokePage $
+                       ARM_A.PageFlush (label_to_flush_type (invocation_type (mi_label mi)))
+                                       (start + vaddr) (end + vaddr - 1) (page_base + start)
+                                       pd asid
+                 odE
             else throwError ExceptionTypes_A.syscall_error.TruncatedMessage)
            (decodeARMPageFlush (mi_label mi) args
              (arch_capability.PageCap d word (vmrights_map seta) vmpage_size option))"
@@ -471,24 +487,15 @@ lemma decodeARMPageFlush_corres:
   apply (case_tac a)
   apply (rename_tac asid vref)
   apply clarsimp
-  apply (rule corres_guard_imp)
-    apply (rule corres_splitEE)
-       apply (rule corres_lookup_error)
-       apply (rule find_pd_for_asid_corres[OF refl])
-      apply (rule whenE_throwError_corres, simp)
-       apply simp
-      apply (rule whenE_throwError_corres, simp)
-       apply simp
-      apply (rule corres_trivial)
-      apply (rule corres_returnOk)
-      apply (clarsimp simp: archinv_relation_def page_invocation_map_def
-                            label_to_flush_type_def labelToFlushType_def flush_type_map_def
-                            ARM_H.isPageFlushLabel_def
-                     split: flush_type.splits invocation_label.splits arch_invocation_label.splits)
-     apply wp+
-   apply (fastforce simp: valid_cap_def mask_def
-                          invs_vspace_objs[simplified])
-  apply (auto)
+  apply (corres corres: corres_lookup_error resolveVAddr_corres' corres_returnOkTT
+         | corres_cases_both)+
+        apply (clarsimp simp: archinv_relation_def page_invocation_map_def
+                              label_to_flush_type_def labelToFlushType_def flush_type_map_def
+                              ARM_H.isPageFlushLabel_def
+                       split: flush_type.splits invocation_label.splits arch_invocation_label.splits)
+       apply (wpsimp | wp (once) hoare_drop_imps)+
+   apply (fastforce simp: valid_cap_def mask_def invs_vspace_objs[simplified])
+  apply fastforce
   done
 
 lemma vs_refs_pages_ptI:
@@ -1455,12 +1462,9 @@ lemma arch_decodeARMPageFlush_wf:
         (\<lambda>s. vs_valid_duplicates' (ksPSpace s))\<rbrace>
        decodeARMPageFlush label args (arch_capability.PageCap d word vmrights vmpage_size option)
        \<lbrace>valid_arch_inv'\<rbrace>, -"
-  apply (simp add: decodeARMPageFlush_def)
-  apply (rule hoare_pre)
-   apply (wp throwE_R whenE_throwError_wp | wpc | clarsimp simp: if_apply_def2)+
-   apply (wpsimp simp: valid_arch_inv'_def valid_page_inv'_def)
-  apply fastforce
-  done
+  unfolding decodeARMPageFlush_def
+  by (wpsimp wp: throwE_R whenE_throwError_wp hoare_drop_imps hoare_vcg_op_lift
+             simp: if_apply_def2 valid_arch_inv'_def valid_page_inv'_def)
 
 lemma arch_decodeInvocation_wf[wp]:
   notes ensureSafeMapping_inv[wp del]

--- a/proof/refine/Tcb_R.thy
+++ b/proof/refine/Tcb_R.thy
@@ -2517,17 +2517,17 @@ lemma decodeUnbindNotification_corres:
   done
 
 lemma decodeSetTLSBase_corres:
-  "corres (ser \<oplus> tcbinv_relation) (tcb_at t) (tcb_at' t)
+  "corres (ser \<oplus> tcbinv_relation) \<top> \<top>
           (decode_set_tls_base w (cap.ThreadCap t))
           (decodeSetTLSBase w (capability.ThreadCap t))"
-  by (clarsimp simp: decode_set_tls_base_def decodeSetTLSBase_def returnOk_def
+  by (clarsimp simp: decode_set_tls_base_def decodeSetTLSBase_def corres_returnOkTT
                split: list.split)
 
 lemma decodeSetFlags_corres:
-  "corres (ser \<oplus> tcbinv_relation) (tcb_at t) (tcb_at' t)
+  "corres (ser \<oplus> tcbinv_relation) \<top> \<top>
           (decode_set_flags w (cap.ThreadCap t))
           (decodeSetFlags w (capability.ThreadCap t))"
-  by (clarsimp simp: decode_set_flags_def decodeSetFlags_def returnOk_def
+  by (clarsimp simp: decode_set_flags_def decodeSetFlags_def corres_returnOkTT
                split: list.split)
 
 context Tcb_R begin

--- a/spec/abstract/ARM/ArchDecode_A.thy
+++ b/spec/abstract/ARM/ArchDecode_A.thy
@@ -184,10 +184,16 @@ where
             pd \<leftarrow> lookup_error_on_failure False $ find_pd_for_asid asid;
             whenE (end \<le> start) $ throwError $ InvalidArgument 1;
             page_size \<leftarrow> returnOk $ 1 << pageBitsForSize pgsz;
+            page_base \<leftarrow> returnOk $ addrFromPPtr p;
+            frame_info \<leftarrow> liftE $ resolve_vaddr pd vaddr;
+            case frame_info of
+              None \<Rightarrow> throwError $ InvalidCapability 0
+            | Some (sz', base') \<Rightarrow> whenE (sz' \<noteq> pgsz \<or> base' \<noteq> page_base) $
+                                         throwError $ InvalidCapability 0;
             whenE (start \<ge> page_size \<or> end > page_size) $ throwError $ InvalidArgument 0;
             returnOk $ InvokePage $ PageFlush
                 (label_to_flush_type (invocation_type label)) (start + vaddr)
-                (end + vaddr - 1) (addrFromPPtr p + start) pd asid
+                (end + vaddr - 1) (page_base + start) pd asid
     odE
     else throwError TruncatedMessage
     else if invocation_type label = ArchInvocationLabel ARMPageGetAddress

--- a/spec/haskell/src/SEL4/Kernel/VSpace/ARM.lhs
+++ b/spec/haskell/src/SEL4/Kernel/VSpace/ARM.lhs
@@ -1450,6 +1450,20 @@ The function should not be called on any other cap types.
 >             throw $ InvalidArgument 1
 >         let pageSize = bit (pageBitsForSize (capVPSize cap))
 >         let pageBase = addrFromPPtr $ capVPBasePtr cap
+#ifndef CONFIG_ARM_HYPERVISOR_SUPPORT
+
+The provided cap might have stale mapping info, which we should not use for flushing,
+because the page may now be unmapped or mapped at a different address or size, which
+would lead to failure. If it is mapped at same size and address, then at least the
+flush is safe. On hypervisor configs, we are using the kernel's mappings for flushing,
+so the operation is already safe.
+
+>         frameInfo <- withoutFailure $ resolveVAddr pd vaddr
+>         case frameInfo of
+>             Nothing -> throw $ InvalidCapability 0
+>             Just (sz', base') -> when (sz' /= capVPSize cap || base' /= pageBase) $
+>                                       throw $ InvalidCapability 0
+#endif
 >         when (start >= pageSize || end > pageSize) $
 >             throw $ InvalidArgument 0
 >         let pstart = pageBase + toPAddr start


### PR DESCRIPTION
Sync specs and proof with seL4 PR seL4/seL4#1633 which aborts the flush operation when the cap that is used to invoke it has stale mapping info.

When the check passes, we cannot guarantee that the cap is the original authority to this mapping, but we do know that it is at least authority to the same frame.

Test with: seL4/seL4#1633