### PR TITLE
clean up manual instantiation in CRefine

### DIFF
--- a/lib/clib/CCorresLemmas.thy
+++ b/lib/clib/CCorresLemmas.thy
@@ -630,6 +630,22 @@ lemma ccorres_if_lhs:
           hs (if P then f else g) conc"
   by (simp split: if_split)
 
+lemma ccorres_if_bind_lhs:
+  "\<lbrakk> P \<Longrightarrow> ccorres_underlying sr Gamm r xf arrel axf Q S hs (f >>= m) conc;
+     \<not> P \<Longrightarrow> ccorres_underlying sr Gamm r xf arrel axf R T hs (g >>= m) conc \<rbrakk>
+   \<Longrightarrow> ccorres_underlying sr Gamm r xf arrel axf (\<lambda>s. (P \<longrightarrow> Q s) \<and> (\<not> P \<longrightarrow> R s))
+                      {s. (P \<longrightarrow> s \<in> S) \<and> (\<not> P \<longrightarrow> s \<in> T)}
+          hs ((if P then f else g) >>= m) conc"
+  by (simp split: if_split)
+
+lemma ccorres_if_bindE_lhs:
+  "\<lbrakk> P \<Longrightarrow> ccorres_underlying sr Gamm r xf arrel axf Q S hs (f >>=E m) conc;
+     \<not> P \<Longrightarrow> ccorres_underlying sr Gamm r xf arrel axf R T hs (g >>=E m) conc \<rbrakk>
+   \<Longrightarrow> ccorres_underlying sr Gamm r xf arrel axf (\<lambda>s. (P \<longrightarrow> Q s) \<and> (\<not> P \<longrightarrow> R s))
+                      {s. (P \<longrightarrow> s \<in> S) \<and> (\<not> P \<longrightarrow> s \<in> T)}
+          hs ((if P then f else g) >>=E m) conc"
+  by (simp split: if_split)
+
 lemma ccorres_if_bindE:
   "ccorres_underlying sr Gamm r xf arrel axf G G' hs (if a then (b >>=E f) else (c >>=E f)) d
   \<Longrightarrow> ccorres_underlying sr Gamm r xf arrel axf G G' hs ((if a then b else c) >>=E f) d"

--- a/proof/crefine/ARM/Arch_C.thy
+++ b/proof/crefine/ARM/Arch_C.thy
@@ -2335,7 +2335,7 @@ lemma decodeARMFrameInvocation_ccorres:
         apply (wpsimp wp: sts_invs_minor' ct_in_state'_set)+
       apply (vcg exspec=setThreadState_modifies)
 
-      \<comment> \<open>PageUnify_Instruction | PageCleanInvalidate_Data | Page Invalidate_Data | PageClean_Data\<close>
+     \<comment> \<open>PageUnify_Instruction | PageCleanInvalidate_Data | Page Invalidate_Data | PageClean_Data\<close>
      apply (rule ccorres_rhs_assoc)+
      apply csymbr+
      apply (simp add: ivc_label_flush_case decodeARMPageFlush_def list_case_If2 if3_fold2
@@ -2383,7 +2383,8 @@ lemma decodeARMFrameInvocation_ccorres:
               apply (simp add: injection_handler_throwError)
               apply (rule syscall_error_throwError_ccorres_n)
               apply (simp add: syscall_error_to_H_cases)
-             apply (simp only: returnOk_bindE injection_liftE liftE_bindE cong: ccorres_prog_only_cong)
+             apply (simp only: returnOk_bindE injection_handler_If injection_liftE liftE_bindE
+                         cong: ccorres_prog_only_cong)
              apply csymbr
              apply csymbr
              apply (rule ccorres_Guard_Seq)
@@ -2392,122 +2393,81 @@ lemma decodeARMFrameInvocation_ccorres:
              apply csymbr
              apply (ctac add: resolveVAddr_ccorres)
                apply (rename_tac resolve_rv resolve_ret)
-               (* instantiate to enable case_tac for IF chain compiled from logical shortcut
-                  operator (valid || addr+size match) *)
-               apply (rule_tac P="\<lambda>s. tcb_at' thread s \<and> sch_act_simple s \<and> invs' s \<and>
-                                      st_tcb_at' (\<lambda>st'. tcb_st_refs_of' st' = {} \<and> st' \<noteq> Inactive \<and>
-                                                        st' \<noteq> IdleThreadState) thread s \<and>
-                                      thread \<noteq> ksIdleThread s \<and>
-                                      (obj_at' tcbQueued thread s \<longrightarrow> st_tcb_at' runnable' thread s) \<and>
-                                      fst (the m_opt) \<le> mask asid_bits \<and>
-                                      is_aligned p (pageBitsForSize vmsz) \<and>
-                                      hd args + snd (the m_opt) && mask cacheLineBits =
-                                        addrFromPPtr p + hd args && mask cacheLineBits \<and>
-                                      2 ^ pageBitsForSize vmsz \<le> gsMaxObjectSize s" and
-                               P'="\<lbrace>\<acute>ksCurThread = tcb_ptr_to_ctcb_ptr thread \<and>
-                                     flushtype_relation (labelToFlushType label) (ucast label)\<rbrace>"
-                               in ccorres_inst)
-               apply (case_tac resolve_rv; clarsimp)
-               (* not mapped (= resolve_ret not valid) *)
-                apply (simp add: injection_handler_throwError)
-                apply (rule ccorres_symb_exec_r2)
-                  (* SKIP case of first IF (= resolve_ret not valdid) *)
+               (* can't use _know_rv rule here, because we cannot lift ret__int yet;
+                  use ccorres_symb_exec_r2 twice instead *)
+               apply (rule ccorres_if_bindE_lhs)
+                prefer 2
+                apply (prop_tac "resolve_rv = None", clarsimp)
+                apply (prop_tac "valid_C resolve_ret = 0", clarsimp)
+                apply (simp cong: ccorres_prog_only_cong)
+                (* error case first, resolve_rv = None, resolve_ret not valid, ret__int = 1 *)
+                apply (rule ccorres_symb_exec_r2[where R'=UNIV])
                   apply (rule ccorres_cond_true_seq)
                   apply ccorres_rewrite
                   (* pass-through means exception (True) case of second IF *)
                   apply (rule ccorres_cond_true_seq)
                   apply ccorres_rewrite
-                  apply (rule ccorres_guard_imp)
-                    apply (rule syscall_error_throwError_ccorres_n)
-                    apply (simp add: syscall_error_to_H_cases)
-                   apply clarsimp
-                  apply assumption
-                 apply clarsimp
-                 apply vcg
-                 apply clarsimp
+                  apply (clarsimp simp: injection_handler_throwError)
+                  apply (rule syscall_error_throwError_ccorres_n)
+                  apply (simp add: syscall_error_to_H_cases)
+                 apply (rule conseqPre, vcg)
+                 apply (solves clarsimp)
                 apply vcg
                 apply (clarsimp simp: meq_def)
-               (* frame is mapped, check for size and base match *)
-               apply (rename_tac sz base asid vaddr)
-               apply (clarsimp simp: resolve_ret_rel_def option_rel_Some1 to_bool_neq_0
+               (* resolve_rv = Some, resolve_ret valid *)
+               apply (prop_tac "valid_C resolve_ret \<noteq> 0")
+                apply (clarsimp simp: resolve_ret_rel_def option_rel_Some1 to_bool_neq_0
                                dest!: to_option_SomeD)
-               apply (case_tac "sz \<noteq> vmsz \<or> frameBase_C resolve_ret \<noteq> addrFromPPtr p"; clarsimp)
-                (* size or base do not match *)
-                apply (simp add: whenE_True injection_handler_throwError)
-                apply (rule ccorres_symb_exec_r2)
-                  (* valid resolve_ret *)
-                  apply (rule ccorres_cond_false_seq)
-                  apply (rule ccorres_rhs_assoc)+
-                  apply csymbr
-                  apply csymbr
-                  (* size/base check fails (True case, throw exception) *)
-                  apply (rule ccorres_cond_true_seq)
-                  apply ccorres_rewrite
-                  apply (rule ccorres_guard_imp)
-                    apply (rule syscall_error_throwError_ccorres_n)
-                    apply (simp add: syscall_error_to_H_cases)
-                   apply clarsimp
-                  apply assumption
-                 apply clarsimp
-                 apply vcg
-                 apply clarsimp
+               apply (simp add: injection_handler_whenE cong: ccorres_prog_only_cong)
+               apply csymbr
+               apply ccorres_rewrite
+               apply (rule ccorres_rhs_assoc)+
+               apply csymbr
+               apply csymbr
+               apply (rule ccorres_cond_seq)
+               apply (rule ccorres_if_bindE)
+               apply (rule ccorres_cond_both'[where Q=\<top> and Q'=\<top>])
+                 apply (clarsimp simp: resolve_ret_rel_def option_rel_Some1 to_bool_neq_0
+                                dest!: to_option_SomeD)
                  apply (frule ccap_relation_PageCap_generics)
-                 apply (clarsimp simp: cap_get_tag_isCap_unfolded_H_cap_page framesize_from_H_eq_eqs
+                 apply (fastforce simp: cap_get_tag_isCap_unfolded_H_cap_page framesize_from_H_eq_eqs
                                  split: if_split)
-                apply vcg
-                apply (clarsimp simp: meq_def)
-               (* size and base do match; continue decode *)
-               apply (simp add: whenE_False injection_handler_returnOk)
-               apply (rule ccorres_symb_exec_r2)
-                 (* valid resolve_ret *)
-                 apply (rule ccorres_cond_false_seq)
-                 apply (rule ccorres_rhs_assoc)+
-                 apply csymbr
-                 apply csymbr
-                 (* size/base check succeeds (False case, no exception) *)
-                 apply (rule ccorres_cond_false_seq)
-                 apply ccorres_rewrite
-                 apply (rule ccorres_guard_imp)
-                   apply (rule ccorres_if_cond_throws[rotated -1,where Q = \<top> and Q' = \<top>])
-                      apply vcg
-                     apply (clarsimp simp: hd_drop_conv_nth hd_conv_nth)
-                     apply (clarsimp dest!: ccap_relation_PageCap_generics)
-                    apply (simp add: injection_handler_throwError)
-                    apply (rule syscall_error_throwError_ccorres_n)
-                    apply (simp add: syscall_error_to_H_cases)
-                   apply csymbr
-                   apply csymbr
-                   apply csymbr
-                   apply (simp add: performARMMMUInvocations bindE_assoc)
-                   apply (ctac add: setThreadState_ccorres)
-                     apply (ctac(no_vcg) add: performPageFlush_ccorres)
-                       apply (rule ccorres_gen_asm)
-                       apply (erule ssubst[OF if_P, where P="\<lambda>x. ccorres _ _ _ _ _ x _"])
-                       apply (rule ccorres_alternative2)
-                       apply (rule ccorres_return_CE, simp+)[1]
-                      apply (rule ccorres_inst[where P=\<top> and P'=UNIV], simp)
-                     apply (wpsimp simp: performPageInvocation_def)
-                    apply simp
-                    apply (strengthen unat_sub_le_strg[where v="2 ^ pageBitsForSize (capVPSize cp)"])
-                    apply (simp add: linorder_not_less linorder_not_le order_less_imp_le)
-                    apply (wp sts_invs_minor')
-                   apply simp
-                   apply (vcg exspec=setThreadState_modifies)
-                  apply (clarsimp simp: hd_drop_conv_nth hd_conv_nth not_le not_less
-                                        order_less_imp_le)
-                  apply (prop_tac "is_aligned (addrFromPPtr p) (pageBitsForSize vmsz)")
-                   apply (simp add: vmsz_aligned_addrFromPPtr)
-                  apply (fastforce elim: is_aligned_no_overflow3)
-                 apply assumption
-                apply clarsimp
-                apply vcg
-                apply (clarsimp simp: hd_drop_conv_nth hd_conv_nth)
-                apply (frule ccap_relation_PageCap_generics)
-                apply (clarsimp simp: cap_get_tag_isCap_unfolded_H_cap_page framesize_from_H_eq_eqs
-                                  split: if_split)
-               apply vcg
-               apply (clarsimp simp: meq_def)
-              apply wp
+                (* base/size mismatch, throwError *)
+                apply (simp cong: ccorres_prog_only_cong)
+                apply ccorres_rewrite
+                apply (simp add: injection_handler_throwError cong: ccorres_prog_only_cong)
+                apply (rule syscall_error_throwError_ccorres_n)
+                apply (simp add: syscall_error_to_H_cases)
+               (* base/size match, continue decode *)
+               apply (simp cong: ccorres_prog_only_cong)
+               apply ccorres_rewrite
+               apply (rule ccorres_if_cond_throws[rotated -1,where Q = \<top> and Q' = \<top>])
+                  apply vcg
+                 apply (clarsimp simp: hd_drop_conv_nth hd_conv_nth)
+                 apply (clarsimp dest!: ccap_relation_PageCap_generics)
+                apply (simp add: injection_handler_throwError)
+                apply (rule syscall_error_throwError_ccorres_n)
+                apply (simp add: syscall_error_to_H_cases)
+               apply csymbr
+               apply csymbr
+               apply csymbr
+               apply (simp add: performARMMMUInvocations bindE_assoc)
+               apply (ctac add: setThreadState_ccorres)
+                 apply (ctac (no_vcg) add: performPageFlush_ccorres)
+                   apply (rule ccorres_gen_asm)
+                   apply (erule ssubst[OF if_P, where P="\<lambda>x. ccorres _ _ _ _ _ x _"])
+                   apply (rule ccorres_alternative2)
+                   apply (rule ccorres_return_CE, simp+)[1]
+                  apply (rule ccorres_inst[where P=\<top> and P'=UNIV], simp)
+                 apply (wpsimp simp: performPageInvocation_def)
+                apply simp
+                apply (strengthen unat_sub_le_strg[where v="2 ^ pageBitsForSize (capVPSize cp)"])
+                apply (simp add: linorder_not_less linorder_not_le order_less_imp_le)
+                apply (wp sts_invs_minor')
+               apply simp
+               apply (vcg exspec=setThreadState_modifies)
+              apply clarsimp
+              apply (wp hoare_vcg_const_imp_lift | wp (once) hoare_drop_imps)+
              apply (vcg exspec=resolveVAddr_modifies)
             apply wp
            apply vcg
@@ -2523,7 +2483,7 @@ lemma decodeARMFrameInvocation_ccorres:
                              syscall_error_to_H_cases exception_defs)
        apply (erule lookup_failure_rel_fault_lift[rotated])
        apply (simp add: exception_defs)
-      apply (wp injection_wp[OF refl] hoare_drop_imps)
+      apply (wp injection_wp[OF refl] hoare_vcg_const_imp_liftE_R)
      apply simp
      apply (vcg exspec=findPDForASID_modifies)
 

--- a/proof/refine/README.md
+++ b/proof/refine/README.md
@@ -27,11 +27,9 @@ To build for the ARM architecture from the `l4v/` directory, run:
 Important Theories
 ------------------
 
-The top-level theory where the refinement statement is established over
-the entire kernel is [`Refine`](ARM/Refine.thy); the state-relation that
-relates the state-spaces of the two specifications is defined in
-[`StateRelation`](StateRelation.thy) and the basic correspondence
-property proved over each kernel function is defined in
-[`Corres`](Corres.thy).
-
-
+The top-level theory where the refinement statement is established over the
+entire kernel is [`Refine`](Refine.thy) with architecture assumptions that
+are discharged in [`ArchRefine`](AARCH64/ArchRefine.thy); the state-relation
+that relates the state-spaces of the two specifications is defined in
+[`StateRelation`](StateRelation.thy) and the basic correspondence property
+proved over each kernel function is defined in [`Corres`](Corres.thy).


### PR DESCRIPTION
As promised in #1035, clean up that manual instantiation. The right combination of `ccorres_if_bindE_lhs` and `ccorres_symb_exec_r2` does the trick in the end (plus avoiding further `ccorres_symb_exec_r2` steps later by  using `ccorres_cond_both'` later).
