### PR TITLE
ignore isabelle.in.tum.de in link check

### DIFF
--- a/.linkcheck-ignore.yml
+++ b/.linkcheck-ignore.yml
@@ -4,4 +4,5 @@
 
 urls:
   - ".*haskellstack.org.*"
+  - "https://isabelle.in.tum.de.*"
   - https://doi.org/10.1145/1190215.1190234

--- a/lib/Eisbach_Tools/README.md
+++ b/lib/Eisbach_Tools/README.md
@@ -13,7 +13,7 @@ but are mostly used from Eisbach methods, so we collect them here as well.
 We only include theories that are needed in the [Monads], [CParser], and
 [AutoCorres] sessions.
 
-[Eisbach]: https://isabelle.in.tum.de/dist//doc/eisbach.pdf
+[Eisbach]: https://isabelle.in.tum.de/dist/doc/eisbach.pdf
 [Monads]: ../Monads/
 [CParser]: ../../tools/c-parser/
 [AutoCorres]: ../../tools/autocorres/


### PR DESCRIPTION
I got fed up with the constant link check failures, so

- fix one slightly broken link
- ignore isabelle.in.tum.de entirely