### PR TITLE
github: add verified RISCV64 platforms to CI

### DIFF
--- a/.github/workflows/proof-deploy.yml
+++ b/.github/workflows/proof-deploy.yml
@@ -69,6 +69,8 @@ jobs:
             plat: bcm2711
           - arch: AARCH64
             plat: imx8mm
+          - arch: RISCV64
+            plat: hifive-p550
     # test only most recent push, but let started jobs finish:
     concurrency:
       group: l4v-deploy-${{ github.ref }}-${{ matrix.arch }}-${{ matrix.num_domains }}-${{ matrix.plat }}

--- a/.github/workflows/weekly-clean.yml
+++ b/.github/workflows/weekly-clean.yml
@@ -75,6 +75,21 @@ jobs:
           - arch: AARCH64
             plat: zynqmp
 
+          - arch: RISCV64
+            plat: ariane
+          - arch: RISCV64
+            plat: bananapi-f3
+          - arch: RISCV64
+            plat: cheshire
+          - arch: RISCV64
+            plat: hifive-p550
+          - arch: RISCV64
+            plat: polarfire
+          - arch: RISCV64
+            plat: rocketchip-zcu102
+          - arch: RISCV64
+            plat: star64
+
     steps:
     - name: Proofs
       uses: seL4/ci-actions/aws-proofs@master


### PR DESCRIPTION
- Add only hifive-p550 to CI push check, because it has the highest variation to baseline RISCV64 and should cover all of the other configs.
- Add all RISCV64 configs to weekly clean test.