### PR TITLE
MCS: remove RISCV64 quick_and_dirty CRefine

### DIFF
--- a/proof/Makefile
+++ b/proof/Makefile
@@ -10,11 +10,6 @@ default: images test
 test:
 all: images test
 
-# Allow sorry command in RISCV64 CRefine during development:
-ifeq "$(L4V_ARCH)" "RISCV64"
-  export CREFINE_QUICK_AND_DIRTY=1
-endif
-
 #
 # Setup heaps.
 #


### PR DESCRIPTION
CRefine on RISCV64 is now sorry-free, and there are no other sorried developments at this time.