### PR TITLE
clean up all warnings in Refine

### DIFF
--- a/proof/crefine/AARCH64/CSpace_C.thy
+++ b/proof/crefine/AARCH64/CSpace_C.thy
@@ -2623,7 +2623,7 @@ lemma cap_get_capSizeBits_spec:
                         word_sle_def Let_def mask_def
                         isZombieTCB_C_def ZombieTCB_C_def
                         cap_lift_domain_cap cap_get_tag_scast
-                        objBits_defs wordRadix_def
+                        objBits_defs wordRadix_def vcpuBits_def
                         c_valid_cap_def cl_valid_cap_def pageBits_def asidPoolBits_def
                         Kernel_Config.config_ARM_PA_SIZE_BITS_40_def (* #define in C, so no other option for now *)
                  cong: option.case_cong

--- a/proof/invariant-abstract/Invariants_AI.thy
+++ b/proof/invariant-abstract/Invariants_AI.thy
@@ -394,6 +394,11 @@ abbreviation
 where
   "s \<turnstile> c \<equiv> valid_cap c s"
 
+(* include in order to prevent syntax ambiguity warning with spec_validE *)
+bundle no_valid_cap_syn begin
+no_notation valid_cap_syn ("_ \<turnstile> _" [60, 60] 61)
+end
+
 definition
   "valid_caps cs s \<equiv> \<forall>slot cap. cs slot = Some cap \<longrightarrow> valid_cap cap s"
 

--- a/proof/refine/AARCH64/ArchBits_R.thy
+++ b/proof/refine/AARCH64/ArchBits_R.thy
@@ -31,14 +31,14 @@ lemma objBitsKO_less_word_bits[Arch_assms]:
   "objBitsKO ko < word_bits"
   unfolding objBits_def
   by (case_tac ko;
-      simp add: pageBits_def pteBits_def objBits_simps' word_bits_def
+      simp add: pageBits_def pteBits_def vcpuBits_def objBits_simps' word_bits_def
          split: arch_kernel_object.split)
 
 lemma objBitsKO_neq_0[Arch_assms]:
   "objBitsKO ko \<noteq> 0"
   unfolding objBits_def
   by (case_tac ko;
-      simp add: pageBits_def pteBits_def objBits_simps' word_bits_def
+      simp add: pageBits_def pteBits_def vcpuBits_def objBits_simps' word_bits_def
          split: arch_kernel_object.split)
 
 lemma arch_isCap_simps:

--- a/proof/refine/AARCH64/ArchCSpace_R.thy
+++ b/proof/refine/AARCH64/ArchCSpace_R.thy
@@ -388,7 +388,7 @@ lemma setupReplyMaster_global_refs[wp]:
   apply (case_tac prev_cte, simp)
   apply (frule(1) ctes_of_valid_cap')
   apply (drule(1) valid_global_refsD_with_objSize)+
-  apply (clarsimp simp: valid_cap'_def objBits_simps' obj_at'_def
+  apply (clarsimp simp: valid_cap'_def objBits_simps' vcpuBits_def obj_at'_def
                  split: capability.split_asm)
   done
 

--- a/proof/refine/AARCH64/ArchDetype_R.thy
+++ b/proof/refine/AARCH64/ArchDetype_R.thy
@@ -1438,8 +1438,6 @@ lemma createObject_pspace_aligned_distinct':
    and K (ty = APIObjectType apiobject_type.CapTableObject \<longrightarrow> us < 28)\<rbrace>
   createObject ty ptr us d
   \<lbrace>\<lambda>xa s. pspace_aligned' s \<and> pspace_distinct' s\<rbrace>"
-  (* FIXME: work around warning due to vcpuBits_def being in both bit_simps and objBits_simps' *)
-  supply vcpuBits_def[bit_simps del]
   apply (rule hoare_pre)
    apply (wp placeNewObject_pspace_aligned' unless_wp
              placeNewObject_pspace_distinct'

--- a/proof/refine/AARCH64/ArchEmptyFail.thy
+++ b/proof/refine/AARCH64/ArchEmptyFail.thy
@@ -17,8 +17,6 @@ lemma empty_fail_lookupIPCBuffer[Arch_assms]:
   by (clarsimp simp: lookupIPCBuffer_def Let_def getThreadBufferSlot_def locateSlot_conv
               split: capability.splits arch_capability.splits | wp | wpc | safe)+
 
-declare setRegister_empty_fail[intro!, simp] (* FIXME: tag original instead *)
-
 lemmas EmptyFail_R_assms = Arch_assms (* extract accumulated assumptions *)
 
 end (* Arch *)

--- a/proof/refine/AARCH64/ArchFinalise_R.thy
+++ b/proof/refine/AARCH64/ArchFinalise_R.thy
@@ -651,9 +651,6 @@ lemma invs_asid_update_strg':
   apply (auto simp add: ran_def split: if_split_asm)
   done
 
-crunch invalidateTLBByASID
-  for asidTable[wp]: "\<lambda>s. P (armKSASIDTable (ksArchState s))"
-
 lemma deleteASIDPool_invs[wp]:
   "\<lbrace>invs'\<rbrace> deleteASIDPool asid pool \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: deleteASIDPool_def)

--- a/proof/refine/AARCH64/ArchInvsLemmas_H.thy
+++ b/proof/refine/AARCH64/ArchInvsLemmas_H.thy
@@ -25,7 +25,7 @@ lemmas wordRadix_def' = wordRadix_def[simplified]
 lemma wordSizeCase_simp[simp]: "wordSizeCase a b = b"
   by (simp add: wordSizeCase_def wordBits_def word_size)
 
-lemmas objBits_defs = tcbBlockSizeBits_def epSizeBits_def ntfnSizeBits_def cteSizeBits_def vcpuBits_def
+lemmas objBits_defs = tcbBlockSizeBits_def epSizeBits_def ntfnSizeBits_def cteSizeBits_def
 lemmas untypedBits_defs = minUntypedSizeBits_def maxUntypedSizeBits_def
 lemmas objBits_simps = objBits_def objBitsKO_def word_size_def archObjSize_def
 lemmas objBits_simps' = objBits_simps objBits_defs
@@ -302,7 +302,7 @@ lemma frame_at_update' [iff]:
 
 lemma pspace_in_kernel_mappings_update' [iff]:
   "pspace_in_kernel_mappings' (f s) = pspace_in_kernel_mappings' s"
-  by (simp add: pspace_in_kernel_mappings'_def)
+  by simp
 
 lemma valid_arch_tcb_update'[iff]:
   "valid_arch_tcb' atcb (f s) = valid_arch_tcb' atcb s"

--- a/proof/refine/AARCH64/ArchKHeap_R.thy
+++ b/proof/refine/AARCH64/ArchKHeap_R.thy
@@ -163,9 +163,6 @@ lemma obj_relation_cut_same_type:
                     arch_kernel_obj.split_asm arch_kernel_object.split_asm)
   done
 
-lemmas obj_at_simps = gen_obj_at_simps is_other_obj_relation_type_def
-                      objBits_simps pageBits_def
-
 lemma arch_state_relation_vmids_cong:
   "aobjs |> asid_pool_of' ||> vmids_of_pool' = aobjs' |> asid_pool_of' ||> vmids_of_pool' \<Longrightarrow>
   ((s, s') \<in> arch_state_relation aobjs) = ((s, s') \<in> arch_state_relation aobjs')"

--- a/proof/refine/AARCH64/ArchRetype_R.thy
+++ b/proof/refine/AARCH64/ArchRetype_R.thy
@@ -138,8 +138,6 @@ lemma makeObjectKO_eq[Arch_assms]:
 
 lemma objBits_le_obj_bits_api[Arch_assms]:
   "makeObjectKO dev d ty = Some ko \<Longrightarrow> objBitsKO ko \<le> obj_bits_api (APIType_map2 ty) us"
-  (* FIXME: work around warning due to vcpuBits_def being in both bit_simps and objBits_simps' *)
-  supply vcpuBits_def[bit_simps del]
   apply (case_tac ty)
     apply (auto simp: default_arch_object_def bit_simps
                       makeObjectKO_def objBits_simps' APIType_map2_def obj_bits_api_def slot_bits_def

--- a/proof/refine/AARCH64/ArchUntyped_R.thy
+++ b/proof/refine/AARCH64/ArchUntyped_R.thy
@@ -91,7 +91,6 @@ lemma APIType_map2_arch_data_to_obj_type[Arch_assms]:
 
 lemma obj_bits_api_APIType_map2[Arch_assms]:
   "obj_bits_api (APIType_map2 (Inr x)) y = getObjectSize x y"
-  supply vcpuBits_def[bit_simps del] (* FIXME arch-split: suppress warning *)
   apply (clarsimp simp:obj_bits_api_def APIType_map2_def getObjectSize_def simp del: objSize_eq_capBits)
   apply (case_tac x)
         apply (simp_all add:arch_kobj_size_def default_arch_object_def pageBits_def ptBits_def)
@@ -331,7 +330,6 @@ lemma resetChunkBits_le_word_bits[Arch_assms]:
 lemma APIType_capBits_lower_bound[Arch_assms]:
   "\<lbrakk>tp = APIObjectType ArchTypes_H.apiobject_type.Untyped \<longrightarrow> minUntypedSizeBits \<le> us\<rbrakk>
    \<Longrightarrow> minUntypedSizeBits \<le> APIType_capBits tp us"
-  supply vcpuBits_def[bit_simps del] (* FIXME arch-split: suppress warning *)
   by (simp add: APIType_capBits_def objBits_simps' bit_simps minUntypedSizeBits_def
            split: object_type.split apiobject_type.split)
 

--- a/proof/refine/ARM/ArchArchAcc_R.thy
+++ b/proof/refine/ARM/ArchArchAcc_R.thy
@@ -1412,10 +1412,10 @@ lemma obj_relation_cuts_range_limit:
        apply (rule_tac x=tcbBlockSizeBits in exI)
        apply (simp add: tcbBlockSizeBits_def)
       apply (rule_tac x=pteBits in exI)
-      apply (simp add: bit_simps is_aligned_shift mask_def pteBits_def)
+      apply (simp add: is_aligned_shift mask_def pteBits_def)
       apply word_bitwise
      apply (rule_tac x=pdeBits in exI)
-     apply (simp add: bit_simps is_aligned_shift mask_def pdeBits_def)
+     apply (simp add: is_aligned_shift mask_def pdeBits_def)
      apply word_bitwise
     apply (rule_tac x=pageBits in exI)
     apply (simp add: is_aligned_shift pbfs_atleast_pageBits is_aligned_mult_triv2)
@@ -1440,7 +1440,7 @@ lemma obj_relation_cuts_range_mask_range[Arch_assms]:
 lemma obj_relation_cuts_obj_bits:
   "\<lbrakk> (p', P) \<in> obj_relation_cuts ko p; P ko ko' \<rbrakk> \<Longrightarrow> objBitsKO ko' \<le> obj_bits ko"
   apply (erule (1) obj_relation_cutsE;
-          clarsimp simp: objBits_simps objBits_defs bit_simps cte_level_bits_def
+          clarsimp simp: objBits_simps objBits_defs cte_level_bits_def
                          pbfs_atleast_pageBits[simplified bit_simps'] bit_simps')
    apply (cases ko; simp add: other_obj_relation_def objBits_defs split: kernel_object.splits)
   apply (rename_tac ako)
@@ -1459,7 +1459,7 @@ lemma pspace_distinct_cross[Arch_assms]:
   apply (frule (1) pspace_alignedD')
   apply (frule (1) pspace_alignedD)
   apply (rule ps_clearI, assumption)
-   apply (case_tac ko'; simp add: objBits_simps objBits_defs obj_at_simps)
+   apply (case_tac ko'; simp add: obj_at_simps)
    apply (simp split: arch_kernel_object.splits add: obj_at_simps pteBits_def pdeBits_def)
   apply (rule ccontr, clarsimp)
   apply (rename_tac x' ko_x')

--- a/proof/refine/ARM/ArchCSpace_I.thy
+++ b/proof/refine/ARM/ArchCSpace_I.thy
@@ -144,7 +144,6 @@ lemma capUntypedSize_capBits:
   "capClass cap = PhysicalClass \<Longrightarrow> capUntypedSize cap = 2 ^ (capBits cap)"
   by (fastforce simp: global.capUntypedSize_def objBits_simps
                       ARM_H.capUntypedSize_def
-                      pteBits_def pdeBits_def
                       ptBits_def pdBits_def
                       shiftl_eq_mult bit_simps'
                 split: capability.splits arch_capability.splits

--- a/proof/refine/ARM/ArchInvsLemmas_H.thy
+++ b/proof/refine/ARM/ArchInvsLemmas_H.thy
@@ -111,7 +111,6 @@ clear_named_theorems Arch_assms (* accumulate assumptions for Invariants_H_cte_a
 
 (* FIXME arch-split: for proofs which require exact offsets lining up instead of cteSizeBits *)
 lemma raw_tcb_cte_cases_simps:
-  "tcb_cte_cases 0  = Some (tcbCTable, tcbCTable_update)"
   "tcb_cte_cases 16 = Some (tcbVTable, tcbVTable_update)"
   "tcb_cte_cases 32 = Some (tcbReply, tcbReply_update)"
   "tcb_cte_cases 48 = Some (tcbCaller, tcbCaller_update)"
@@ -252,7 +251,7 @@ begin
 
 lemma pspace_in_kernel_mappings_update' [iff]:
   "pspace_in_kernel_mappings' (f s) = pspace_in_kernel_mappings' s"
-  by (simp add: pspace_in_kernel_mappings'_def)
+  by simp
 
 lemma valid_asid_table_update' [iff]:
   "valid_asid_table' t (f s) = valid_asid_table' t s"
@@ -308,7 +307,7 @@ lemma tcb_hyp_refs_of'_simps[simp]:
 
 lemma refs_of_a'_simps[simp]:
   "refs_of_a' ako = {}"
-  by (auto simp: refs_of_a'_def)
+  by auto
 
 lemma hyp_refs_of_hyp_live':
   "hyp_refs_of' ko \<noteq> {} \<Longrightarrow> hyp_live' ko"
@@ -429,7 +428,7 @@ end (* typ_at_props' *)
 context Arch begin arch_global_naming
 
 lemmas bit_simps' = pteBits_def pdeBits_def asidHighBits_def asid_low_bits_def word_size_bits_def
-                    asid_high_bits_def bit_simps
+                    asid_high_bits_def
 
 lemma objBitsT_simps:
   "objBitsT EndpointT = epSizeBits"

--- a/proof/refine/ARM/ArchKHeap_R.thy
+++ b/proof/refine/ARM/ArchKHeap_R.thy
@@ -118,7 +118,7 @@ lemma obj_relation_cut_same_type:
   done
 
 lemmas obj_at_simps = gen_obj_at_simps is_other_obj_relation_type_def
-                      objBits_simps pageBits_def
+                      word_size_def archObjSize_def pageBits_def
 
 (* No aobjs dependency on this architecture *)
 lemma arch_state_relation_no_aobjs[elim!]:

--- a/proof/refine/ARM/ArchVSpace_R.thy
+++ b/proof/refine/ARM/ArchVSpace_R.thy
@@ -892,7 +892,7 @@ lemma deleteASID_corres:
       apply (drule Some_to_the)
       apply (wpsimp wp: getASID_wp)+
    apply (clarsimp simp: valid_arch_state_def valid_asid_table_def
-                  dest!: invs_arch_state)
+                   del: invs_arch_state dest!: invs_arch_state)
    apply blast
   apply (clarsimp simp: valid_arch_state'_def valid_asid_table'_def)
   done

--- a/proof/refine/ARM/PageTableDuplicates.thy
+++ b/proof/refine/ARM/PageTableDuplicates.thy
@@ -34,7 +34,7 @@ lemma set_ntfn_valid_duplicate' [wp]:
   setNotification ep v  \<lbrace>\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (simp add:setNotification_def)
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd
+                        pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = v,simplified])
@@ -93,7 +93,7 @@ lemma mapM_x_storePTE_updates:
   apply (intro conjI ballI)
    apply (drule(1) bspec)
    apply (clarsimp simp:typ_at'_def ko_wp_at'_def
-     objBits_simps archObjSize_def dest!:koTypeOf_pte
+     objBits_simps dest!:koTypeOf_pte
      split:  Structures_H.kernel_object.split_asm)
    apply (simp add:ps_clear_def dom_fun_upd2[unfolded fun_upd_def])
   apply (erule rsubst[where P=Q])
@@ -170,7 +170,7 @@ lemma page_table_at_set_list:
     apply simp
    apply (simp add:shiftl_less_t2n word_shiftl_add_distrib
      word_bits_def mask_def shiftr_mask2)
-  apply (clarsimp simp:objBits_simps pageBits_def archObjSize_def
+  apply (clarsimp simp:objBits_simps pageBits_def
      split:Structures_H.kernel_object.splits arch_kernel_object.splits)
   apply (subst upto_enum_step_subtract)
    apply (rule is_aligned_no_wrap'[OF is_aligned_neg_mask])
@@ -190,7 +190,7 @@ lemma page_table_at_set_list:
       dest!: koTypeOf_pte)
     apply (drule pspace_alignedD')
      apply simp
-    apply (simp add:objBits_simps archObjSize_def pteBits_def)
+    apply (simp add:objBits_simps pteBits_def)
    apply simp
   apply clarsimp
   apply (rule le_shiftr)
@@ -241,7 +241,7 @@ lemma page_directory_at_set_list:
     apply simp
    apply (simp add:shiftl_less_t2n word_shiftl_add_distrib
      word_bits_def mask_def shiftr_mask2)
-  apply (clarsimp simp:objBits_simps pageBits_def archObjSize_def
+  apply (clarsimp simp:objBits_simps pageBits_def
      split:Structures_H.kernel_object.splits arch_kernel_object.splits)
   apply (subst upto_enum_step_subtract)
    apply (rule is_aligned_no_wrap'[OF is_aligned_neg_mask])
@@ -261,7 +261,7 @@ lemma page_directory_at_set_list:
       dest!: koTypeOf_pde)
     apply (drule pspace_alignedD')
      apply simp
-    apply (simp add:objBits_simps archObjSize_def pdeBits_def)
+    apply (simp add:objBits_simps pdeBits_def)
    apply simp
   apply clarsimp
   apply (rule le_shiftr)
@@ -326,7 +326,7 @@ lemma mapM_x_storePTE_update_helper:
     apply (drule_tac p' = x in page_table_at_pte_atD')
       apply (drule pspace_alignedD')
        apply simp
-      apply (simp add:objBits_simps' archObjSize_def pteBits_def
+      apply (simp add:objBits_simps' pteBits_def
         is_aligned_weaken[where y = 2] pageBits_def pdeBits_def
         split:kernel_object.splits arch_kernel_object.splits)
      apply (simp add:mask_lower_twice)
@@ -390,7 +390,7 @@ lemma mapM_x_storePDE_updates:
   apply (intro conjI ballI)
    apply (drule(1) bspec)
    apply (clarsimp simp:typ_at'_def ko_wp_at'_def
-     objBits_simps archObjSize_def dest!:koTypeOf_pde
+     objBits_simps dest!:koTypeOf_pde
      split:  Structures_H.kernel_object.split_asm  arch_kernel_object.split_asm if_split)
    apply (simp add:ps_clear_def dom_fun_upd2[unfolded fun_upd_def])
   apply (erule rsubst[where P=Q])
@@ -439,7 +439,7 @@ lemma mapM_x_storePDE_update_helper:
     apply (drule_tac p' = x in page_directory_at_pde_atD')
       apply (drule pspace_alignedD')
        apply simp
-      apply (simp add:objBits_simps' archObjSize_def pteBits_def
+      apply (simp add:objBits_simps' pteBits_def
         is_aligned_weaken[where y = 2] pageBits_def pdeBits_def
         split:kernel_object.splits arch_kernel_object.splits)
      apply (simp add:mask_lower_twice)
@@ -562,7 +562,7 @@ proof -
     apply (drule(1) pspace_alignedD')
     apply (drule is_aligned_weaken[where y=2])
      apply (case_tac y, simp_all add: objBits_simps' pageBits_def)
-    apply (simp add: archObjSize_def pageBits_def pteBits_def pdeBits_def
+    apply (simp add: pageBits_def pteBits_def pdeBits_def
                 split: arch_kernel_object.splits)
     done
 
@@ -912,7 +912,7 @@ shows
    apply simp
   using pdpt_align
   apply (clarsimp simp: image_def vs_entry_align_def vs_ptr_align_def
-    new_cap_addrs_def objBits_simps archObjSize_def pdeBits_def pteBits_def
+    new_cap_addrs_def objBits_simps pdeBits_def pteBits_def
     split:ARM_H.pde.splits ARM_H.pte.splits arch_kernel_object.splits
     Structures_H.kernel_object.splits)
   done
@@ -938,13 +938,13 @@ lemma valid_duplicates'_insert_ko:
     apply (drule_tac p' = y in new_cap_addrs_same_align_pdpt_bits)
          apply (simp add:vs_entry_align_def)
         apply (simp add:vs_ptr_align_def)
-       apply (simp add:objBits_simps archObjSize_def pteBits_def)+
+       apply (simp add:objBits_simps pteBits_def)+
    apply (clarsimp split: ARM_H.pde.splits simp:objBits_simps)
    apply (drule(1) bspec)+
    apply (drule_tac p' = y in new_cap_addrs_same_align_pdpt_bits)
         apply (simp add:vs_entry_align_def)
        apply (simp add:vs_ptr_align_def)
-      apply (simp add:objBits_simps archObjSize_def pdeBits_def)+
+      apply (simp add:objBits_simps pdeBits_def)+
   apply clarsimp
   apply (intro conjI impI allI)
    apply (drule(1) valid_duplicates'_D)
@@ -1054,30 +1054,30 @@ lemma createObject_valid_duplicates'[wp]:
                         APIType_capBits_def objBits_simps pageBits_def)+
      apply (rule none_in_new_cap_addrs[where us =12,simplified]
       ,(simp add: objBits_simps pageBits_def word_bits_conv)+)[1]
-    apply (clarsimp simp: objBits_simps ptBits_def archObjSize_def pageBits_def)
+    apply (clarsimp simp: objBits_simps ptBits_def pageBits_def)
    apply (cut_tac ptr=ptr in new_cap_addrs_fold'[where n = "0x100" and ko = "(KOArch (KOPTE makeObject))"
       ,simplified objBits_simps])
     apply simp
-   apply (clarsimp simp: archObjSize_def)
+   apply clarsimp
    apply (erule valid_duplicates'_insert_ko[where us = 8,simplified])
-      apply (simp add: toAPIType_def archObjSize_def vs_entry_align_def
+      apply (simp add: toAPIType_def vs_entry_align_def
                        APIType_capBits_def objBits_simps pageBits_def
                        pdeBits_def pteBits_def
                 split: ARM_H.pte.splits)+
     apply (rule none_in_new_cap_addrs[where us =8,simplified]
-      ,(simp add: objBits_simps pageBits_def word_bits_conv archObjSize_def pteBits_def)+)[1]
+      ,(simp add: objBits_simps pageBits_def word_bits_conv pteBits_def)+)[1]
    apply clarsimp
    apply (cut_tac ptr=ptr in new_cap_addrs_fold'[where n = "0x1000" and ko = "(KOArch (KOPDE makeObject))"
      ,simplified objBits_simps])
     apply simp
-   apply (clarsimp simp: objBits_simps archObjSize_def pdBits_def pageBits_def)
+   apply (clarsimp simp: objBits_simps pdBits_def pageBits_def)
    apply (frule(2) retype_aligned_distinct'[where n = 4096 and ko = "KOArch (KOPDE makeObject)"])
-    apply (simp add:objBits_simps archObjSize_def)
+    apply (simp add:objBits_simps)
     apply (rule range_cover_rel[OF range_cover_full])
        apply simp
       apply (simp add:APIType_capBits_def word_bits_def pdeBits_def)+
    apply (frule(2) retype_aligned_distinct'(2)[where n = 4096 and ko = "KOArch (KOPDE makeObject)"])
-    apply (simp add:objBits_simps archObjSize_def)
+    apply (simp add:objBits_simps)
     apply (rule range_cover_rel[OF range_cover_full])
        apply simp
       apply (simp add:APIType_capBits_def word_bits_def pdeBits_def)+
@@ -1086,13 +1086,13 @@ lemma createObject_valid_duplicates'[wp]:
                   (map (\<lambda>n. ptr + (n << 2)) [0.e.2 ^ (pdBits - 2) - 1]) (ksPSpace s))")
     apply (simp add:APIType_capBits_def pdBits_def pageBits_def pdeBits_def
      data_map_insert_def[abs_def])
-   apply (clarsimp simp: archObjSize_def pdBits_def pageBits_def pdeBits_def)
+   apply (clarsimp simp: pdBits_def pageBits_def pdeBits_def)
    apply (rule valid_duplicates'_insert_ko[where us = 12,simplified])
-      apply (simp add: ARM_H.toAPIType_def archObjSize_def vs_entry_align_def
+      apply (simp add: ARM_H.toAPIType_def vs_entry_align_def
                        APIType_capBits_def objBits_simps pageBits_def pdeBits_def
                 split: ARM_H.pde.splits)+
    apply (rule none_in_new_cap_addrs[where us =12,simplified]
-     ,(simp add: objBits_simps pageBits_def word_bits_conv archObjSize_def pdeBits_def)+)[1]
+     ,(simp add: objBits_simps pageBits_def word_bits_conv pdeBits_def)+)[1]
   supply APIType_capBits_generic[simp del]
   supply if_cong[cong]
   apply (intro conjI impI allI)
@@ -1122,7 +1122,7 @@ lemma createObject_valid_duplicates'[wp]:
    apply (simp add: objBits_simps')
    apply (rule none_in_new_cap_addrs
      ,(simp add: objBits_simps' pageBits_def APIType_capBits_def
-                 word_bits_conv archObjSize_def is_aligned_mask
+                 word_bits_conv is_aligned_mask
           split: ARM_H.object_type.splits)+)[1]
   apply (clarsimp simp: word_bits_def)
  done
@@ -1410,7 +1410,7 @@ lemma invokeUntyped_valid_duplicates[wp]:
   apply (frule invokeUntyped_proofs.not_0_ptr)
   apply (strengthen is_aligned_armKSGlobalPD)
   apply (frule cte_wp_at_valid_objs_valid_cap'[OF ctes_of_cte_wpD], clarsimp+)
-  apply (clarsimp simp add: isCap_simps valid_cap_simps' capAligned_def objSize_eq_capBits)
+  apply (clarsimp simp add: isCap_simps valid_cap_simps' capAligned_def)
   apply (auto split: if_split_asm)
   done
 
@@ -1447,7 +1447,7 @@ lemma set_asid_pool_valid_duplicates'[wp]:
   setObject a (pool::asidpool)
   \<lbrace>\<lambda>r s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd
+                        pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = pool,simplified])
@@ -1782,7 +1782,7 @@ lemma mapM_x_storePTE_invalid_whole:
    \<lbrace>\<lambda>_ s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (wp mapM_x_storePTE_update_helper[where word = word and sz = ptBits and ptr = word])
   apply (clarsimp simp: valid_cap'_def capAligned_def pageBits_def ptBits_def objBits_simps
-                        archObjSize_def pteBits_def)
+                        pteBits_def)
   apply (simp add: mask_def field_simps pteBits_def)
   done
 
@@ -1847,13 +1847,13 @@ lemma invokeCNode_valid_duplicates'[wp]:
 lemma getObject_pte_sp:
   "\<lbrace>P\<rbrace> getObject r \<lbrace>\<lambda>t::pte. P and ko_at' t r\<rbrace>"
   apply (wp getObject_ko_at)
-  apply (auto simp: objBits_simps archObjSize_def pteBits_def)
+  apply (auto simp: objBits_simps pteBits_def)
   done
 
 lemma getObject_pde_sp:
   "\<lbrace>P\<rbrace> getObject r \<lbrace>\<lambda>t::pde. P and ko_at' t r\<rbrace>"
   apply (wp getObject_ko_at)
-  apply (auto simp: objBits_simps archObjSize_def pdeBits_def)
+  apply (auto simp: objBits_simps pdeBits_def)
   done
 
 lemma performPageInvocation_valid_duplicates'[wp]:

--- a/proof/refine/ARM_HYP/ArchArchAcc_R.thy
+++ b/proof/refine/ARM_HYP/ArchArchAcc_R.thy
@@ -356,14 +356,14 @@ lemma getObject_pde_ko_at':
   "(pde::pde, s') \<in> fst (getObject p s) \<Longrightarrow> s' = s \<and> ko_at' pde p s"
   apply (rule context_conjI)
    apply (drule use_valid, rule getObject_inv[where P="(=) s"]; simp add: loadObject_default_inv)
-  apply (drule use_valid, rule getObject_ko_at; clarsimp simp: obj_at_simps pde_bits_def)
+  apply (drule use_valid, rule getObject_ko_at; clarsimp simp: pde_bits_def)
   done
 
 lemma getObject_pte_ko_at':
   "(pte::pte, s') \<in> fst (getObject p s) \<Longrightarrow> s' = s \<and> ko_at' pte p s"
   apply (rule context_conjI)
    apply (drule use_valid, rule getObject_inv[where P="(=) s"]; simp add: loadObject_default_inv)
-  apply (drule use_valid, rule getObject_ko_at; clarsimp simp: obj_at_simps pte_bits_def)
+  apply (drule use_valid, rule getObject_ko_at; clarsimp simp: pte_bits_def)
   done
 
 lemma ko_at'_pd:
@@ -1655,10 +1655,10 @@ lemma obj_relation_cuts_range_limit:
        apply (rule_tac x=tcbBlockSizeBits in exI)
        apply (simp add: tcbBlockSizeBits_def)
       apply (rule_tac x=pteBits in exI)
-      apply (simp add: bit_simps is_aligned_shift mask_def vspace_bits_defs)
+      apply (simp add: is_aligned_shift mask_def vspace_bits_defs)
       apply word_bitwise
      apply (rule_tac x=pdeBits in exI)
-     apply (simp add: bit_simps is_aligned_shift mask_def vspace_bits_defs)
+     apply (simp add: is_aligned_shift mask_def vspace_bits_defs)
      apply word_bitwise
     apply (rule_tac x=pageBits in exI)
     apply (simp add: is_aligned_shift pbfs_atleast_pageBits is_aligned_mult_triv2)
@@ -1683,7 +1683,7 @@ lemma obj_relation_cuts_range_mask_range[Arch_assms]:
 lemma obj_relation_cuts_obj_bits:
   "\<lbrakk> (p', P) \<in> obj_relation_cuts ko p; P ko ko' \<rbrakk> \<Longrightarrow> objBitsKO ko' \<le> obj_bits ko"
   apply (erule (1) obj_relation_cutsE;
-          clarsimp simp: objBits_simps objBits_defs bit_simps cte_level_bits_def
+          clarsimp simp: objBits_simps objBits_defs cte_level_bits_def
                          pbfs_atleast_pageBits[simplified vspace_bits_defs] vspace_bits_defs)
    apply (cases ko; simp add: other_obj_relation_def objBits_defs split: kernel_object.splits)
   apply (rename_tac ako)
@@ -1702,9 +1702,7 @@ lemma pspace_distinct_cross[Arch_assms]:
   apply (frule (1) pspace_alignedD')
   apply (frule (1) pspace_alignedD)
   apply (rule ps_clearI, assumption)
-   apply (case_tac ko'; simp add: objBits_defs obj_at_simps)
-   apply (simp split: arch_kernel_object.splits
-                 add: obj_at_simps vspace_bits_defs vcpu_bits_def)
+   apply (case_tac ko'; simp)
   apply (rule ccontr, clarsimp)
   apply (rename_tac x' ko_x')
   apply (frule_tac x=x' in pspace_alignedD', assumption)

--- a/proof/refine/ARM_HYP/ArchArch_R.thy
+++ b/proof/refine/ARM_HYP/ArchArch_R.thy
@@ -2146,7 +2146,7 @@ lemma assoc_invs':
   apply (rule conjI)
    apply (clarsimp simp: typ_at_to_obj_at_arches obj_at'_def)
   apply (rule conjI)
-   apply (fastforce dest!: obj_at_aligned' simp add: objBits_def objBits_simps')
+   apply (fastforce dest!: obj_at_aligned' simp: objBits_simps')
   supply fun_upd_apply[simp]
   apply (clarsimp simp: hyp_live'_def arch_live'_def)
   apply (rule_tac rfs'="state_hyp_refs_of' s" in delta_sym_refs, assumption)

--- a/proof/refine/ARM_HYP/ArchDetype_R.thy
+++ b/proof/refine/ARM_HYP/ArchDetype_R.thy
@@ -1717,8 +1717,6 @@ lemma createObject_pspace_aligned_distinct':
    and K (ty = APIObjectType apiobject_type.CapTableObject \<longrightarrow> us < 28)\<rbrace>
   createObject ty ptr us d
   \<lbrace>\<lambda>xa s. pspace_aligned' s \<and> pspace_distinct' s\<rbrace>"
-  (* FIXME: work around warning due to vcpuBits_def being in both bit_simps and objBits_simps' *)
-  supply vcpuBits_def[bit_simps del]
   apply (rule hoare_pre)
    apply (wp placeNewObject_pspace_aligned' unless_wp
              placeNewObject_pspace_distinct'

--- a/proof/refine/ARM_HYP/ArchInvsLemmas_H.thy
+++ b/proof/refine/ARM_HYP/ArchInvsLemmas_H.thy
@@ -30,7 +30,7 @@ lemmas wordRadix_def' = wordRadix_def[simplified]
 lemma wordSizeCase_simp[simp]: "wordSizeCase a b = a"
   by (simp add: wordSizeCase_def wordBits_def word_size)
 
-lemmas objBits_defs = tcbBlockSizeBits_def epSizeBits_def ntfnSizeBits_def cteSizeBits_def vcpuBits_def
+lemmas objBits_defs = tcbBlockSizeBits_def epSizeBits_def ntfnSizeBits_def cteSizeBits_def
 lemmas untypedBits_defs = minUntypedSizeBits_def maxUntypedSizeBits_def
 lemmas objBits_simps = objBits_def objBitsKO_def word_size_def archObjSize_def
 lemmas objBits_simps' = objBits_simps objBits_defs
@@ -108,7 +108,6 @@ clear_named_theorems Arch_assms (* accumulate assumptions for Invariants_H_cte_a
 
 (* FIXME arch-split: for proofs which require exact offsets lining up instead of cteSizeBits *)
 lemma raw_tcb_cte_cases_simps:
-  "tcb_cte_cases 0  = Some (tcbCTable, tcbCTable_update)"
   "tcb_cte_cases 16 = Some (tcbVTable, tcbVTable_update)"
   "tcb_cte_cases 32 = Some (tcbReply, tcbReply_update)"
   "tcb_cte_cases 48 = Some (tcbCaller, tcbCaller_update)"
@@ -249,7 +248,7 @@ begin
 
 lemma pspace_in_kernel_mappings_update' [iff]:
   "pspace_in_kernel_mappings' (f s) = pspace_in_kernel_mappings' s"
-  by (simp add: pspace_in_kernel_mappings'_def)
+  by simp
 
 lemma valid_asid_table_update' [iff]:
   "valid_asid_table' t (f s) = valid_asid_table' t s"
@@ -470,7 +469,7 @@ end (* typ_at_props' *)
 context Arch begin arch_global_naming
 
 lemmas bit_simps' = pteBits_def pdeBits_def asidHighBits_def asid_low_bits_def word_size_bits_def
-                    asid_high_bits_def bit_simps
+                    asid_high_bits_def
 
 lemma objBitsT_simps:
   "objBitsT EndpointT = epSizeBits"

--- a/proof/refine/ARM_HYP/ArchKHeap_R.thy
+++ b/proof/refine/ARM_HYP/ArchKHeap_R.thy
@@ -176,7 +176,7 @@ lemma obj_relation_cut_same_type:
   done
 
 lemmas obj_at_simps = gen_obj_at_simps is_other_obj_relation_type_def
-                      objBits_simps pageBits_def
+                      word_size_def archObjSize_def pageBits_def
 
 (* No aobjs dependency on this architecture *)
 lemma arch_state_relation_no_aobjs[elim!]:

--- a/proof/refine/ARM_HYP/ArchRetype_R.thy
+++ b/proof/refine/ARM_HYP/ArchRetype_R.thy
@@ -145,8 +145,6 @@ lemma makeObjectKO_eq[Arch_assms]:
 
 lemma objBits_le_obj_bits_api[Arch_assms]:
   "makeObjectKO dev d ty = Some ko \<Longrightarrow> objBitsKO ko \<le> obj_bits_api (APIType_map2 ty) us"
-  (* FIXME: work around warning due to vcpuBits_def being in both bit_simps and objBits_simps' *)
-  supply vcpuBits_def[bit_simps del]
   apply (case_tac ty)
     apply (auto simp: default_arch_object_def vspace_bits_defs vcpu_bits_def
                       makeObjectKO_def objBits_simps' APIType_map2_def obj_bits_api_def slot_bits_def

--- a/proof/refine/ARM_HYP/ArchVSpace_R.thy
+++ b/proof/refine/ARM_HYP/ArchVSpace_R.thy
@@ -1393,7 +1393,7 @@ lemma deleteASID_corres:
       apply (drule Some_to_the)
       apply (wpsimp wp: getASID_wp)+
    apply (clarsimp simp: valid_arch_state_def valid_asid_table_def
-                  dest!: invs_arch_state)
+                   del: invs_arch_state dest!: invs_arch_state)
    apply blast
   apply (clarsimp simp: valid_arch_state'_def valid_asid_table'_def)
   done

--- a/proof/refine/ARM_HYP/PageTableDuplicates.thy
+++ b/proof/refine/ARM_HYP/PageTableDuplicates.thy
@@ -15,7 +15,7 @@ lemma set_ntfn_valid_duplicate' [wp]:
   setNotification ep v  \<lbrace>\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (simp add:setNotification_def)
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd
+                        pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = v,simplified])
@@ -36,11 +36,6 @@ crunch setupReplyMaster
   for valid_duplicates'[wp]: "(\<lambda>s. vs_valid_duplicates' (ksPSpace s))"
   (wp: crunch_wps simp: crunch_simps)
 
-
-(* we need the following lemma in ArchSyscall_R *)
-crunch getRegister
-  for inv[wp]: "P"
-
 lemma doMachineOp_ksPSpace_inv[wp]:
   "\<lbrace>\<lambda>s. P (ksPSpace s)\<rbrace> doMachineOp f \<lbrace>\<lambda>ya s. P (ksPSpace s)\<rbrace>"
   by (simp add:doMachineOp_def split_def | wp)+
@@ -50,7 +45,7 @@ lemma setEP_valid_duplicates'[wp]:
   setEndpoint a b \<lbrace>\<lambda>_ s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (simp add:setEndpoint_def)
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd
+                        pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = b,simplified])
@@ -65,7 +60,7 @@ lemma setTCB_valid_duplicates'[wp]:
  "\<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace>
   setObject a (tcb::tcb) \<lbrace>\<lambda>rv s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd
+                        pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = tcb,simplified])
@@ -91,22 +86,9 @@ lemma getExtraCptrs_valid_duplicates'[wp]:
   apply (wpc|simp|wp mapM_wp')+
   done
 
-crunch getExtraCPtrs
-  for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
-  (wp: setObject_ksInterrupt asUser_inv updateObject_default_inv)
-
-crunch lookupExtraCaps
-  for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
-  (wp: setObject_ksInterrupt asUser_inv updateObject_default_inv mapME_wp)
-
 crunch setExtraBadge
   for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
   (wp: setObject_ksInterrupt asUser_inv updateObject_default_inv mapME_wp)
-
-crunch getReceiveSlots
-  for valid_duplicates'[wp]: "\<lambda>s. vs_valid_duplicates' (ksPSpace s)"
-  (simp: unless_def getReceiveSlots_def
-     wp: setObject_ksInterrupt asUser_inv updateObject_default_inv mapME_wp)
 
 lemma transferCapsToSlots_duplicates'[wp]:
  "\<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace>
@@ -167,7 +149,7 @@ lemma mapM_x_storePTE_updates:
   apply clarsimp
   apply (intro conjI ballI)
    apply (drule(1) bspec)
-   apply (clarsimp simp:typ_at'_def ko_wp_at'_def objBits_simps archObjSize_def lookupAround2_known1
+   apply (clarsimp simp:typ_at'_def ko_wp_at'_def objBits_simps lookupAround2_known1
                   dest!:koTypeOf_pte)
    apply (simp add:ps_clear_def dom_fun_upd2[unfolded fun_upd_def])
   apply (erule rsubst[where P=Q])
@@ -245,7 +227,7 @@ lemma page_table_at_set_list:
     apply simp
    apply (simp add:shiftl_less_t2n word_shiftl_add_distrib
      word_bits_def mask_def shiftr_mask2)
-  apply (clarsimp simp:objBits_simps pageBits_def archObjSize_def
+  apply (clarsimp simp:objBits_simps pageBits_def
      split:Structures_H.kernel_object.splits arch_kernel_object.splits)
   apply (subst upto_enum_step_subtract)
    apply (rule is_aligned_no_wrap'[OF is_aligned_neg_mask])
@@ -265,7 +247,7 @@ lemma page_table_at_set_list:
       dest!: koTypeOf_pte)
     apply (drule pspace_alignedD')
      apply simp
-    apply (simp add:vspace_bits_defs objBits_simps archObjSize_def)
+    apply (simp add:vspace_bits_defs objBits_simps)
    apply simp
   apply clarsimp
   apply (rule le_shiftr)
@@ -283,8 +265,7 @@ lemma page_directory_at_set_list:
    apply (subst (asm) upto_enum_step_subtract)
     apply (simp add:field_simps mask_def)
     apply (erule is_aligned_no_overflow)
-   apply (clarsimp simp:set_upto_enum_step_8 vspace_bits_defs
-           image_def pageBits_def)
+   apply (clarsimp simp: set_upto_enum_step_8 vspace_bits_defs image_def)
    apply (drule_tac x= "((p && mask 14) >> 3) + xb" in spec)
    apply (erule impE)
     apply (rule is_aligned_plus_bound[where lz = 11 and sz = "sz - 3" ,simplified])
@@ -316,7 +297,7 @@ lemma page_directory_at_set_list:
     apply simp
    apply (simp add:shiftl_less_t2n word_shiftl_add_distrib
      word_bits_def mask_def shiftr_mask2)
-  apply (clarsimp simp:objBits_simps pageBits_def archObjSize_def
+  apply (clarsimp simp:objBits_simps pageBits_def
      split:Structures_H.kernel_object.splits arch_kernel_object.splits)
   apply (subst upto_enum_step_subtract)
    apply (rule is_aligned_no_wrap'[OF is_aligned_neg_mask])
@@ -336,7 +317,7 @@ lemma page_directory_at_set_list:
       dest!: koTypeOf_pde)
     apply (drule pspace_alignedD')
      apply simp
-    apply (simp add:objBits_simps archObjSize_def vspace_bits_defs)
+    apply (simp add:objBits_simps vspace_bits_defs)
    apply simp
   apply clarsimp
   apply (rule le_shiftr)
@@ -406,7 +387,7 @@ lemma mapM_x_storePTE_update_helper:
      apply (simp add: AND_NOT_mask_plus_AND_mask_eq)
     apply (subst aligned_shiftr_mask_shiftl)
      apply (drule (1) pspace_alignedD')
-     apply (simp add: objBits_simps archObjSize_def vspace_bits_defs)
+     apply (simp add: objBits_simps vspace_bits_defs)
     apply simp
    apply (clarsimp simp: vspace_bits_defs mask_lower_twice)
    apply (drule (1) bspec, clarsimp)
@@ -434,7 +415,7 @@ lemma mapM_x_storePTE_update_helper:
     apply (simp add: AND_NOT_mask_plus_AND_mask_eq)
    apply (subst aligned_shiftr_mask_shiftl)
     apply (drule (1) pspace_alignedD')
-    apply (simp add: objBits_simps archObjSize_def vspace_bits_defs)
+    apply (simp add: objBits_simps vspace_bits_defs)
    apply simp
   apply (clarsimp simp: vspace_bits_defs mask_lower_twice)
   apply (drule (1) bspec, clarsimp)
@@ -484,7 +465,7 @@ lemma mapM_x_storePDE_updates:
   apply clarsimp
   apply (intro conjI ballI)
    apply (drule(1) bspec)
-   apply (clarsimp simp:typ_at'_def ko_wp_at'_def objBits_simps archObjSize_def lookupAround2_known1
+   apply (clarsimp simp:typ_at'_def ko_wp_at'_def objBits_simps lookupAround2_known1
                   dest!:koTypeOf_pde)
    apply (simp add:ps_clear_def dom_fun_upd2[unfolded fun_upd_def])
   apply (erule rsubst[where P=Q])
@@ -521,7 +502,7 @@ lemma mapM_x_storePDE_update_helper:
      apply (simp add: AND_NOT_mask_plus_AND_mask_eq)
     apply (subst aligned_shiftr_mask_shiftl)
      apply (drule (1) pspace_alignedD')
-     apply (simp add: objBits_simps archObjSize_def vspace_bits_defs)
+     apply (simp add: objBits_simps vspace_bits_defs)
     apply simp
    apply (clarsimp simp: vspace_bits_defs mask_lower_twice)
    apply (drule (1) bspec, clarsimp)
@@ -549,7 +530,7 @@ lemma mapM_x_storePDE_update_helper:
     apply (simp add: AND_NOT_mask_plus_AND_mask_eq)
    apply (subst aligned_shiftr_mask_shiftl)
     apply (drule (1) pspace_alignedD')
-    apply (simp add: objBits_simps archObjSize_def vspace_bits_defs)
+    apply (simp add: objBits_simps vspace_bits_defs)
    apply simp
   apply (clarsimp simp: vspace_bits_defs mask_lower_twice)
   apply (drule (1) bspec, clarsimp)
@@ -687,29 +668,29 @@ lemma createObject_valid_duplicates'[wp]:
                         APIType_capBits_def objBits_simps pageBits_def)+
      apply (rule none_in_new_cap_addrs[where us =13,simplified]
       ,(simp add: objBits_simps pageBits_def word_bits_conv)+)[1]
-    apply (clarsimp simp: objBits_simps ptBits_def archObjSize_def pageBits_def)
+    apply (clarsimp simp: objBits_simps ptBits_def pageBits_def)
    apply (cut_tac ptr=ptr in new_cap_addrs_fold'[where n = "0x200" and ko = "(KOArch (KOPTE makeObject))"
       ,simplified objBits_simps])
     apply simp
    apply (clarsimp simp: archObjSize_def pt_bits_def pte_bits_def)
    apply (erule valid_duplicates'_insert_ko[where us = 9,simplified])
-      apply (simp add: toAPIType_def archObjSize_def nondup_obj_def makeObject_pte
+      apply (simp add: toAPIType_def nondup_obj_def makeObject_pte
                        APIType_capBits_def objBits_simps pageBits_def pte_bits_def
                 split: ARM_HYP_H.pte.splits)+
     apply (rule none_in_new_cap_addrs[where us =9,simplified]
-      ,(simp add: objBits_simps pageBits_def word_bits_conv archObjSize_def pte_bits_def)+)[1]
+      ,(simp add: objBits_simps pageBits_def word_bits_conv pte_bits_def)+)[1]
    apply (clarsimp simp: pd_bits_def pde_bits_def)
    apply (cut_tac ptr=ptr in new_cap_addrs_fold'[where n = "0x0800" and ko = "(KOArch (KOPDE makeObject))"
      ,simplified objBits_simps])
     apply simp
-   apply (clarsimp simp: objBits_simps archObjSize_def pdBits_def pageBits_def pde_bits_def)
+   apply (clarsimp simp: objBits_simps pdBits_def pageBits_def pde_bits_def)
    apply (frule(2) retype_aligned_distinct'[where n = "0x0800" and ko = "KOArch (KOPDE makeObject)"])
-    apply (simp add:objBits_simps archObjSize_def)
+    apply (simp add: objBits_simps)
     apply (rule range_cover_rel[OF range_cover_full])
        apply simp
       apply (simp add:APIType_capBits_def word_bits_def pde_bits_def)+
    apply (frule(2) retype_aligned_distinct'(2)[where n = "2048" and ko = "KOArch (KOPDE makeObject)"])
-    apply (simp add:objBits_simps archObjSize_def)
+    apply (simp add:objBits_simps)
     apply (rule range_cover_rel[OF range_cover_full])
        apply simp
       apply (simp add:APIType_capBits_def word_bits_def pde_bits_def)+
@@ -718,13 +699,13 @@ lemma createObject_valid_duplicates'[wp]:
                   (map (\<lambda>n. ptr + (n << 3)) [0.e.0x7FF]) (ksPSpace s))")
      apply (simp add:APIType_capBits_def pdBits_def pageBits_def pde_bits_def pd_bits_def
      data_map_insert_def[abs_def])
-    apply (clarsimp simp: archObjSize_def pdBits_def pageBits_def pdBits_def pd_bits_def pde_bits_def)
+    apply (clarsimp simp: pageBits_def pdBits_def pd_bits_def pde_bits_def)
     apply (rule valid_duplicates'_insert_ko[where us = 11,simplified])
-        apply (simp add: ARM_HYP_H.toAPIType_def archObjSize_def nondup_obj_def makeObject_pde
+        apply (simp add: ARM_HYP_H.toAPIType_def nondup_obj_def makeObject_pde
                        APIType_capBits_def objBits_simps pageBits_def pde_bits_def
                 split: ARM_HYP_H.pde.splits)+
     apply (rule none_in_new_cap_addrs[where us =11,simplified],
-           (simp add: objBits_simps pageBits_def word_bits_conv archObjSize_def pde_bits_def)+)[1]
+           (simp add: objBits_simps pageBits_def word_bits_conv pde_bits_def)+)[1]
 
    apply clarsimp
    apply (erule(2) valid_duplicates'_update)
@@ -758,7 +739,7 @@ lemma createObject_valid_duplicates'[wp]:
    apply simp
    apply (rule none_in_new_cap_addrs
      ,(simp add: objBits_simps' pageBits_def APIType_capBits_gen_def
-                 word_bits_conv archObjSize_def is_aligned_mask
+                 word_bits_conv is_aligned_mask
           split: ARM_HYP_H.object_type.splits)+)[1]
   apply (clarsimp simp: word_bits_def)
  done
@@ -998,7 +979,7 @@ lemma invokeUntyped_valid_duplicates[wp]:
   apply (frule new_CapTable_bound)
   apply (frule invokeUntyped_proofs.not_0_ptr)
   apply (frule cte_wp_at_valid_objs_valid_cap'[OF ctes_of_cte_wpD], clarsimp+)
-  apply (clarsimp simp add: isCap_simps valid_cap_simps' capAligned_def objSize_eq_capBits)
+  apply (clarsimp simp add: isCap_simps valid_cap_simps' capAligned_def)
   apply (auto split: if_split_asm)
   done
 
@@ -1011,13 +992,13 @@ crunch
 lemma setVCPU_valid_duplicates'[wp]:
  "setObject a (vcpu::vcpu) \<lbrace>\<lambda>s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd
+                        pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = vcpu,simplified])
   apply (clarsimp simp:updateObject_default_def assert_def bind_def
     alignCheck_def in_monad when_def alignError_def magnitudeCheck_def
-    assert_opt_def return_def fail_def typeError_def projectKOs
+    assert_opt_def return_def fail_def typeError_def
     split:if_splits option.splits Structures_H.kernel_object.splits)
      apply (erule valid_duplicates'_non_pd_pt_I[rotated 3],simp+)+
   done
@@ -1053,7 +1034,7 @@ lemma set_asid_pool_valid_duplicates'[wp]:
   setObject a (pool::asidpool)
   \<lbrace>\<lambda>r s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd
+                        pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = pool,simplified])
@@ -1287,7 +1268,7 @@ lemma setVCPU_nondup_obj[wp]:
    setObject a (vcpu::vcpu)
   \<lbrace>\<lambda>rv. ko_wp_at' nondup_obj p\<rbrace>"
   apply (clarsimp simp: setObject_def split_def valid_def in_monad
-                        projectKOs pspace_aligned'_def ps_clear_upd
+                        pspace_aligned'_def ps_clear_upd
                         objBits_def[symmetric] lookupAround2_char1
                  split: if_split_asm)
   apply (frule pspace_storable_class.updateObject_type[where v = vcpu,simplified])
@@ -1297,7 +1278,7 @@ lemma setVCPU_nondup_obj[wp]:
      by (clarsimp simp: updateObject_default_def assert_def bind_def
                            alignCheck_def in_monad when_def alignError_def magnitudeCheck_def
                            assert_opt_def return_def fail_def typeError_def objBits_simps
-                           nondup_obj_def projectKOs archObjSize_def
+                           nondup_obj_def
                     split: if_splits option.splits Structures_H.kernel_object.splits,
          (erule(1) ps_clear_updE)+)
   apply (clarsimp)
@@ -1426,7 +1407,7 @@ lemma mapM_x_storePTE_invalid_whole:
   \<lbrace>\<lambda>y s. vs_valid_duplicates' (ksPSpace s)\<rbrace>"
   apply (wp mapM_x_storePTE_update_helper[where word = word and sz = ptBits and ptr = word])
   apply (clarsimp simp: valid_cap'_def capAligned_def pageBits_def
-                        ptBits_def objBits_simps archObjSize_def)
+                        ptBits_def objBits_simps)
   apply (simp add: mask_def field_simps vspace_bits_defs is_aligned_neg_mask_eq')
   done
 
@@ -1493,15 +1474,13 @@ lemma invokeCNode_valid_duplicates'[wp]:
 
 lemma getObject_pte_sp:
   "\<lbrace>P\<rbrace> getObject r \<lbrace>\<lambda>t::pte. P and ko_at' t r\<rbrace>"
-  apply (wp getObject_ko_at)
-  apply (auto simp: objBits_simps archObjSize_def pte_bits_def)
-  done
+  by (wp getObject_ko_at)
+     (auto simp: objBits_simps pte_bits_def)
 
 lemma getObject_pde_sp:
   "\<lbrace>P\<rbrace> getObject r \<lbrace>\<lambda>t::pde. P and ko_at' t r\<rbrace>"
-  apply (wp getObject_ko_at)
-  apply (auto simp: objBits_simps archObjSize_def pde_bits_def)
-  done
+  by (wp getObject_ko_at)
+     (auto simp: objBits_simps pde_bits_def)
 
 lemma vs_entry_align_nondup_obj:
   "(vs_entry_align ko = 0) = nondup_obj ko"
@@ -1589,7 +1568,7 @@ lemma mapM_x_storePTE_slot_updates:
   apply clarsimp
   apply (intro conjI ballI)
    apply (drule(1) bspec)
-   apply (clarsimp simp:typ_at'_def ko_wp_at'_def objBits_simps archObjSize_def lookupAround2_known1
+   apply (clarsimp simp:typ_at'_def ko_wp_at'_def objBits_simps lookupAround2_known1
                   dest!:koTypeOf_pte)
    apply (simp add:ps_clear_def dom_fun_upd2[unfolded fun_upd_def])
   apply (erule rsubst[where P=Q])
@@ -1623,8 +1602,8 @@ lemma mapM_x_storePDE_slot_updates:
   apply clarsimp
   apply (intro conjI ballI)
    apply (drule(1) bspec)
-   apply (clarsimp simp:typ_at'_def ko_wp_at'_def objBits_simps archObjSize_def lookupAround2_known1
-                  dest!:koTypeOf_pde)
+   apply (clarsimp simp: typ_at'_def ko_wp_at'_def objBits_simps lookupAround2_known1
+                  dest!: koTypeOf_pde)
    apply (simp add:ps_clear_def dom_fun_upd2[unfolded fun_upd_def])
   apply (erule rsubst[where P=Q])
   apply (rule ext)

--- a/proof/refine/Bits_R.thy
+++ b/proof/refine/Bits_R.thy
@@ -9,11 +9,10 @@ theory Bits_R
 imports Corres ArchStateRelationLemmas
 begin
 
-(* FIXME: clearMemory generates a warning on some architectures *)
 crunch_ignore (add:
   withoutFailure throw catchFailure rethrowFailure capFaultOnFailure lookupErrorOnFailure
   nullCapOnFailure nothingOnFailure withoutPreemption preemptionPoint ignoreFailure
-  emptyOnFailure unifyFailure maskInterrupt clearMemory clearMemoryVM  assertDerived
+  emptyOnFailure unifyFailure maskInterrupt clearMemoryVM assertDerived
   setObject getObject updateObject loadObject)
 
 (* FIXME: move to WordLib *)
@@ -104,7 +103,7 @@ context Bits_R begin
 lemma objBitsKO_pos_power2[simp]:
   "(1::machine_word) < 2 ^ objBitsKO ko"
   using objBitsKO_neq_0
-  by (simp add: objBitsKO_less_word_bits word_2p_lem word_bits_size)
+  by (simp add: word_2p_lem word_bits_size)
 
 lemma objBits_less_word_bits:
   "objBits v < word_bits"

--- a/proof/refine/CNodeInv_R.thy
+++ b/proof/refine/CNodeInv_R.thy
@@ -908,10 +908,15 @@ termination finaliseSlot'
 lemmas finaliseSlot'_simps_ext =
     finaliseSlot'.simps [THEN ext [where f="finaliseSlot' slot exp" for slot exp]]
 
+context includes no_valid_cap_syn begin
+
 lemmas finalise_spec_induct = finaliseSlot'.induct[where P=
     "\<lambda>sl exp s. s \<turnstile> \<lbrace>P sl exp\<rbrace> finaliseSlot' sl exp \<lbrace>Q sl exp\<rbrace>,\<lbrace>E sl exp\<rbrace>" for P Q E]
 
+end
+
 lemma finaliseSlot'_preservation:
+  includes no_valid_cap_syn
   assumes wp:
     "\<And>cap final. \<lbrace>P\<rbrace> finaliseCap cap final False \<lbrace>\<lambda>rv. P\<rbrace>"
     "\<And>sl opt. \<lbrace>P\<rbrace> emptySlot sl opt \<lbrace>\<lambda>rv. P\<rbrace>"
@@ -5196,8 +5201,7 @@ lemma capSwap_invs'[wp]:
    \<lbrace>\<lambda>rv. invs'\<rbrace>"
   apply (simp add: capSwapForDelete_def)
   apply (wp getCTE_wp')
-  apply (clarsimp simp: cte_wp_at_ctes_of)
-  apply (auto dest!: ctes_of_valid')
+  apply (auto simp: cte_wp_at_ctes_of)
   done
 
 end (* CNodeInv_R *)
@@ -5839,6 +5843,8 @@ crunch capSwapForDelete
 context CNodeInv_R begin
 
 lemma finaliseSlot_abort_cases':
+  includes no_valid_cap_syn
+  shows
   "s \<turnstile> \<lbrace>\<top>\<rbrace>
        finaliseSlot' sl ex
        \<lbrace>\<lambda>rv s. fst rv \<or> (\<not> ex \<and> cte_wp_at' (\<lambda>cte. isZombie (cteCap cte)
@@ -6028,6 +6034,7 @@ lemma finalise_prop_stuff_archD:
   by (simp add: finalise_prop_stuff_def)
 
 lemma reduceZombie_invs'':
+  includes no_valid_cap_syn
   assumes fin:
   "\<And>s'' rv. \<lbrakk>\<not> (isZombie cap \<and> capZombieNumber cap = 0); \<not> (isZombie cap \<and> \<not> exposed); isZombie cap \<and> exposed;
               (Inr rv, s'')
@@ -6102,6 +6109,7 @@ lemma reduceZombie_invs'':
   done
 
 lemma finaliseSlot_invs':
+  includes no_valid_cap_syn
   assumes finaliseCap:
     "\<And>cap final sl. \<lbrace>no_cte_prop Pr and invs' and sch_act_simple
         and cte_wp_at' (\<lambda>cte. cteCap cte = cap) sl\<rbrace> finaliseCap cap final False \<lbrace>\<lambda>rv. no_cte_prop Pr\<rbrace>"
@@ -6563,6 +6571,8 @@ lemmas finalise_induct3 = finaliseSlot'.induct[where P=
     "\<lambda>sl exp s. P sl (finaliseSlot' sl exp) s" for P]
 
 lemma finaliseSlot_rvk_prog:
+  includes no_valid_cap_syn
+  shows
   "s \<turnstile> \<lbrace>\<lambda>s. revoke_progress_ord m (option_map capToRPO \<circ> cteCaps_of s)\<rbrace>
        finaliseSlot' slot e
        \<lbrace>\<lambda>rv s. revoke_progress_ord m (option_map capToRPO \<circ> cteCaps_of s)\<rbrace>,\<lbrace>\<top>\<top>\<rbrace>"
@@ -7297,6 +7307,7 @@ termination cteRevoke
   done
 
 lemma cteRevoke_preservation':
+  includes no_valid_cap_syn
   assumes x: "\<And>ptr. \<lbrace>P\<rbrace> cteDelete ptr True \<lbrace>\<lambda>rv. P\<rbrace>"
   assumes y: "\<And>f s. P (ksWorkUnitsCompleted_update f s) = P s"
   assumes irq: "irq_state_independent_H P"
@@ -8740,6 +8751,8 @@ crunch capSwapForDelete
   (wp: withoutPreemption_lift)
 
 lemma preemptionPoint_IRQInactive_spec:
+  includes no_valid_cap_syn
+  shows
   "s \<turnstile> \<lbrace>valid_irq_states'\<rbrace>
        preemptionPoint
        \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
@@ -8753,6 +8766,8 @@ crunch finaliseCap
    simp: crunch_simps o_def)
 
 lemma finaliseSlot_IRQInactive':
+  includes no_valid_cap_syn
+  shows
   "s \<turnstile> \<lbrace>valid_irq_states'\<rbrace>
        finaliseSlot' a b
        \<lbrace>\<lambda>_. valid_irq_states'\<rbrace>, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
@@ -8813,6 +8828,8 @@ lemma cteDelete_irq_states':
   done
 
 lemma cteRevoke_IRQInactive':
+  includes no_valid_cap_syn
+  shows
   "s \<turnstile> \<lbrace>valid_irq_states'\<rbrace> cteRevoke x
   \<lbrace>\<lambda>_. \<top>\<rbrace>, \<lbrace>\<lambda>rv s. intStateIRQTable (ksInterruptState s) rv \<noteq> irqstate.IRQInactive\<rbrace>"
 proof (induct rule: cteRevoke.induct)

--- a/proof/refine/CSpace_I.thy
+++ b/proof/refine/CSpace_I.thy
@@ -66,6 +66,7 @@ lemma cap_case_CNodeCap:
 declare resolveAddressBits.simps[simp del]
 
 lemma resolveAddressBits_inv_induct:
+  includes no_valid_cap_syn
   shows
   "s \<turnstile> \<lbrace>P\<rbrace>
      resolveAddressBits cap cref depth
@@ -324,7 +325,8 @@ proof (cases rule: next_rtrancl_tranclE)
   case eq thus ?thesis by simp
 next
   case trancl thus ?thesis
-    by (auto intro: trancl_into_rtrancl elim: mdb_trancl_update_other [OF _ nopath])
+    by (auto del: trancl_into_rtrancl intro: trancl_into_rtrancl
+             elim: mdb_trancl_update_other[OF _ nopath])
 qed
 
 lemma mdb_trancl_other_update:
@@ -360,7 +362,8 @@ proof (cases rule: next_rtrancl_tranclE)
   case eq thus ?thesis by simp
 next
   case trancl thus ?thesis
-    by (auto intro: trancl_into_rtrancl elim: mdb_trancl_other_update [OF _ nopath])
+    by (auto del: trancl_into_rtrancl intro: trancl_into_rtrancl
+             elim: mdb_trancl_other_update[OF _ nopath])
 qed
 
 lemma mdb_chain_0_update:

--- a/proof/refine/CSpace_R.thy
+++ b/proof/refine/CSpace_R.thy
@@ -3907,8 +3907,8 @@ lemma setupReplyMaster_corres:
        apply (rule create_reply_master_corres; simp)
       apply (subgoal_tac "\<exists>cte. cte_wp_at' ((=) cte) (cte_map (t, tcb_cnode_index 2)) s'
                               \<and> cteCap cte = capability.NullCap")
-       apply (fastforce dest: pspace_relation_no_reply_caps
-                             state_relation_pspace_relation)
+       apply (fastforce del: state_relation_pspace_relation
+                        dest: pspace_relation_no_reply_caps state_relation_pspace_relation)
       apply (clarsimp simp: cte_map_def tcb_cnode_index_def cte_wp_at_ctes_of)
      apply (rule_tac Q'="\<lambda>rv. einvs and tcb_at t and
                              cte_wp_at ((=) rv) (t, tcb_cnode_index 2)"
@@ -5180,6 +5180,7 @@ lemma locateSlot_cap_to'[wp]:
 (* FIXME: ambiguous notation between spec_validE (this) and validE; introduce bundles for both,
    unbundle by default, and use `includes no` contexts to disambiguate *)
 lemma rab_cap_to'':
+  includes no_valid_cap_syn
   assumes P: "\<And>cap. isCNodeCap cap \<longrightarrow> P cap"
   shows
   "s \<turnstile> \<lbrace>\<lambda>s. isCNodeCap cap \<longrightarrow> (\<forall>r\<in>cte_refs' cap (irq_node' s). ex_cte_cap_wp_to' P r s)\<rbrace>

--- a/proof/refine/Finalise_R.thy
+++ b/proof/refine/Finalise_R.thy
@@ -1818,8 +1818,6 @@ lemma unbindNotification_invs[wp]:
   apply normalise_obj_at'
   apply (subst delta_sym_refs, assumption)
     apply (auto split: if_split_asm)[1]
-   (* FIXME: weak elimination rule warning for no_0_obj_at' despite supply *)
-   supply no_0_obj_at'[rule del] (* avoid weak elim rule warning *)
    apply (auto simp: tcb_st_not_Bound ntfn_q_refs_of'_mult split: if_split_asm)[1]
   apply (frule obj_at_valid_objs', clarsimp+)
   apply (simp add: valid_ntfn'_def valid_obj'_def live'_def
@@ -2527,6 +2525,7 @@ lemma unbindNotification_corres:
            apply (clarsimp simp: ntfn_relation_def split:Structures_A.ntfn.splits)
           apply (rule setBoundNotification_corres)
          apply (wp gbn_wp' gbn_wp)+
+   supply [rule del] = invs_valid_objs invs_valid_objs' (* suppress elim warning *)
    apply (clarsimp elim!: obj_at_valid_objsE
                    dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
                     simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def obj_at_def
@@ -2553,6 +2552,7 @@ lemma unbindMaybeNotification_corres:
          apply (clarsimp simp: ntfn_relation_def split: Structures_A.ntfn.splits)
         apply (rule setBoundNotification_corres)
        apply (wp get_simple_ko_wp getNotification_wp)+
+   supply [rule del] = invs_valid_objs invs_valid_objs' (* suppress elim warning *)
    apply (clarsimp elim!: obj_at_valid_objsE
                    dest!: bound_tcb_at_state_refs_ofD invs_valid_objs
                     simp: valid_obj_def is_tcb tcb_ntfn_is_bound_def invs_psp_aligned invs_distinct
@@ -2802,7 +2802,7 @@ lemma fast_finaliseCap_corres:
             | wpc)+
    apply (clarsimp simp: valid_cap_def)
   apply (clarsimp simp: valid_cap'_def valid_obj'_def
-                 dest!: invs_valid_objs' obj_at_valid_objs' )
+                  del: invs_valid_objs' dest!: invs_valid_objs' obj_at_valid_objs' )
   done
 
 crunch ThreadDecls_H.suspend, unbindNotification

--- a/proof/refine/Interrupt_R.thy
+++ b/proof/refine/Interrupt_R.thy
@@ -694,7 +694,7 @@ lemma handleInterrupt_corres:
    apply (rule corres_guard_imp)
      apply (rule corres_split)
         apply (rule corres_machine_op, rule corres_eq_trivial;
-               simp add: no_fail_maskInterrupt)+
+               simp)+
       apply ((wp | simp)+)[4]
   apply (rule corres_gen_asm2)
   apply (case_tac st, simp_all add: irq_state_relation_def bind_assoc split: irqstate.split_asm)

--- a/proof/refine/InvariantUpdates_H.thy
+++ b/proof/refine/InvariantUpdates_H.thy
@@ -66,8 +66,8 @@ lemma opt_tcb_at'_update'[iff]:
 (* exports from Arch locale version which are safe for generic use *)
 interpretation Arch_pspace_update_eq' ..
 
-lemmas pspace_in_kernel_mappings_update'[iff] = pspace_in_kernel_mappings_update'
-lemmas valid_arch_tcb_update'[iff] = valid_arch_tcb_update'
+lemmas pspace_in_kernel_mappings_update' = pspace_in_kernel_mappings_update'
+lemmas valid_arch_tcb_update' = valid_arch_tcb_update'
 
 lemma valid_tcb_update'[iff]:
   "valid_tcb' tcb (f s) = valid_tcb' tcb s"
@@ -75,6 +75,9 @@ lemma valid_tcb_update'[iff]:
   by auto
 
 end
+
+(* avoid duplicate declaration warning when re-binding name after interpretation *)
+lemmas (in pspace_update_eq') [iff] = pspace_in_kernel_mappings_update' valid_arch_tcb_update'
 
 context p_arch_idle_update_eq'
 begin
@@ -86,9 +89,12 @@ lemma ifunsafe_update [iff]:
 (* exports from Arch locale version (safe for generic use) *)
 interpretation Arch_p_arch_idle_update_eq' ..
 
-lemmas valid_arch_state_update'[iff] = valid_arch_state_update'
+lemmas valid_arch_state_update' = valid_arch_state_update'
 
 end
+
+(* avoid duplicate declaration warning when re-binding name after interpretation *)
+lemmas (in p_arch_idle_update_eq') [iff] =  valid_arch_state_update'
 
 locale InvariantUpdates_H =
   assumes valid_arch_state'_interrupt[simp]:

--- a/proof/refine/Invariants_H.thy
+++ b/proof/refine/Invariants_H.thy
@@ -2504,9 +2504,12 @@ context arch_idle_update_eq' begin
 (* exports from Arch locale version (safe for generic use) *)
 interpretation Arch_arch_idle_update_eq' ..
 
-lemmas global_refs_update'[iff] = global_refs_update'
+lemmas global_refs_update' = global_refs_update'
 
 end
+
+(* avoid duplicate declaration warning when re-binding name after interpretation *)
+lemmas (in arch_idle_update_eq') [iff] = global_refs_update'
 
 context Arch_p_arch_idle_update_eq'
 begin
@@ -2527,9 +2530,12 @@ lemma valid_idle_update' [iff]:
 (* exports from Arch locale version (safe for generic use) *)
 interpretation Arch_p_arch_idle_update_eq' ..
 
-lemmas valid_global_refs_update'[iff] = valid_global_refs_update'
+lemmas valid_global_refs_update' = valid_global_refs_update'
 
 end
+
+(* avoid duplicate declaration warning when re-binding name after interpretation *)
+lemmas (in p_arch_idle_update_eq') [iff] = valid_global_refs_update'
 
 context int_update_eq'
 begin
@@ -2794,16 +2800,16 @@ lemma valid_bitmaps_machine_state[simp]:
   by (simp add: valid_bitmaps_def bitmapQ_defs)
 
 (* these should be reasonable safe for automation because of the 0 pattern *)
-lemma no_0_ko_wp' [elim!]:
-  "\<lbrakk> ko_wp_at' Q 0 s; no_0_obj' s \<rbrakk> \<Longrightarrow> P"
+lemma no_0_ko_wp'[dest!]:
+  "\<lbrakk> ko_wp_at' Q 0 s; no_0_obj' s \<rbrakk> \<Longrightarrow> False"
   by (simp add: ko_wp_at'_def no_0_obj'_def)
 
-lemma no_0_obj_at' [elim!]:
-  "\<lbrakk> obj_at' Q 0 s; no_0_obj' s \<rbrakk> \<Longrightarrow> P"
+lemma no_0_obj_at'[dest!]:
+  "\<lbrakk> obj_at' Q 0 s; no_0_obj' s \<rbrakk> \<Longrightarrow> False"
   by (simp add: obj_at'_def no_0_obj'_def)
 
-lemma no_0_typ_at' [elim!]:
-  "\<lbrakk> typ_at' T 0 s; no_0_obj' s \<rbrakk> \<Longrightarrow> P"
+lemma no_0_typ_at'[dest!]:
+  "\<lbrakk> typ_at' T 0 s; no_0_obj' s \<rbrakk> \<Longrightarrow> False"
   by (clarsimp simp: typ_at'_def)
 
 lemma no_0_ko_wp'_eq [simp]:
@@ -2998,7 +3004,7 @@ lemma invs_valid_global'[elim!]:
 
 lemma invs_pspace_canonical'[elim!]:
   "invs' s \<Longrightarrow> pspace_canonical' s"
-  by (fastforce dest!: invs_valid_pspace' simp: valid_pspace'_def)
+  by (fastforce del: invs_valid_pspace' dest!: invs_valid_pspace' simp: valid_pspace'_def)
 
 lemma valid_pspace_canonical'[elim!]:
   "valid_pspace' s \<Longrightarrow> pspace_canonical' s"

--- a/proof/refine/IpcCancel_R.thy
+++ b/proof/refine/IpcCancel_R.thy
@@ -163,7 +163,7 @@ declare delete.simps[simp del]
 
 lemma invs_weak_sch_act_wf[elim!]:
   "invs' s \<Longrightarrow> weak_sch_act_wf (ksSchedulerAction s) s"
-  by (clarsimp dest!: invs_sch_act_wf' simp: weak_sch_act_wf_def)
+  by (clarsimp del: invs_sch_act_wf' dest!: invs_sch_act_wf' simp: weak_sch_act_wf_def)
 
 lemma blocked_cancelIPC_corres:
   "\<lbrakk> st = Structures_A.BlockedOnReceive epPtr p' \<or>
@@ -425,6 +425,7 @@ proof -
     using invs sr
     by (fastforce simp: cte_wp_at_master_reply_cap_to_ex_rights shiftl_t2n cte_index_repair
                         cte_wp_at_ctes_of cte cte_map_def tcb_cnode_index_def
+                  del: state_relation_pspace_relation (* suppress elim warning *)
                   dest: pspace_relation_cte_wp_at state_relation_pspace_relation)
 
   hence class_link:
@@ -471,9 +472,9 @@ proof -
     by (clarsimp simp: no_0_def nullPointer_def valid_mdb'_def valid_mdb_ctes_def)
 
   from invs cte have no_loop: "mdbNext (cteMDBNode cte) \<noteq> t + 2*2^cte_level_bits"
-    by (fastforce simp: mdb_next_rel_def mdb_next_def
-                       valid_mdb'_def
-                 dest: valid_mdb_no_loops no_loops_direct_simp)
+    by (fastforce simp: mdb_next_rel_def mdb_next_def valid_mdb'_def
+                  del: valid_mdb_no_loops (* suppress elim warning *)
+                  dest: valid_mdb_no_loops no_loops_direct_simp)
 
   from invs cte have
     "mdbNext (cteMDBNode cte) \<noteq> nullPointer \<longrightarrow>
@@ -534,7 +535,7 @@ proof -
     apply (erule subtree.cases)
      apply (clarsimp simp: mdb_next_rel_def mdb_next_def)
     apply (subgoal_tac "c' = cte_map sl")
-     apply (fastforce dest: invs_no_loops no_loops_direct_simp)
+     apply (fastforce del: invs_no_loops dest: invs_no_loops no_loops_direct_simp)
     apply fastforce
     done
 qed
@@ -582,6 +583,7 @@ lemma (in delete_one_gen) cancelIPC_ReplyCap_corres:
        od)"
   proof -
   show ?thesis
+  supply state_relation_pspace_relation[rule del] (* suppress safe elim warning *)
   apply (simp add: reply_cancel_ipc_def getThreadReplySlot_def
                    locateSlot_conv liftM_def tcbReplySlot_def
               del: split_paired_Ex)
@@ -642,8 +644,8 @@ lemma (in delete_one_gen) cancelIPC_ReplyCap_corres:
                            reply_masters_mdb_def cte_wp_at_caps_of_state
                            can_fast_finalise_def)
     apply (fastforce simp: valid_mdb'_def valid_mdb_ctes_def
-                          cte_wp_at_ctes_of nullPointer_def
-                    elim: valid_dlistEn dest: invs_mdb')
+                           cte_wp_at_ctes_of nullPointer_def
+                     elim: valid_dlistEn del: invs_mdb' dest: invs_mdb')
    apply (simp add: exs_valid_def gets_def get_def return_def bind_def
                del: split_paired_Ex split_paired_All)
   apply (wp)
@@ -870,7 +872,7 @@ proof -
          y \<leftarrow> setEndpoint epptr ep';
          setThreadState Inactive t
       od \<lbrace>\<lambda>rv. invs'\<rbrace>"
-    supply no_0_obj_at'[rule del] (* avoid weak elim rule warning *)
+    supply no_0_obj_at'[rule del]
     apply (simp add: invs'_def valid_state'_def)
     apply (subst P)
     apply (wp valid_irq_node_lift valid_global_refs_lift' valid_dom_schedule'_lift
@@ -888,7 +890,7 @@ proof -
     apply (clarsimp simp: valid_obj'_def)
     apply (rule conjI)
      apply (clarsimp simp: obj_at'_def valid_ep'_def
-                    dest!: pred_tcb_at')
+                     del: pred_tcb_at' dest!: pred_tcb_at')
     apply (clarsimp, rule conjI)
      apply (auto simp: pred_tcb_at'_def obj_at'_def)[1]
     apply (rule conjI)
@@ -912,7 +914,6 @@ proof -
                     cong: list.case_cong)
      apply (frule_tac x=t in distinct_remove1)
      apply (frule_tac x=t in set_remove1_eq)
-     (* FIXME arch-split: still getting multiple no_0_obj_at' weak elim rule warnings despite rule del above!  *)
      by (auto elim!: delta_sym_refs
                simp: symreftype_inverse' tcb_st_refs_of'_def tcb_bound_refs'_def
               split: thread_state.splits if_split_asm)
@@ -946,7 +947,7 @@ proof -
                                hoare_weaken_pre[OF cancelSignal_invs']
                        elim!: pred_tcb'_weakenE)
           apply (auto simp: pred_tcb_at'_def obj_at'_def
-                      dest: invs_sch_act_wf')
+                      del: invs_sch_act_wf' dest: invs_sch_act_wf')
   done
 qed
 
@@ -1262,6 +1263,7 @@ lemma as_user_ready_qs_distinct[wp]:
 lemma (in delete_one_gen) suspend_corres:
   "corres dc (einvs and tcb_at t) invs'
              (IpcCancel_A.suspend t) (ThreadDecls_H.suspend t)"
+  supply state_relation_pspace_relation[rule del] (* suppress elim warning *)
   apply (rule corres_cross_over_guard[where P'=P' and Q="tcb_at' t and P'" for P'])
    apply (fastforce dest!: tcb_at_cross state_relation_pspace_relation)
   apply (simp add: IpcCancel_A.suspend_def Thread_H.suspend_def)
@@ -2082,7 +2084,6 @@ lemma cancelBadgedSends_invs[wp]:
            rule cancelBadgedSends_filterM_helper[where epptr=epptr])
     apply (clarsimp simp: ep_redux_simps3 fun_upd_def[symmetric])
     apply (clarsimp simp add: valid_ep'_def split: list.split)
-    supply no_0_obj_at'[rule del] (* avoid weak elim rule warning *)
     apply blast
    apply (wp valid_irq_node_lift irqs_masked_lift valid_dom_schedule'_lift
           | wp (once) sch_act_sane_lift)+

--- a/proof/refine/Ipc_R.thy
+++ b/proof/refine/Ipc_R.thy
@@ -70,15 +70,6 @@ lemma (in Arch) word_size_gt_0_mw[simp]:
 requalify_facts Arch.word_size_gt_0_mw
 lemmas [simp] = word_size_gt_0_mw
 
-(* same proof on all architectures *)
-(* FIXME: move to Bits_R *)
-lemma (in Arch) word_size_bits_le_pageBits:
-  "word_size_bits \<le> pageBits"
-  by (simp add: pageBits_def word_size_bits_def)
-
-requalify_facts Arch.word_size_bits_le_pageBits
-lemmas [simp] = word_size_bits_le_pageBits
-
 (* FIXME arch-split: move *)
 (* invariant version; a proper wp lemma would look more like no_fail_mapM_wp *)
 lemma no_fail_zipWithM_x_inv:
@@ -107,7 +98,7 @@ lemma gets_the_noop_corres:
 (* FIXME arch-split: move *)
 lemma invs_pspace_in_kernel_mappings'[elim!]:
   "invs' s \<Longrightarrow> pspace_in_kernel_mappings' s"
-  by (fastforce dest!: invs_valid_pspace' simp: valid_pspace'_def)
+  by (fastforce del: invs_valid_pspace' dest!: invs_valid_pspace' simp: valid_pspace'_def)
 
 (* FIXME: move *)
 lemma unifyFailure_wp_E[wp]:
@@ -992,10 +983,8 @@ lemma transferCapsToSlots_vp[wp]:
         \<and> transferCaps_srcs caps s\<rbrace>
    transferCapsToSlots ep buffer n caps slots mi
    \<lbrace>\<lambda>rv. valid_pspace'\<rbrace>"
-  apply (rule hoare_pre)
-   apply (simp add: valid_pspace'_def | wp)+
-  apply (fastforce simp: cte_wp_at_ctes_of dest: ctes_of_valid')
-  done
+  by (wpsimp simp: valid_pspace'_def)
+     (fastforce simp: cte_wp_at_ctes_of del: ctes_of_valid' dest: ctes_of_valid')
 
 crunch setExtraBadge, doIPCTransfer
   for sch_act [wp]: "\<lambda>s. P (ksSchedulerAction s)"
@@ -2157,7 +2146,7 @@ lemma doReplyTransfer_corres:
      apply (rule getThreadState_corres, (clarsimp simp add: st_tcb_at_tcb_at invs_distinct invs_psp_aligned)+)
   apply (rule_tac F = "awaiting_reply state" in corres_req)
    apply (clarsimp simp add: st_tcb_at_def obj_at_def is_tcb)
-   apply (fastforce simp: invs_def valid_state_def intro: has_reply_cap_cte_wpD
+   apply (fastforce simp: invs_def valid_state_def
                    dest: has_reply_cap_cte_wpD
                   dest!: valid_reply_caps_awaiting_reply cte_wp_at_is_reply_cap_toI)
   apply (case_tac state, simp_all add: bind_assoc)
@@ -2550,7 +2539,6 @@ proof -
         apply (clarsimp simp: st_tcb_at_refs_of_rev st_tcb_at_reply_cap_valid
                               st_tcb_def2 valid_sched_def valid_sched_action_def)
         apply (force simp: st_tcb_def2 dest!: st_tcb_at_caller_cap_null[simplified,rotated])
-       (* FIXME: weak elimination rule warning *)
        subgoal by (auto simp: valid_ep'_def invs'_def valid_state'_def split: list.split)
       apply wp+
     apply (clarsimp simp: ep_at_def2)+
@@ -2621,7 +2609,6 @@ proof -
        apply (clarsimp simp: st_tcb_at_refs_of_rev st_tcb_at_reply_cap_valid
                              st_tcb_at_caller_cap_null)
        apply (fastforce simp: st_tcb_def2 valid_sched_def valid_sched_action_def)
-      (* FIXME: weak elimination rule warning *)
       subgoal by (auto simp: valid_ep'_def
                       split: list.split;
                   clarsimp simp: invs'_def valid_state'_def)
@@ -2751,7 +2738,6 @@ lemma sendSignal_corres:
                            valid_pspace_def neq_Nil_conv
                            ntfn_queued_st_tcb_at valid_sched_def valid_sched_action_def
                     split: option.splits)
-   (* FIXME: weak elimination rule warning *)
    apply (auto simp: valid_ntfn'_def neq_Nil_conv invs'_def valid_state'_def
                      weak_sch_act_wf_def
               split: option.splits)[1]
@@ -2767,10 +2753,6 @@ lemma sendSignal_corres:
 lemma valid_Running'[simp]:
   "valid_tcb_state' Running = \<top>"
   by (rule ext, simp add: valid_tcb_state'_def)
-
-crunch setMRs
-  for typ'[wp]: "\<lambda>s. P (typ_at' T p s)"
-   (wp: crunch_wps simp: zipWithM_x_mapM)
 
 lemma possibleSwitchTo_sch_act[wp]:
   "\<lbrace>\<lambda>s. sch_act_wf (ksSchedulerAction s) s \<and> st_tcb_at' runnable' t s\<rbrace>
@@ -3284,7 +3266,6 @@ lemma receiveIPC_corres:
               apply (clarsimp simp add: valid_ep_def valid_pspace_def)
               apply (drule(1) sym_refs_obj_atD[where P="\<lambda>ko. ko = Endpoint e" for e])
               apply (fastforce simp: st_tcb_at_refs_of_rev elim: st_tcb_weakenE)
-             (* FIXME weak elimination rule warning *)
              apply (auto simp: valid_ep'_def invs'_def valid_state'_def split: list.split)[1]
             \<comment> \<open>RecvEP\<close>
             apply (simp add: ep_relation_def)
@@ -3304,12 +3285,14 @@ lemma receiveIPC_corres:
                     | wpc | simp add: ep_at_def2[symmetric, simplified] | clarsimp)+
    apply (clarsimp simp: valid_cap_def invs_psp_aligned invs_valid_objs pred_tcb_at_def
                          valid_obj_def valid_tcb_def valid_bound_ntfn_def invs_distinct
+                    del: invs_valid_objs (* suppress elim warning *)
                   dest!: invs_valid_objs
                   elim!: obj_at_valid_objsE
                   split: option.splits)
   apply clarsimp
   apply (auto simp: valid_cap'_def invs_valid_pspace' valid_obj'_def valid_tcb'_def
                     valid_bound_ntfn'_def obj_at'_def pred_tcb_at'_def
+               del: invs_valid_objs' (* suppress intro warning *)
              dest!: invs_valid_objs' obj_at_valid_objs'
              split: option.splits)[1]
   done
@@ -3712,8 +3695,10 @@ lemma completeSignal_invs:
                            if_live_then_nonz_capD'[OF invs_iflive'
                                                       obj_at'_real_def[THEN meta_eq_to_obj_eq,
                                                                        THEN iffD1]])
-   apply (fastforce simp: valid_idle'_def pred_tcb_at'_def obj_at'_def dest!: invs_valid_idle')
-  apply (fastforce dest: invs_valid_objs' ko_at_valid_objs' simp: valid_obj'_def)
+   apply (fastforce simp: valid_idle'_def pred_tcb_at'_def obj_at'_def
+                    del: invs_valid_idle' dest!: invs_valid_idle')
+  apply (fastforce del: invs_valid_objs' dest: invs_valid_objs' ko_at_valid_objs'
+                   simp: valid_obj'_def)
   done
 
 lemma setupCallerCap_urz[wp]:
@@ -3845,7 +3830,7 @@ lemma ri_invs' [wp]:
    apply (frule(1) ct_not_in_epQueue, clarsimp, clarsimp)
    apply (drule(1) sym_refs_ko_atD')
    apply (drule simple_st_tcb_at_state_refs_ofD')
-   apply (clarsimp simp: valid_obj'_def valid_ep'_def st_tcb_at_refs_of_rev' conj_ac
+   apply (clarsimp simp: valid_obj'_def valid_ep'_def st_tcb_at_refs_of_rev' conj_left_commute
               split del: if_split
                    cong: if_cong)
    apply (subgoal_tac "sch_act_not sender s")

--- a/proof/refine/KHeap_R.thy
+++ b/proof/refine/KHeap_R.thy
@@ -1842,9 +1842,6 @@ lemma setEndpoint_valid_mdb':
   unfolding setEndpoint_def
   by (rule set_ep_valid_mdb')
 
-crunch setEndpoint, setNotification
-  for pspace_canonical'[wp]: pspace_canonical'
-
 lemma set_ep_valid_pspace'[wp]:
   "\<lbrace>valid_pspace' and valid_ep' ep\<rbrace>
   setEndpoint epptr ep

--- a/proof/refine/Move_R.thy
+++ b/proof/refine/Move_R.thy
@@ -60,8 +60,6 @@ lemma unaligned_helper:
   apply (simp add: not_less power_overflow word_bits_conv)
   done
 
-declare word_unat_power[symmetric, simp del]
-
 lemma neq_out_intv:
   "\<lbrakk> a \<noteq> b; b \<notin> {a..a + c - 1} - {a} \<rbrakk> \<Longrightarrow> b \<notin> {a..a + c - 1}"
   by simp

--- a/proof/refine/RISCV64/ArchCSpace_I.thy
+++ b/proof/refine/RISCV64/ArchCSpace_I.thy
@@ -358,7 +358,7 @@ lemma distinct_zombies_copyMasterE[Arch_assms]:
       apply (drule_tac f=isUntypedCap in arg_cong)
       apply (simp add: gen_isCap_Master)
      apply (drule_tac f=isArchFrameCap in arg_cong)
-     apply (simp add: arch_isCap_Master)
+     apply simp
     apply (rule master_eqI, rule capBits_Master, simp)
    apply clarsimp
    apply (drule_tac f=capClass in arg_cong, simp add: capClass_Master)

--- a/proof/refine/RISCV64/ArchInvsLemmas_H.thy
+++ b/proof/refine/RISCV64/ArchInvsLemmas_H.thy
@@ -334,7 +334,7 @@ lemma in_kernel_mappings_neq_mask:
 
 lemma invs_pspace_in_kernel_mappings'[elim!]:
   "invs' s \<Longrightarrow> pspace_in_kernel_mappings' s"
-  by (fastforce dest!: invs_valid_pspace' simp: valid_pspace'_def)
+  by (fastforce del: invs_valid_pspace' dest!: invs_valid_pspace' simp: valid_pspace'_def)
 
 lemma valid_pspace_in_kernel_mappings'[elim!]:
   "valid_pspace' s \<Longrightarrow> pspace_in_kernel_mappings' s"
@@ -346,7 +346,7 @@ lemma tcb_hyp_refs_of'_simps[simp]:
 
 lemma refs_of_a'_simps[simp]:
   "refs_of_a' ako = {}"
-  by (auto simp: refs_of_a'_def)
+  by auto
 
 lemma hyp_refs_of_hyp_live':
   "hyp_refs_of' ko \<noteq> {} \<Longrightarrow> hyp_live' ko"

--- a/proof/refine/RISCV64/ArchKHeap_R.thy
+++ b/proof/refine/RISCV64/ArchKHeap_R.thy
@@ -105,9 +105,6 @@ lemma obj_relation_cut_same_type:
                     arch_kernel_obj.split_asm)
   done
 
-lemmas obj_at_simps = gen_obj_at_simps is_other_obj_relation_type_def
-                      objBits_simps pageBits_def
-
 (* No aobjs dependency on this architecture *)
 lemma arch_state_relation_no_aobjs[elim!]:
   "(s, s') \<in> arch_state_relation aobjs' \<Longrightarrow> (s, s') \<in> arch_state_relation aobjs"

--- a/proof/refine/RISCV64/ArchMove_R.thy
+++ b/proof/refine/RISCV64/ArchMove_R.thy
@@ -15,9 +15,6 @@ begin
 lemmas cte_index_repair = mult.commute[where a="(2::'a::len word) ^ cte_level_bits"]
 lemmas cte_index_repair_sym = cte_index_repair[symmetric]
 
-lemma invs_valid_ioc[elim!]: "invs s \<Longrightarrow> valid_ioc s"
-  by (clarsimp simp add: invs_def valid_state_def)
-
 context Arch begin arch_global_naming
 
 (* Move to Arch_Structs_A *)

--- a/proof/refine/RISCV64/ArchVSpace_R.thy
+++ b/proof/refine/RISCV64/ArchVSpace_R.thy
@@ -182,7 +182,7 @@ lemma deleteASID_corres[corres]:
                      set_asid_pool_vspace_objs_unmap_single getASID_wp
                   | strengthen valid_arch_state_asid_table valid_arch_state_global_arch_objs
                   | simp flip: cur_tcb_def)+
-   apply (fastforce dest: valid_asid_tableD invs_valid_asid_table)
+   apply (fastforce del: invs_valid_asid_table dest: valid_asid_tableD invs_valid_asid_table)
   apply simp
   done
 

--- a/proof/refine/Retype_R.thy
+++ b/proof/refine/Retype_R.thy
@@ -1828,7 +1828,7 @@ proof -
    apply (simp add: bind_assoc)
    apply (rule corres_guard_imp)
      apply (rule_tac r'=pspace_relation in corres_underlying_split)
-        apply (clarsimp dest!: state_relation_pspace_relation)
+        apply (clarsimp del: state_relation_pspace_relation dest!: state_relation_pspace_relation)
        apply (simp add: gets_def)
        apply (rule corres_symb_exec_l[rotated])
           apply (rule exs_valid_get)

--- a/proof/refine/Schedule_R.thy
+++ b/proof/refine/Schedule_R.thy
@@ -75,9 +75,6 @@ lemma schedule_choose_new_thread_sched_act_rct[wp]:
   unfolding schedule_choose_new_thread_def
   by wp
 
-crunch tcbQueueAppend
-  for ghost_relation_wrapper[wp]: "ghost_relation_wrapper s"
-
 \<comment> \<open>This proof shares many similarities with the proof of @{thm tcbSchedEnqueue_corres}\<close>
 lemma tcbSchedAppend_corres:
   "tcb_ptr = tcbPtr \<Longrightarrow>
@@ -113,7 +110,8 @@ lemma tcbSchedAppend_corres:
   apply (subst if_distrib[where f="set_tcb_queue domain prio" for domain prio])
   apply (rule corres_if_strong')
     subgoal
-      by (fastforce dest!: state_relation_ready_queues_relation
+      by (fastforce   del: state_relation_ready_queues_relation (* suppress elim warning *)
+                    dest!: state_relation_ready_queues_relation
                            in_ready_q_tcbQueued_eq[where t=tcbPtr]
                      simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
                            obj_at_def etcb_at_def etcbs_of'_def)
@@ -760,7 +758,8 @@ lemma switchToThread_corres:
      apply wpsimp
      apply (fastforce simp: st_tcb_at'_def runnable_eq_active' obj_at'_def)
     apply (rule corres_stateAssert_ignore)
-     apply (fastforce dest!: state_relation_ready_queues_relation intro: ksReadyQueues_asrt_cross)
+     apply (fastforce del: state_relation_ready_queues_relation dest!: state_relation_ready_queues_relation
+                      intro: ksReadyQueues_asrt_cross)
     apply (rule corres_stateAssert_add_assertion[rotated])
      apply fastforce
     apply (rule corres_guard_imp)
@@ -1534,7 +1533,8 @@ lemma (in Schedule_R_2) isHighestPrio_corres:
            apply (elim conjE)
            apply (clarsimp simp: valid_bitmaps_def)
            apply (subst lookupBitmapPriority_Max_eqI; blast?)
-           apply (fastforce dest: state_relation_ready_queues_relation Max_prio_helper[where d=d]
+           apply (fastforce del: state_relation_ready_queues_relation (* suppress elim warning *)
+                            dest: state_relation_ready_queues_relation Max_prio_helper[where d=d]
                             simp: tcbQueueEmpty_def)
           apply fastforce
          apply (wpsimp simp: if_apply_def2 wp: hoare_drop_imps ksReadyQueuesL1Bitmap_return_wp)+
@@ -2011,7 +2011,7 @@ lemma (in Schedule_R_3) schedule_ct_activatable'[wp]:
            | simp only: obj_at'_activatable_st_tcb_at'[simplified comp_def]
            | strengthen invs'_invs_no_cicd
            | wp hoare_vcg_imp_lift)+
-  apply (fastforce dest: invs_sch_act_wf' elim: pred_tcb'_weakenE
+  apply (fastforce del: invs_sch_act_wf' dest: invs_sch_act_wf' elim: pred_tcb'_weakenE
                    simp: sch_act_wf obj_at'_activatable_st_tcb_at')
   done
 

--- a/proof/refine/Syscall_R.thy
+++ b/proof/refine/Syscall_R.thy
@@ -753,7 +753,7 @@ lemma performInvocation_corres:
        apply (clarsimp simp: liftME_def)
        apply (rule corres_guard_imp)
          apply (erule invokeTCB_corres)
-        apply ((clarsimp dest!: schact_is_rct_simple)+)[2]
+        apply ((clarsimp del: schact_is_rct_simple dest!: schact_is_rct_simple)+)[2]
       \<comment> \<open>domain cap\<close>
       apply (clarsimp simp: liftE_bind_return_bindE_returnOk)
       apply corres
@@ -764,7 +764,7 @@ lemma performInvocation_corres:
           apply assumption
          apply (rule corres_trivial, simp add: returnOk_def)
         apply wp+
-      apply ((clarsimp dest!: schact_is_rct_simple)+)[2]
+      apply ((clarsimp del: schact_is_rct_simple dest!: schact_is_rct_simple)+)[2]
     apply (clarsimp simp: liftME_def[symmetric] o_def dc_def[symmetric])
     apply (rule corres_guard_imp, rule performIRQControl_corres, simp+)
    apply (clarsimp simp: liftME_def[symmetric] o_def dc_def[symmetric])
@@ -1959,7 +1959,7 @@ lemma hr_ct_active'[wp]:
     apply (fastforce simp: cte_wp_at_ctes_of)
    apply (wpsimp wp: getCTE_wp doReplyTransfer_st_tcb_at_active)+
   apply (fastforce simp: ct_in_state'_def cte_wp_at_ctes_of valid_cap'_def
-                   dest: ctes_of_valid')
+                   del: ctes_of_valid' dest: ctes_of_valid')
   done
 
 context Syscall_R begin

--- a/proof/refine/TcbAcc_R.thy
+++ b/proof/refine/TcbAcc_R.thy
@@ -2195,7 +2195,8 @@ lemma tcbSchedEnqueue_corres:
   apply (subst if_distrib[where f="set_tcb_queue domain prio" for domain prio])
   apply (rule corres_if_strong')
     subgoal
-      by (fastforce dest!: state_relation_ready_queues_relation
+      by (fastforce   del: state_relation_ready_queues_relation (* suppress elim warning *)
+                    dest!: state_relation_ready_queues_relation
                            in_ready_q_tcbQueued_eq[where t=tcbPtr]
                      simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
                            obj_at_def etcb_at_def etcbs_of'_def)
@@ -2706,8 +2707,9 @@ lemma tcbSchedDequeue_corres:
    apply (fastforce intro: ksReadyQueues_asrt_cross)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; (solves wpsimp)?)
   apply (rule corres_if_strong'; fastforce?)
-   apply (fastforce dest!: state_relation_ready_queues_relation
-                           in_ready_q_tcbQueued_eq[where t=tcbPtr]
+   apply (fastforce  del: state_relation_ready_queues_relation (* suppress elim warning *)
+                     dest!: state_relation_ready_queues_relation
+                            in_ready_q_tcbQueued_eq[where t=tcbPtr]
                      simp: obj_at'_def opt_pred_def opt_map_def in_correct_ready_q_def
                            obj_at_def etcb_at_def etcbs_of'_def)
   apply (rule corres_symb_exec_r[OF _ threadGet_sp]; wpsimp?)
@@ -2716,7 +2718,8 @@ lemma tcbSchedDequeue_corres:
   apply (rule corres_from_valid_det)
     apply (fastforce intro: det_wp_modify det_wp_pre simp: set_tcb_queue_def)
    apply (wpsimp wp: tcbQueueRemove_no_fail)
-   apply (fastforce dest: state_relation_ready_queues_relation
+   apply (fastforce del: state_relation_ready_queues_relation (* suppress elim warning *)
+                    dest: state_relation_ready_queues_relation
                     simp: ex_abs_underlying_def ready_queues_relation_def ready_queue_relation_def
                           Let_def inQ_def opt_pred_def opt_map_def obj_at'_def)
   apply (clarsimp simp: state_relation_def)
@@ -2963,7 +2966,6 @@ end (* TcbAcc_R_2 *)
 
 crunch rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
   for typ_at'[wp]: "\<lambda>s. P (typ_at' T p s)"
-  and ctes_of[wp]: "\<lambda>s. P (ctes_of s)"
   (wp: crunch_wps)
 
 global_interpretation rescheduleRequired: gen_typ_at_props' "rescheduleRequired"
@@ -3757,10 +3759,6 @@ lemma setSchedulerAction_ct'[wp]:
 
 crunch rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
   for ct'[wp]: "\<lambda>s. P (ksCurThread s)"
-  (simp: crunch_simps wp: crunch_wps)
-
-crunch rescheduleRequired, tcbSchedDequeue, setThreadState, setBoundNotification
-  for typ_at'[wp]:  "\<lambda>s. P (typ_at' T p s)"
   (simp: crunch_simps wp: crunch_wps)
 
 end (* TcbAcc_R_2 *)

--- a/proof/refine/Tcb_R.thy
+++ b/proof/refine/Tcb_R.thy
@@ -1738,7 +1738,8 @@ lemma invokeTCB_corres:
             apply (rule rescheduleRequired_corres)
            apply (rule corres_trivial, simp)
           apply (wpsimp wp: hoare_drop_imp)+
-    apply (fastforce dest: valid_sched_valid_queues simp: valid_sched_weak_strg)
+    apply (fastforce del: valid_sched_valid_queues dest: valid_sched_valid_queues
+                     simp: valid_sched_weak_strg)
    apply fastforce
   apply (clarsimp simp: invokeTCB_def invokeSetFlags_def bind_assoc)
   apply (corres corres: threadGet_corres[where r="\<lambda>flags flags'. flags = word_to_tcb_flags flags'"]
@@ -1773,7 +1774,7 @@ lemma bindNotification_invs':
           | clarsimp dest!: global'_no_ex_cap simp: cteCaps_of_def)+
   apply (clarsimp simp: valid_pspace'_def)
   apply (cases "tcbptr = ntfnptr")
-   apply (clarsimp dest!: pred_tcb_at' simp: obj_at'_def)
+   apply (clarsimp del: pred_tcb_at' dest!: pred_tcb_at' simp: obj_at'_def)
   apply (clarsimp simp: pred_tcb_at' conj_comms o_def)
   apply (subst delta_sym_refs, assumption)
     apply (fastforce simp: ntfn_q_refs_of'_def obj_at'_def
@@ -1788,8 +1789,8 @@ lemma bindNotification_invs':
   apply (clarsimp simp: valid_pspace'_def)
   apply (frule_tac P="\<lambda>k. k=ntfn" in obj_at_valid_objs', simp)
   apply (clarsimp simp: valid_obj'_def valid_ntfn'_def obj_at'_def
-                    dest!: pred_tcb_at'
-                    split: ntfn.splits)
+                  del: pred_tcb_at' dest!: pred_tcb_at'
+                  split: ntfn.splits)
   done
 
 lemma tcbntfn_invs':

--- a/proof/refine/X64/ArchArch_R.thy
+++ b/proof/refine/X64/ArchArch_R.thy
@@ -1269,7 +1269,7 @@ lemma performX64PortInvocation_corres:
   apply (case_tac x; clarsimp simp: bind_assoc simp del: split_paired_All)
   apply (rule_tac corres_stateAssert_add_assertion[rotated])
    apply (rule all_ioports_issued_cross;
-          fastforce dest!: invs_valid_ioports simp: valid_ioports_def)
+          fastforce del: invs_valid_ioports dest!: invs_valid_ioports simp: valid_ioports_def)
   apply (rule corres_guard_imp)
     apply (rule corres_split_nor[OF set_ioport_mask_corres])
       apply (rule corres_split_nor[OF cteInsert_simple_corres])

--- a/proof/refine/X64/ArchEmptyFail.thy
+++ b/proof/refine/X64/ArchEmptyFail.thy
@@ -17,8 +17,6 @@ lemma empty_fail_lookupIPCBuffer[Arch_assms]:
   by (clarsimp simp: lookupIPCBuffer_def Let_def getThreadBufferSlot_def locateSlot_conv
               split: capability.splits arch_capability.splits | wp | wpc | safe)+
 
-declare setRegister_empty_fail[intro!, simp] (* FIXME: tag original instead *)
-
 lemmas EmptyFail_R_assms = Arch_assms (* extract accumulated assumptions *)
 
 end (* Arch *)

--- a/proof/refine/X64/ArchInvsLemmas_H.thy
+++ b/proof/refine/X64/ArchInvsLemmas_H.thy
@@ -43,7 +43,6 @@ lemma valid_cap'_pspaceI[Arch_assms]:
 lemma valid_obj'_pspaceI[Arch_assms]:
   "valid_obj' obj s \<Longrightarrow> ksPSpace s = ksPSpace s' \<Longrightarrow> valid_obj' obj s'"
   unfolding valid_obj'_def
-  supply no_0_obj_at'[rule del] (* avoid weak elim rule warning *)
   by (cases obj)
      (auto simp: valid_ep'_def valid_ntfn'_def valid_tcb'_def valid_cte'_def
                  valid_tcb_state'_def valid_bound_tcb'_def
@@ -346,7 +345,7 @@ lemma in_kernel_mappings_neq_mask:
 
 lemma invs_pspace_in_kernel_mappings'[elim!]:
   "invs' s \<Longrightarrow> pspace_in_kernel_mappings' s"
-  by (fastforce dest!: invs_valid_pspace' simp: valid_pspace'_def)
+  by (fastforce del: invs_valid_pspace' dest!: invs_valid_pspace' simp: valid_pspace'_def)
 
 lemma valid_pspace_in_kernel_mappings'[elim!]:
   "valid_pspace' s \<Longrightarrow> pspace_in_kernel_mappings' s"

--- a/proof/refine/X64/ArchKHeap_R.thy
+++ b/proof/refine/X64/ArchKHeap_R.thy
@@ -113,9 +113,6 @@ lemma obj_relation_cut_same_type:
                   Structures_H.kernel_object.split_asm
                   X64_A.arch_kernel_obj.split_asm)
 
-lemmas obj_at_simps = gen_obj_at_simps is_other_obj_relation_type_def
-                      objBits_simps pageBits_def
-
 (* No aobjs dependency on this architecture *)
 lemma arch_state_relation_no_aobjs[elim!]:
   "(s, s') \<in> arch_state_relation aobjs' \<Longrightarrow> (s, s') \<in> arch_state_relation aobjs"

--- a/proof/refine/X64/ArchVSpace_R.thy
+++ b/proof/refine/X64/ArchVSpace_R.thy
@@ -383,7 +383,7 @@ lemma deleteASID_corres [corres]:
       apply (drule Some_to_the)
       apply (wpsimp wp: getASID_wp)+
    apply (clarsimp simp: valid_arch_state_def valid_asid_table_def
-                  dest!: invs_arch_state)
+                   del: invs_arch_state dest!: invs_arch_state)
    apply blast
   apply (clarsimp simp: valid_arch_state'_def valid_asid_table'_def)
   done


### PR DESCRIPTION
Refine is warning-free possibly for the first time in history, hopefully
we can keep it that way.

Adjusted:
- use `del:` to remove safe elimination rules prior to using them as
  destruction rules (prevents warning from blast), or alternatively
  use `supply *[rule del]`
- after interpreting a locale inside another and re-binding a name, move
  any attribute declarations for re-bound theorems to after the locale,
  otherwise it isn't clear which theorem we are trying to tag
- vcpuBits_def removed from objBits_defs (clash with bit_simps)
- bit_simps, projectKOs and archObjSize_def were already simp
- declares which already happened earlier
- obj_at_simps was only used on 32-bit arches, and had duplicates
- raw_tcb_cte_cases_simps 0 case was a duplicate
- clearMemory was already crunch_ignore
- use no_valid_cap_syn to prevent spec_validE vs valid_cap_syn ambiguity
- adjust some `no_0_*[elim!]` lemmas to be proper `[dest!]` lemmas
- clear crunches that proved nothing, combine overlapping crunches